### PR TITLE
Fixed typographical error, changed auxilary to auxiliary in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 detectorSimulations
 ===================
 
-The detectorSimulations package contains the Geant4 simulations for GRIFFIN, TIGRESS, and all of their auxilary detectors.  Please note that in order to respect our non-disclosure agreements, all source containing third party IP have been omitted from this repo, and can be obtained from your colleagues directly at the lab.
+The detectorSimulations package contains the Geant4 simulations for GRIFFIN, TIGRESS, and all of their auxiliary detectors.  Please note that in order to respect our non-disclosure agreements, all source containing third party IP have been omitted from this repo, and can be obtained from your colleagues directly at the lab.
 
 
 #Setup


### PR DESCRIPTION
GRIFFINCollaboration, I've corrected a typographical error in the documentation of the [detectorSimulations_v10](https://github.com/GRIFFINCollaboration/detectorSimulations_v10) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.