### PR TITLE
Fixing issue #56

### DIFF
--- a/Griffinv10.cc
+++ b/Griffinv10.cc
@@ -107,6 +107,7 @@ int main(int argc, char** argv)
 
 #ifdef G4UI_USE
 		 ui->SessionStart();
+
 		 delete ui;
 #endif
 	 }

--- a/include/ApparatusGenericTarget.hh
+++ b/include/ApparatusGenericTarget.hh
@@ -44,31 +44,24 @@ class ApparatusGenericTarget
     ApparatusGenericTarget();
     ~ApparatusGenericTarget();
 
+    void Build(G4String, G4double, G4double, G4double); 
+    void PlaceApparatus(G4LogicalVolume*, G4ThreeVector, G4RotationMatrix*); 
+
   private:
+    G4Box* BuildTarget();
+    void BuildTargetVolume();           
+    G4ThreeVector GetDirectionXYZ(G4double, G4double);
+
     // Logical volumes        
     G4LogicalVolume* fTargetLog;    
 
     // Assembly volumes
     G4AssemblyVolume* fAssembly;
 
-  private: 
     G4String fTargetMaterial;
     G4double fTargetLengthX;   
     G4double fTargetLengthY;
     G4double fTargetLengthZ;
-
-  public: 
-    G4int Build(G4String, G4double, G4double, G4double); 
-    G4int PlaceApparatus(G4LogicalVolume*, G4ThreeVector, G4RotationMatrix*); 
-
-  private: 
-    G4Box* BuildTarget();
-    
-  private: 
-    G4int BuildTargetVolume();           
-        
-  private:
-    G4ThreeVector GetDirectionXYZ(G4double, G4double);
 };
 
 #endif

--- a/include/DetectorConstruction.hh
+++ b/include/DetectorConstruction.hh
@@ -73,11 +73,18 @@ class DetectionSystemAncillaryBGO;
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
 struct DetectorProperties {
-	std::string mnemonic;
 	G4int systemID;
 	G4int detectorNumber;
 	G4int crystalNumber;
+	void Clear()
+	{
+		systemID = 0;
+		detectorNumber = 0;
+		crystalNumber = 0;
+	}
 };
+
+bool operator==(const DetectorProperties& lhs, const DetectorProperties& rhs);
 
 class DetectorConstruction : public G4VUserDetectorConstruction
 {
@@ -202,7 +209,7 @@ public:
 private:
 	bool CheckVolumeName(G4String volumeName);
 	DetectorProperties ParseVolumeName(G4String volumeName);
-	const char* CrystalColour(G4int crystalNumber);
+
 	G4int     fGriffinDetectorsMapIndex;
 	G4int     fGriffinDetectorsMap[16];
 

--- a/include/DetectorConstruction.hh
+++ b/include/DetectorConstruction.hh
@@ -37,6 +37,8 @@
 #ifndef DETECTORCONSTRUCTION_HH
 #define DETECTORCONSTRUCTION_HH
 
+#include <unordered_map>
+
 #include "G4VUserDetectorConstruction.hh"
 #include "globals.hh"
 #include "G4ThreeVector.hh"
@@ -69,6 +71,13 @@ class DetectionSystemAncillaryBGO;
 //class MagneticField;
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+struct DetectorProperties {
+	std::string mnemonic;
+	G4int systemID;
+	G4int detectorNumber;
+	G4int crystalNumber;
+};
 
 class DetectorConstruction : public G4VUserDetectorConstruction
 {
@@ -184,7 +193,16 @@ public:
 	bool SpiceRes() { return fSpiceRes; }
 	void UseTIGRESSPositions( G4bool input )                  {fUseTigressPositions = input;};
 
+	bool HasProperties(G4VPhysicalVolume* vol) { return fPropertiesMap.find(vol) != fPropertiesMap.end(); }
+	DetectorProperties GetProperties(G4VPhysicalVolume* vol) { return fPropertiesMap.at(vol); }
+	void SetProperties();
+
+	void Print();
+
 private:
+	bool CheckVolumeName(G4String volumeName);
+	DetectorProperties ParseVolumeName(G4String volumeName);
+	const char* CrystalColour(G4int crystalNumber);
 	G4int     fGriffinDetectorsMapIndex;
 	G4int     fGriffinDetectorsMap[16];
 
@@ -266,6 +284,9 @@ private:
 	G4bool fTestcan;
 	G4bool fSpice;
 	G4bool fPaces;
+
+	//unordered maps which hold properties of the physical volumes created
+	std::unordered_map<G4VPhysicalVolume*, DetectorProperties> fPropertiesMap;
 };
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 

--- a/include/EventAction.hh
+++ b/include/EventAction.hh
@@ -41,6 +41,8 @@
 #include "globals.hh"
 #include "HistoManager.hh"
 
+#include "DetectorConstruction.hh" // for DetectorProperties
+
 class RunAction;
 class HistoManager;
 
@@ -61,8 +63,8 @@ public:
 
 	G4int GetEventNumber() { return fEvtNb;};
 
-	void AddHitTracker(G4String mnemonic, G4int eventNumber, G4int trackID, G4int parentID, G4int stepNumber, G4int particleType, G4int processType, G4int systemID, G4int cryNumber, G4int detNumber, G4double depEnergy, G4double posx, G4double posy, G4double posz, G4double time, G4int trackerZ);
-	void AddStepTracker(G4int eventNumber, G4int trackID, G4int parentID, G4int stepNumber, G4int particleType, G4int processType, G4int systemID, G4int cryNumber, G4int detNumber, G4double depEnergy, G4double posx, G4double posy, G4double posz, G4double time, G4int trackerZ);
+	void AddHitTracker(const DetectorProperties& properties, const G4int& eventNumber, const G4int& trackID, const G4int& parentID, const G4int& stepNumber, const G4int& particleType, const G4int& processType, const G4double& depEnergy, const G4ThreeVector& pos, const G4double& time, const G4int& trackerZ);
+	void AddStepTracker(const DetectorProperties& properties, const G4int& eventNumber, const G4int& trackID, const G4int& parentID, const G4int& stepNumber, const G4int& particleType, const G4int& processType, const G4double& depEnergy, const G4ThreeVector& pos, const G4double& time, const G4int& trackerZ);
 
 
 	// Energy deposit in detection systems
@@ -83,7 +85,6 @@ private:
 	void SetupSpiceErfc();
 	G4double SpiceErfc();
 
-
 	//Applying a resolution to SPCIE energies if desired
 	G4double fAmp[10000];//Bin amp (effective y)
 	G4double fAmpx[10000];
@@ -92,27 +93,18 @@ private:
 	// Tracking info
 	G4int    fHitTrackerI[NUMSTEPVARS][MAXHITS];
 	G4double fHitTrackerD[NUMSTEPVARS][MAXHITS];
-	G4int    fHitIndex;
 	G4int    fNumberOfHits;
-	G4String fPHitMnemonic[MAXHITS];
+	DetectorProperties fProperties[MAXHITS];
 
 	G4int    fStepTrackerI[NUMSTEPVARS][MAXSTEPS];
 	G4double fStepTrackerD[NUMSTEPVARS][MAXSTEPS];
-	G4int    fStepIndex;
 	G4int    fNumberOfSteps;
-
-	G4int    fPTrackID;
-	G4int    fPParentID;
-
 
 	// Energy deposit in detection systems
 	G4double fSpiceEnergyDet[10][12];
 	G4double fSpiceTrackDet[10][12];
-
 };
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
 #endif
-
-

--- a/include/SteppingAction.hh
+++ b/include/SteppingAction.hh
@@ -56,28 +56,6 @@ public:
 private:
     DetectorConstruction* fDetector;
     EventAction*          fEventAction;
-
-    // Griffin
-    void SetDetAndCryNumberForGriffinComponent( G4String );
-    void SetDetAndCryNumberForDeadLayerSpecificGriffinCrystal(G4String);
-    void SetDetNumberForGenericDetector( G4String );
-    void SetDetNumberForAncillaryBGODetector( G4String );
-    void SetDetAndCryNumberForSpiceDetector( G4String );
-    void SetDetAndCryNumberForTrificDetector( G4String );
-
-    G4int FindTrueGriffinDetector(G4int);
-
-    G4int fStepNumber;
-    G4int fDet;
-    G4int fCry;
-    G4int fTrueGriffinDetectorMap[16];
-    G4bool fGriffinDetectorMapSet;
-
-    G4int fNumberOfAssemblyVols;
-
-    G4String G4intToG4String(G4int value);
-    G4String GetCrystalColour(G4int value);
-
 };
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......

--- a/src/ApparatusDescantStructure.cc
+++ b/src/ApparatusDescantStructure.cc
@@ -35,199 +35,202 @@
 
 
 ApparatusDescantStructure::ApparatusDescantStructure() :
-    fDescantStructureLog(0) {
+	fDescantStructureLog(0)
+{
 
-    // DESCANT structure properties
-    fStructureMaterial 	      = "G4_Al";
-    fStructureInnerRadius     = 915.82*mm;// using freeCAD to calculate thickness of the shell from STEP file
-    fStructureOuterRadius     = 1007.9566*mm;
-    fStartPhi                 = 0.0*deg;
-    fDeltaPhi                 = (360.0/5)*deg;
-    fStartTheta		         = 13.0*deg;
-    fDeltaTheta               = 67.8743593*deg - fStartTheta;
-    fStructureRadialDistance  = 85.75*cm;
+	// DESCANT structure properties
+	fStructureMaterial 	      = "G4_Al";
+	fStructureInnerRadius     = 915.82*mm;// using freeCAD to calculate thickness of the shell from STEP file
+	fStructureOuterRadius     = 1007.9566*mm;
+	fStartPhi                 = 0.0*deg;
+	fDeltaPhi                 = (360.0/5)*deg;
+	fStartTheta		         = 13.0*deg;
+	fDeltaTheta               = 67.8743593*deg - fStartTheta;
+	fStructureRadialDistance  = 85.75*cm;
 
-    // for red polyhedra subtraction
-    fNumSides = 6;
-    fNumZplanes = 2;
-    G4double cutExtra = 4.0*mm;
-    fPolyRadiusRed = (171.57*mm)/2. + cutExtra; // taken from furthest distance between opposide sides on a red detector
+	// for red polyhedra subtraction
+	fNumSides = 6;
+	fNumZplanes = 2;
+	G4double cutExtra = 4.0*mm;
+	fPolyRadiusRed = (171.57*mm)/2. + cutExtra; // taken from furthest distance between opposide sides on a red detector
 
-    G4double innerRadiusRedArray[2] = {0.0*mm, 0.0*mm};
-    memcpy(fInnerRadiusRed, innerRadiusRedArray, sizeof(fInnerRadiusRed));
-    G4double outerRadiusRedArray[2] = {fPolyRadiusRed, fPolyRadiusRed};
-    memcpy(fOuterRadiusRed, outerRadiusRedArray, sizeof(fOuterRadiusRed));
-    G4double zPlanesArray[2] = {-500.0*mm, 500.0*mm};
-    memcpy(fZPlanes, zPlanesArray, sizeof(fZPlanes));
+	G4double innerRadiusRedArray[2] = {0.0*mm, 0.0*mm};
+	memcpy(fInnerRadiusRed, innerRadiusRedArray, sizeof(fInnerRadiusRed));
+	G4double outerRadiusRedArray[2] = {fPolyRadiusRed, fPolyRadiusRed};
+	memcpy(fOuterRadiusRed, outerRadiusRedArray, sizeof(fOuterRadiusRed));
+	G4double zPlanesArray[2] = {-500.0*mm, 500.0*mm};
+	memcpy(fZPlanes, zPlanesArray, sizeof(fZPlanes));
 
-    // for green/yellow polyhedra subtraction
-    fPolyRadiusGreenYellow = (150.96*mm)/2. + cutExtra; // taken from furthest distance between opposide sides on a red detector
+	// for green/yellow polyhedra subtraction
+	fPolyRadiusGreenYellow = (150.96*mm)/2. + cutExtra; // taken from furthest distance between opposide sides on a red detector
 
-    G4double innerRadiusGreenYellowArray[2] = {0.0*mm, 0.0*mm};
-    memcpy(fInnerRadiusGreenYellow, innerRadiusGreenYellowArray, sizeof(fInnerRadiusGreenYellow));
-    G4double outerRadiusGreenYellowArray[2] = {fPolyRadiusGreenYellow, fPolyRadiusGreenYellow};
-    memcpy(fOuterRadiusGreenYellow, outerRadiusGreenYellowArray, sizeof(fOuterRadiusGreenYellow));
+	G4double innerRadiusGreenYellowArray[2] = {0.0*mm, 0.0*mm};
+	memcpy(fInnerRadiusGreenYellow, innerRadiusGreenYellowArray, sizeof(fInnerRadiusGreenYellow));
+	G4double outerRadiusGreenYellowArray[2] = {fPolyRadiusGreenYellow, fPolyRadiusGreenYellow};
+	memcpy(fOuterRadiusGreenYellow, outerRadiusGreenYellowArray, sizeof(fOuterRadiusGreenYellow));
 
-    // for white polyhedra subtraction
-    cutExtra = 10.0*mm;
-    fPolyRadiusWhite = (150.86*mm)/2. + cutExtra;
+	// for white polyhedra subtraction
+	cutExtra = 10.0*mm;
+	fPolyRadiusWhite = (150.86*mm)/2. + cutExtra;
 
-    G4double innerRadiusWhiteArray[2] = {0.0*mm, 0.0*mm};
-    memcpy(fInnerRadiusWhite, innerRadiusWhiteArray, sizeof(fInnerRadiusWhite));
-    G4double outerRadiusWhiteArray[2] = {fPolyRadiusWhite, fPolyRadiusWhite};
-    memcpy(fOuterRadiusWhite, outerRadiusWhiteArray, sizeof(fOuterRadiusWhite));
+	G4double innerRadiusWhiteArray[2] = {0.0*mm, 0.0*mm};
+	memcpy(fInnerRadiusWhite, innerRadiusWhiteArray, sizeof(fInnerRadiusWhite));
+	G4double outerRadiusWhiteArray[2] = {fPolyRadiusWhite, fPolyRadiusWhite};
+	memcpy(fOuterRadiusWhite, outerRadiusWhiteArray, sizeof(fOuterRadiusWhite));
 
-    // for polyhedra backing
-    fBackRadius = 105.0*mm;
+	// for polyhedra backing
+	fBackRadius = 105.0*mm;
 
-    G4double innerRadiusBackArray[2] = {0.0*mm, 0.0*mm};
-    memcpy(fInnerRadiusBack, innerRadiusBackArray, sizeof(fInnerRadiusBack));
-    G4double outerRadiusBackArray[2] = {fBackRadius, fBackRadius};
-    memcpy(fOuterRadiusBack, outerRadiusBackArray, sizeof(fOuterRadiusBack));
-    G4double zPlanesBackArray[2] = {-9.0*mm, 9.0*mm};
-    memcpy(fZPlanesBack, zPlanesBackArray, sizeof(fZPlanesBack));
+	G4double innerRadiusBackArray[2] = {0.0*mm, 0.0*mm};
+	memcpy(fInnerRadiusBack, innerRadiusBackArray, sizeof(fInnerRadiusBack));
+	G4double outerRadiusBackArray[2] = {fBackRadius, fBackRadius};
+	memcpy(fOuterRadiusBack, outerRadiusBackArray, sizeof(fOuterRadiusBack));
+	G4double zPlanesBackArray[2] = {-9.0*mm, 9.0*mm};
+	memcpy(fZPlanesBack, zPlanesBackArray, sizeof(fZPlanesBack));
 
-    // for cylinder subtraction from back plates
-    fMinRadius = 0.0*mm;
-    fMaxRadius = 50.0*mm;
-    fHalfLength = 2000.0*mm;
-    fSubtractionStartPhi = 0.0*deg;
-    fSubtractionDeltaPhi = 360.0*deg;
+	// for cylinder subtraction from back plates
+	fMinRadius = 0.0*mm;
+	fMaxRadius = 50.0*mm;
+	fHalfLength = 2000.0*mm;
+	fSubtractionStartPhi = 0.0*deg;
+	fSubtractionDeltaPhi = 360.0*deg;
 
-    // for subtraction box
-    fSubBoxX = fSubBoxY = fSubBoxZ = 1000.0*mm;
-    fMoveCut = 100.0*mm;
+	// for subtraction box
+	fSubBoxX = fSubBoxY = fSubBoxZ = 1000.0*mm;
+	fMoveCut = 100.0*mm;
 
-    // The Euler angles from James' MSc thesis which gives us the detector positions
-    // Some of the angles for the green and yellow detectors are wrong in James' thesis,
-    // note the +180 on a few angles.
+	// The Euler angles from James' MSc thesis which gives us the detector positions
+	// Some of the angles for the green and yellow detectors are wrong in James' thesis,
+	// note the +180 on a few angles.
 
-    G4double blueAlphaBetaGammaArray[15][3] = {
-        {	-22.39*deg,	-33.76*deg,	-71.19*deg},
-        {	-49.61*deg,	-33.76*deg,	71.19*deg},
-        {	-36.00*deg,	-46.06*deg,	180.00*deg},
-        {	85.61*deg,	33.76*deg,	108.81*deg},
-        {	58.39*deg,	33.76*deg,	251.19*deg},
-        {	72.00*deg,	46.06*deg,	360.00*deg},
-        {	13.61*deg,	33.76*deg,	108.81*deg},
-        {	-13.61*deg,	33.76*deg,	251.19*deg},
-        {	0.00*deg,	46.06*deg,	360.00*deg},
-        {	-58.39*deg,	33.76*deg,	108.81*deg},
-        {	-85.61*deg,	33.76*deg,	251.19*deg},
-        {	-72.00*deg,	46.06*deg,	360.00*deg},
-        {	49.61*deg,	-33.76*deg,	-71.19*deg},
-        {	22.39*deg,	-33.76*deg,	71.19*deg},
-        {	36.00*deg,	-46.06*deg,	180.00*deg}
-    };
+	G4double blueAlphaBetaGammaArray[15][3] = {
+		{	-22.39*deg,	-33.76*deg,	-71.19*deg},
+		{	-49.61*deg,	-33.76*deg,	71.19*deg},
+		{	-36.00*deg,	-46.06*deg,	180.00*deg},
+		{	85.61*deg,	33.76*deg,	108.81*deg},
+		{	58.39*deg,	33.76*deg,	251.19*deg},
+		{	72.00*deg,	46.06*deg,	360.00*deg},
+		{	13.61*deg,	33.76*deg,	108.81*deg},
+		{	-13.61*deg,	33.76*deg,	251.19*deg},
+		{	0.00*deg,	46.06*deg,	360.00*deg},
+		{	-58.39*deg,	33.76*deg,	108.81*deg},
+		{	-85.61*deg,	33.76*deg,	251.19*deg},
+		{	-72.00*deg,	46.06*deg,	360.00*deg},
+		{	49.61*deg,	-33.76*deg,	-71.19*deg},
+		{	22.39*deg,	-33.76*deg,	71.19*deg},
+		{	36.00*deg,	-46.06*deg,	180.00*deg}
+	};
 
-    memcpy(fBlueAlphaBetaGamma, blueAlphaBetaGammaArray, sizeof(fBlueAlphaBetaGamma));
+	memcpy(fBlueAlphaBetaGamma, blueAlphaBetaGammaArray, sizeof(fBlueAlphaBetaGamma));
 
-    G4double greenAlphaBetaGammaArray[10][3] = {
-        {	-12.45*deg,	-60.47*deg,	-12.45*deg},
-        {	-27.73*deg,	-58.55*deg,	-4.54*deg},
-        {	-84.45*deg,	-60.47*deg,	-12.45*deg},
-        {	80.27*deg,	58.55*deg,	(-4.54+180)*deg},
-        {	23.55*deg,	60.47*deg,	167.55*deg},
-        {	8.27*deg,	58.55*deg,	175.46*deg},
-        {	-48.45*deg,	60.47*deg,	167.55*deg},
-        {	-63.73*deg,	58.55*deg,	175.46*deg},
-        {	59.55*deg,	-60.47*deg,	-12.45*deg},
-        {	44.27*deg,	-58.55*deg,	-4.54*deg}
-    };
+	G4double greenAlphaBetaGammaArray[10][3] = {
+		{	-12.45*deg,	-60.47*deg,	-12.45*deg},
+		{	-27.73*deg,	-58.55*deg,	-4.54*deg},
+		{	-84.45*deg,	-60.47*deg,	-12.45*deg},
+		{	80.27*deg,	58.55*deg,	(-4.54+180)*deg},
+		{	23.55*deg,	60.47*deg,	167.55*deg},
+		{	8.27*deg,	58.55*deg,	175.46*deg},
+		{	-48.45*deg,	60.47*deg,	167.55*deg},
+		{	-63.73*deg,	58.55*deg,	175.46*deg},
+		{	59.55*deg,	-60.47*deg,	-12.45*deg},
+		{	44.27*deg,	-58.55*deg,	-4.54*deg}
+	};
 
-    memcpy(fGreenAlphaBetaGamma, greenAlphaBetaGammaArray, sizeof(fGreenAlphaBetaGamma));
+	memcpy(fGreenAlphaBetaGamma, greenAlphaBetaGammaArray, sizeof(fGreenAlphaBetaGamma));
 
-    G4double redAlphaBetaGammaArray[15][3] = {
-        {	-36.00*deg,	-20.39*deg,	180.00*deg},
-        {	-16.04*deg,	-47.84*deg,	45.10*deg},
-        {	-55.96*deg,	-47.84*deg,	314.90*deg},
-        {	72.00*deg,	20.39*deg,	0.00*deg},
-        {	-88.04*deg,	-47.84*deg,	45.10*deg},
-        {	52.04*deg,	47.84*deg,	134.90*deg},
-        {	0.00*deg,	20.39*deg,	0.00*deg},
-        {	19.96*deg,	47.84*deg,	225.10*deg},
-        {	-19.96*deg,	47.84*deg,	134.90*deg},
-        {	-72.00*deg,	20.39*deg,	0.00*deg},
-        {	-52.04*deg,	47.84*deg,	225.10*deg},
-        {	88.04*deg,	-47.84*deg,	314.90*deg},
-        {	36.00*deg,	-20.39*deg,	180.00*deg},
-        {	55.96*deg,	-47.84*deg,	45.10*deg},
-        {	16.04*deg,	-47.84*deg,	314.90*deg}
-    };
+	G4double redAlphaBetaGammaArray[15][3] = {
+		{	-36.00*deg,	-20.39*deg,	180.00*deg},
+		{	-16.04*deg,	-47.84*deg,	45.10*deg},
+		{	-55.96*deg,	-47.84*deg,	314.90*deg},
+		{	72.00*deg,	20.39*deg,	0.00*deg},
+		{	-88.04*deg,	-47.84*deg,	45.10*deg},
+		{	52.04*deg,	47.84*deg,	134.90*deg},
+		{	0.00*deg,	20.39*deg,	0.00*deg},
+		{	19.96*deg,	47.84*deg,	225.10*deg},
+		{	-19.96*deg,	47.84*deg,	134.90*deg},
+		{	-72.00*deg,	20.39*deg,	0.00*deg},
+		{	-52.04*deg,	47.84*deg,	225.10*deg},
+		{	88.04*deg,	-47.84*deg,	314.90*deg},
+		{	36.00*deg,	-20.39*deg,	180.00*deg},
+		{	55.96*deg,	-47.84*deg,	45.10*deg},
+		{	16.04*deg,	-47.84*deg,	314.90*deg}
+	};
 
-    memcpy(fRedAlphaBetaGamma, redAlphaBetaGammaArray, sizeof(fRedAlphaBetaGamma));
+	memcpy(fRedAlphaBetaGamma, redAlphaBetaGammaArray, sizeof(fRedAlphaBetaGamma));
 
-    G4double whiteAlphaBetaGammaArray[20][3] = {
-        {	0.00*deg,	-11.37*deg,	90.00*deg},
-        {	0.00*deg,	-24.67*deg,	90.00*deg},
-        {	0.00*deg,	-38.76*deg,	-90.00*deg},
-        {	0.00*deg,	-52.06*deg,	-90.00*deg},
-        {	-72.00*deg,	-11.37*deg,	90.00*deg},
-        {	-72.00*deg,	-24.67*deg,	90.00*deg},
-        {	-72.00*deg,	-38.76*deg,	-90.00*deg},
-        {	-72.00*deg,	-52.06*deg,	-90.00*deg},
-        {	36.00*deg,	11.37*deg,	270.00*deg},
-        {	36.00*deg,	24.67*deg,	270.00*deg},
-        {	36.00*deg,	38.76*deg,	90.00*deg},
-        {	36.00*deg,	52.06*deg,	90.00*deg},
-        {	-36.00*deg,	11.37*deg,	270.00*deg},
-        {	-36.00*deg,	24.67*deg,	270.00*deg},
-        {	-36.00*deg,	38.76*deg,	90.00*deg},
-        {	-36.00*deg,	52.06*deg,	90.00*deg},
-        {	72.00*deg,	-11.37*deg,	90.00*deg},
-        {	72.00*deg,	-24.67*deg,	90.00*deg},
-        {	72.00*deg,	-38.76*deg,	-90.00*deg},
-        {	72.00*deg,	-52.06*deg,	-90.00*deg} //59
-    };
+	G4double whiteAlphaBetaGammaArray[20][3] = {
+		{	0.00*deg,	-11.37*deg,	90.00*deg},
+		{	0.00*deg,	-24.67*deg,	90.00*deg},
+		{	0.00*deg,	-38.76*deg,	-90.00*deg},
+		{	0.00*deg,	-52.06*deg,	-90.00*deg},
+		{	-72.00*deg,	-11.37*deg,	90.00*deg},
+		{	-72.00*deg,	-24.67*deg,	90.00*deg},
+		{	-72.00*deg,	-38.76*deg,	-90.00*deg},
+		{	-72.00*deg,	-52.06*deg,	-90.00*deg},
+		{	36.00*deg,	11.37*deg,	270.00*deg},
+		{	36.00*deg,	24.67*deg,	270.00*deg},
+		{	36.00*deg,	38.76*deg,	90.00*deg},
+		{	36.00*deg,	52.06*deg,	90.00*deg},
+		{	-36.00*deg,	11.37*deg,	270.00*deg},
+		{	-36.00*deg,	24.67*deg,	270.00*deg},
+		{	-36.00*deg,	38.76*deg,	90.00*deg},
+		{	-36.00*deg,	52.06*deg,	90.00*deg},
+		{	72.00*deg,	-11.37*deg,	90.00*deg},
+		{	72.00*deg,	-24.67*deg,	90.00*deg},
+		{	72.00*deg,	-38.76*deg,	-90.00*deg},
+		{	72.00*deg,	-52.06*deg,	-90.00*deg} //59
+	};
 
-    memcpy(fWhiteAlphaBetaGamma, whiteAlphaBetaGammaArray, sizeof(fWhiteAlphaBetaGamma));
+	memcpy(fWhiteAlphaBetaGamma, whiteAlphaBetaGammaArray, sizeof(fWhiteAlphaBetaGamma));
 
-    G4double yellowAlphaBetaGammaArray[10][3] = {
-        {	-44.27*deg,	-58.55*deg,	(4.54+180)*deg},
-        {	-59.55*deg,	-60.47*deg,	192.45*deg},
-        {	63.73*deg,	58.55*deg,	4.54*deg},
-        {	48.45*deg,	60.47*deg,	(192.45+180)*deg},
-        {	-8.27*deg,	58.55*deg,	(184.54+180)*deg},
-        {	-23.55*deg,	60.47*deg,	372.45*deg},
-        {	-80.27*deg,	58.55*deg,	(184.54+180)*deg},
-        {	84.45*deg,	-60.47*deg,	(372.45+180)*deg},
-        {	27.73*deg,	-58.55*deg,	(4.54+180)*deg},
-        {	12.45*deg,	-60.47*deg,	192.45*deg}
-    };
+	G4double yellowAlphaBetaGammaArray[10][3] = {
+		{	-44.27*deg,	-58.55*deg,	(4.54+180)*deg},
+		{	-59.55*deg,	-60.47*deg,	192.45*deg},
+		{	63.73*deg,	58.55*deg,	4.54*deg},
+		{	48.45*deg,	60.47*deg,	(192.45+180)*deg},
+		{	-8.27*deg,	58.55*deg,	(184.54+180)*deg},
+		{	-23.55*deg,	60.47*deg,	372.45*deg},
+		{	-80.27*deg,	58.55*deg,	(184.54+180)*deg},
+		{	84.45*deg,	-60.47*deg,	(372.45+180)*deg},
+		{	27.73*deg,	-58.55*deg,	(4.54+180)*deg},
+		{	12.45*deg,	-60.47*deg,	192.45*deg}
+	};
 
-    memcpy(fYellowAlphaBetaGamma, yellowAlphaBetaGammaArray, sizeof(fYellowAlphaBetaGamma));
+	memcpy(fYellowAlphaBetaGamma, yellowAlphaBetaGammaArray, sizeof(fYellowAlphaBetaGamma));
 
-    fGreyColour     = G4Colour(0.9,0.9,0.9);
+	fGreyColour     = G4Colour(0.9,0.9,0.9);
 }
 
 
-ApparatusDescantStructure::~ApparatusDescantStructure() {
-    // LogicalVolumes
-    delete fDescantStructureLog;
-}
-
-
-
-G4int ApparatusDescantStructure::Build() {
-
-    fAssemblyDescantStructure = new G4AssemblyVolume();
-
-    BuildDescantShell();
-
-    return 1;
+ApparatusDescantStructure::~ApparatusDescantStructure()
+{
+	// LogicalVolumes
+	delete fDescantStructureLog;
 }
 
 
 
-G4int ApparatusDescantStructure::PlaceDescantStructure(G4LogicalVolume* expHallLog) {
-    G4RotationMatrix* rotate;
-    G4ThreeVector move = G4ThreeVector(0.0, 0.0, 0.0);
+G4int ApparatusDescantStructure::Build()
+{
+	fAssemblyDescantStructure = new G4AssemblyVolume();
 
-    for(G4int i = 0; i < 5; i++){
-        rotate = new G4RotationMatrix;
-        rotate->rotateZ((i*72.0)*deg);
-        fAssemblyDescantStructure->MakeImprint(expHallLog, move, rotate);
-    }
+	BuildDescantShell();
+
+	return 1;
+}
+
+
+
+G4int ApparatusDescantStructure::PlaceDescantStructure(G4LogicalVolume* expHallLog)
+{
+	G4RotationMatrix* rotate;
+	G4ThreeVector move = G4ThreeVector(0.0, 0.0, 0.0);
+
+	for(G4int i = 0; i < 5; i++){
+		rotate = new G4RotationMatrix;
+		rotate->rotateZ((i*72.0)*deg);
+		fAssemblyDescantStructure->MakeImprint(expHallLog, move, rotate);
+	}
 
 	return 0;
 }
@@ -235,223 +238,223 @@ G4int ApparatusDescantStructure::PlaceDescantStructure(G4LogicalVolume* expHallL
 
 G4int ApparatusDescantStructure::BuildDescantShell()
 {
-    G4ThreeVector move = G4ThreeVector(0.0, 0.0, 0.0);
-    G4RotationMatrix * rotate = new G4RotationMatrix;
-    G4int detectorNumber = 70;
-    G4int idx;
-    fStructureRadialDistance = fStructureOuterRadius + 8.0*mm;
+	G4ThreeVector move = G4ThreeVector(0.0, 0.0, 0.0);
+	G4RotationMatrix * rotate = new G4RotationMatrix;
+	G4int detectorNumber = 70;
+	G4int idx;
+	fStructureRadialDistance = fStructureOuterRadius + 8.0*mm;
 
-    // for cutting the detector shapes
-    G4Box * subtractionBox = new G4Box("subtractionBox", fSubBoxX, fSubBoxY, fSubBoxZ);
+	// for cutting the detector shapes
+	G4Box * subtractionBox = new G4Box("subtractionBox", fSubBoxX, fSubBoxY, fSubBoxZ);
 
-    // for construction of main DESCANT shell structure
-	 G4Sphere * alumSphere = new G4Sphere("descant sphere",
-                                       fStructureInnerRadius, fStructureOuterRadius, fStartPhi, fDeltaPhi, fStartTheta, fDeltaTheta);
+	// for construction of main DESCANT shell structure
+	G4Sphere * alumSphere = new G4Sphere("descant sphere",
+			fStructureInnerRadius, fStructureOuterRadius, fStartPhi, fDeltaPhi, fStartTheta, fDeltaTheta);
 
-    // for the subtraction of each detector shape from the solid shell
-	 //red - cut
-    G4Polyhedra * polyRed = new G4Polyhedra("polyRed", fStartPhi, fDeltaPhi, fNumSides, fNumZplanes, fZPlanes, fInnerRadiusRed, fOuterRadiusRed);
-    rotate = new G4RotationMatrix;
-    rotate->rotateZ(20.0*deg);
-    fMoveCut = 120.0*mm;
-    move = G4ThreeVector(1.0*fSubBoxX + fMoveCut, 0.0, 0.0);
-    rotate = new G4RotationMatrix;
-    rotate->rotateZ(-20.0*deg);
-    fMoveCut = 120.0*mm;
-    move = G4ThreeVector(1.0*fSubBoxX + fMoveCut, 0.0, 0.0);
-	 //white
-    G4Polyhedra * polyWhite = new G4Polyhedra("polyWhite", fStartPhi, fDeltaPhi, fNumSides, fNumZplanes, fZPlanes, fInnerRadiusWhite, fOuterRadiusWhite);
-	 //green or yellow before cut
-    G4Polyhedra * polyGreenYellow = new G4Polyhedra("polyGreenYellow", fStartPhi, fDeltaPhi, fNumSides, fNumZplanes, fZPlanes, fInnerRadiusGreenYellow, fOuterRadiusGreenYellow);
-	 //green after cut
-    rotate = new G4RotationMatrix;
-    fMoveCut = 65.0*mm;
-    move = G4ThreeVector(1.0*fSubBoxX + fMoveCut, 0.0, 0.0);
-    G4SubtractionSolid * polyGreenCut = new G4SubtractionSolid("polyGreenCut", polyGreenYellow, subtractionBox, rotate, move);
-	 //yellow after cut
-    rotate = new G4RotationMatrix;
-    fMoveCut = 65.0*mm;
-    move = G4ThreeVector(-1.0*fSubBoxX - fMoveCut, 0.0, 0.0);
-    G4SubtractionSolid * polyYellowCut = new G4SubtractionSolid("polyYellowCut", polyGreenYellow, subtractionBox, rotate, move);
+	// for the subtraction of each detector shape from the solid shell
+	//red - cut
+	G4Polyhedra * polyRed = new G4Polyhedra("polyRed", fStartPhi, fDeltaPhi, fNumSides, fNumZplanes, fZPlanes, fInnerRadiusRed, fOuterRadiusRed);
+	rotate = new G4RotationMatrix;
+	rotate->rotateZ(20.0*deg);
+	fMoveCut = 120.0*mm;
+	move = G4ThreeVector(1.0*fSubBoxX + fMoveCut, 0.0, 0.0);
+	rotate = new G4RotationMatrix;
+	rotate->rotateZ(-20.0*deg);
+	fMoveCut = 120.0*mm;
+	move = G4ThreeVector(1.0*fSubBoxX + fMoveCut, 0.0, 0.0);
+	//white
+	G4Polyhedra * polyWhite = new G4Polyhedra("polyWhite", fStartPhi, fDeltaPhi, fNumSides, fNumZplanes, fZPlanes, fInnerRadiusWhite, fOuterRadiusWhite);
+	//green or yellow before cut
+	G4Polyhedra * polyGreenYellow = new G4Polyhedra("polyGreenYellow", fStartPhi, fDeltaPhi, fNumSides, fNumZplanes, fZPlanes, fInnerRadiusGreenYellow, fOuterRadiusGreenYellow);
+	//green after cut
+	rotate = new G4RotationMatrix;
+	fMoveCut = 65.0*mm;
+	move = G4ThreeVector(1.0*fSubBoxX + fMoveCut, 0.0, 0.0);
+	G4SubtractionSolid * polyGreenCut = new G4SubtractionSolid("polyGreenCut", polyGreenYellow, subtractionBox, rotate, move);
+	//yellow after cut
+	rotate = new G4RotationMatrix;
+	fMoveCut = 65.0*mm;
+	move = G4ThreeVector(-1.0*fSubBoxX - fMoveCut, 0.0, 0.0);
+	G4SubtractionSolid * polyYellowCut = new G4SubtractionSolid("polyYellowCut", polyGreenYellow, subtractionBox, rotate, move);
 
-    // for construction of the back plates of each DESCANT detector
-        // general
-    rotate = new G4RotationMatrix;
-    move = G4ThreeVector(0.0, 0.0, 0.0);
-    G4Polyhedra * shellBack = new G4Polyhedra("shellBack", fStartPhi, fDeltaPhi, fNumSides, fNumZplanes, fZPlanesBack, fInnerRadiusBack, fOuterRadiusBack);
-    G4Tubs * cylinder = new G4Tubs("cylinder", fMinRadius, fMaxRadius, fHalfLength, fSubtractionStartPhi, fSubtractionDeltaPhi);
-    G4SubtractionSolid * shellBackHole = new G4SubtractionSolid("shellBackWithHoles", shellBack, cylinder, rotate, move);
-        // yellow
-    fMoveCut = 90.0*mm;
-    rotate = new G4RotationMatrix;
-    move = G4ThreeVector(-1.0*fSubBoxX - fMoveCut, 0.0, 0.0);
-    G4SubtractionSolid * shellBackYellow = new G4SubtractionSolid("shellBackWithHolesYellow", shellBackHole, subtractionBox, rotate, move);
-        // green
-    fMoveCut = 90.0*mm;
-    rotate = new G4RotationMatrix;
-    move = G4ThreeVector(1.0*fSubBoxX + fMoveCut, 0.0, 0.0);
-    G4SubtractionSolid * shellBackGreen = new G4SubtractionSolid("shellBackWithHolesGreen", shellBackHole, subtractionBox, rotate, move);
+	// for construction of the back plates of each DESCANT detector
+	// general
+	rotate = new G4RotationMatrix;
+	move = G4ThreeVector(0.0, 0.0, 0.0);
+	G4Polyhedra * shellBack = new G4Polyhedra("shellBack", fStartPhi, fDeltaPhi, fNumSides, fNumZplanes, fZPlanesBack, fInnerRadiusBack, fOuterRadiusBack);
+	G4Tubs * cylinder = new G4Tubs("cylinder", fMinRadius, fMaxRadius, fHalfLength, fSubtractionStartPhi, fSubtractionDeltaPhi);
+	G4SubtractionSolid * shellBackHole = new G4SubtractionSolid("shellBackWithHoles", shellBack, cylinder, rotate, move);
+	// yellow
+	fMoveCut = 90.0*mm;
+	rotate = new G4RotationMatrix;
+	move = G4ThreeVector(-1.0*fSubBoxX - fMoveCut, 0.0, 0.0);
+	G4SubtractionSolid * shellBackYellow = new G4SubtractionSolid("shellBackWithHolesYellow", shellBackHole, subtractionBox, rotate, move);
+	// green
+	fMoveCut = 90.0*mm;
+	rotate = new G4RotationMatrix;
+	move = G4ThreeVector(1.0*fSubBoxX + fMoveCut, 0.0, 0.0);
+	G4SubtractionSolid * shellBackGreen = new G4SubtractionSolid("shellBackWithHolesGreen", shellBackHole, subtractionBox, rotate, move);
 
-    // Colour
-    G4VisAttributes* greyVisAtt = new G4VisAttributes(fGreyColour);
-    greyVisAtt->SetVisibility(true);
+	// Colour
+	G4VisAttributes* greyVisAtt = new G4VisAttributes(fGreyColour);
+	greyVisAtt->SetVisibility(true);
 
-	 // Material
-	 G4Material* structureG4material = G4Material::GetMaterial(fStructureMaterial);
-	 if( !structureG4material ) {
+	// Material
+	G4Material* structureG4material = G4Material::GetMaterial(fStructureMaterial);
+	if(!structureG4material) {
 		G4cout << " ----> Material " << fStructureMaterial << " not found, cannot build! " << G4endl;
 		return 0;
-	 }
-	 
-	 
-	 G4LogicalVolume * logicBack = new G4LogicalVolume(shellBackHole, structureG4material, "logicBack", 0, 0, 0);
-	 logicBack->SetVisAttributes(fGreyColour);
-	 
-	 G4LogicalVolume * logicBackYellow = new G4LogicalVolume(shellBackYellow, structureG4material, "logicBackYellow", 0, 0, 0);
-	 logicBackYellow->SetVisAttributes(fGreyColour);
-	 
-     G4LogicalVolume * logicBackGreen = new G4LogicalVolume(shellBackGreen, structureG4material, "logicBackGreen", 0, 0, 0);
-     logicBackYellow->SetVisAttributes(fGreyColour);
+	}
 
-    // for making the DESCANT shell
-    G4SubtractionSolid * preSubtraction;
-    G4SubtractionSolid * postSubtraction;
-    std::vector<G4SubtractionSolid*> descantShell;
 
-    	// subtract Blue Detector
-    for(G4int i=0; i<(detectorNumber-55); i++){
-        idx = i;
-        //
-        move = G4ThreeVector(0.0, 0.0, fStructureRadialDistance);
-        move.rotateZ(fBlueAlphaBetaGamma[idx][2]);
-        move.rotateY(fBlueAlphaBetaGamma[idx][1]);
-        move.rotateZ(fBlueAlphaBetaGamma[idx][0]);
-        rotate = new G4RotationMatrix;
-        rotate->rotateY(M_PI); // flip the detector so that the face is pointing upstream.
-        rotate->rotateZ(fBlueAlphaBetaGamma[idx][2]);
-        rotate->rotateY(fBlueAlphaBetaGamma[idx][1]);
-        rotate->rotateZ(fBlueAlphaBetaGamma[idx][0]);
-        if(i==4||i==6||i==8){fAssemblyDescantStructure->AddPlacedVolume(logicBack, move, rotate);}
-        rotate->invert();
-        std::stringstream temp;
-        temp << "blueSubtraction_" << i;
-        G4String name = temp.str();
-        if(i==4||i==5||i==6||i==8){
-            if(i == 4){ postSubtraction = new G4SubtractionSolid(name, alumSphere, polyWhite, rotate, move);
-                        descantShell.push_back(postSubtraction);}
-            else{       preSubtraction = descantShell.back();
-                        postSubtraction = new G4SubtractionSolid(name, preSubtraction, polyWhite, rotate, move);
-                        descantShell.push_back(postSubtraction);}
-        }
-    }
+	G4LogicalVolume * logicBack = new G4LogicalVolume(shellBackHole, structureG4material, "logicBack", 0, 0, 0);
+	logicBack->SetVisAttributes(fGreyColour);
 
-	 // subtract Green Detector
-    for(G4int i=15; i<(detectorNumber-45); i++){
-        idx = i-15;
-        move = G4ThreeVector(0.0, 0.0, fStructureRadialDistance);
-        move.rotateZ(fGreenAlphaBetaGamma[idx][2]);
-        move.rotateY(fGreenAlphaBetaGamma[idx][1]);
-        move.rotateZ(fGreenAlphaBetaGamma[idx][0]);
-        rotate = new G4RotationMatrix;
-        rotate->rotateY(M_PI); // flip the detector so that the face is pointing upstream.
-        rotate->rotateZ(fGreenAlphaBetaGamma[idx][2]);
-        rotate->rotateY(fGreenAlphaBetaGamma[idx][1]);
-        rotate->rotateZ(fGreenAlphaBetaGamma[idx][0]);
-        if(i==19||i==20){fAssemblyDescantStructure->AddPlacedVolume(logicBackGreen, move, rotate);}
-        rotate->invert();
-        std::stringstream temp;
-        temp << "greenSubtraction_" << i;
-        G4String name = temp.str();
-        if(i==19||i==20){
-        preSubtraction = descantShell.back();
-        postSubtraction = new G4SubtractionSolid(name, preSubtraction, polyGreenCut, rotate, move);
-        descantShell.push_back(postSubtraction);
-        }
-    }
+	G4LogicalVolume * logicBackYellow = new G4LogicalVolume(shellBackYellow, structureG4material, "logicBackYellow", 0, 0, 0);
+	logicBackYellow->SetVisAttributes(fGreyColour);
+
+	G4LogicalVolume * logicBackGreen = new G4LogicalVolume(shellBackGreen, structureG4material, "logicBackGreen", 0, 0, 0);
+	logicBackYellow->SetVisAttributes(fGreyColour);
+
+	// for making the DESCANT shell
+	G4SubtractionSolid * preSubtraction;
+	G4SubtractionSolid * postSubtraction;
+	std::vector<G4SubtractionSolid*> descantShell;
+
+	// subtract Blue Detector
+	for(G4int i=0; i<(detectorNumber-55); i++){
+		idx = i;
+		//
+		move = G4ThreeVector(0.0, 0.0, fStructureRadialDistance);
+		move.rotateZ(fBlueAlphaBetaGamma[idx][2]);
+		move.rotateY(fBlueAlphaBetaGamma[idx][1]);
+		move.rotateZ(fBlueAlphaBetaGamma[idx][0]);
+		rotate = new G4RotationMatrix;
+		rotate->rotateY(M_PI); // flip the detector so that the face is pointing upstream.
+		rotate->rotateZ(fBlueAlphaBetaGamma[idx][2]);
+		rotate->rotateY(fBlueAlphaBetaGamma[idx][1]);
+		rotate->rotateZ(fBlueAlphaBetaGamma[idx][0]);
+		if(i==4||i==6||i==8){fAssemblyDescantStructure->AddPlacedVolume(logicBack, move, rotate);}
+		rotate->invert();
+		std::stringstream temp;
+		temp << "blueSubtraction_" << i;
+		G4String name = temp.str();
+		if(i==4||i==5||i==6||i==8){
+			if(i == 4){ postSubtraction = new G4SubtractionSolid(name, alumSphere, polyWhite, rotate, move);
+				descantShell.push_back(postSubtraction);}
+			else{       preSubtraction = descantShell.back();
+				postSubtraction = new G4SubtractionSolid(name, preSubtraction, polyWhite, rotate, move);
+				descantShell.push_back(postSubtraction);}
+		}
+	}
+
+	// subtract Green Detector
+	for(G4int i=15; i<(detectorNumber-45); i++){
+		idx = i-15;
+		move = G4ThreeVector(0.0, 0.0, fStructureRadialDistance);
+		move.rotateZ(fGreenAlphaBetaGamma[idx][2]);
+		move.rotateY(fGreenAlphaBetaGamma[idx][1]);
+		move.rotateZ(fGreenAlphaBetaGamma[idx][0]);
+		rotate = new G4RotationMatrix;
+		rotate->rotateY(M_PI); // flip the detector so that the face is pointing upstream.
+		rotate->rotateZ(fGreenAlphaBetaGamma[idx][2]);
+		rotate->rotateY(fGreenAlphaBetaGamma[idx][1]);
+		rotate->rotateZ(fGreenAlphaBetaGamma[idx][0]);
+		if(i==19||i==20){fAssemblyDescantStructure->AddPlacedVolume(logicBackGreen, move, rotate);}
+		rotate->invert();
+		std::stringstream temp;
+		temp << "greenSubtraction_" << i;
+		G4String name = temp.str();
+		if(i==19||i==20){
+			preSubtraction = descantShell.back();
+			postSubtraction = new G4SubtractionSolid(name, preSubtraction, polyGreenCut, rotate, move);
+			descantShell.push_back(postSubtraction);
+		}
+	}
 
 	// subtract Red Detector
-    for(G4int i=25; i<(detectorNumber-30); i++){
-        idx = i-25;
-        move = G4ThreeVector(0.0, 0.0, fStructureRadialDistance);
-        move.rotateZ(fRedAlphaBetaGamma[idx][2]);
-        move.rotateY(fRedAlphaBetaGamma[idx][1]);
-        move.rotateZ(fRedAlphaBetaGamma[idx][0]);
-        rotate = new G4RotationMatrix;
-        rotate->rotateY(M_PI); // flip the detector so that the face is pointing upstream.
-        rotate->rotateZ(fRedAlphaBetaGamma[idx][2]);
-        rotate->rotateY(fRedAlphaBetaGamma[idx][1]);
-        rotate->rotateZ(fRedAlphaBetaGamma[idx][0]);
-        if(i==30||i==31||i==32){fAssemblyDescantStructure->AddPlacedVolume(logicBack, move, rotate);}
-        rotate->invert();
-        std::stringstream temp;
-        temp << "redSubtraction_" << i;
-        G4String name = temp.str();
-        if(i==28||i==30||i==31||i==32){
-        preSubtraction = descantShell.back();
-        postSubtraction = new G4SubtractionSolid(name, preSubtraction, polyRed, rotate, move);
-        //postSubtraction = new G4SubtractionSolid(name, preSubtraction, polyRedCut2, rotate, move);
-        descantShell.push_back(postSubtraction);
-        }
-    }
+	for(G4int i=25; i<(detectorNumber-30); i++){
+		idx = i-25;
+		move = G4ThreeVector(0.0, 0.0, fStructureRadialDistance);
+		move.rotateZ(fRedAlphaBetaGamma[idx][2]);
+		move.rotateY(fRedAlphaBetaGamma[idx][1]);
+		move.rotateZ(fRedAlphaBetaGamma[idx][0]);
+		rotate = new G4RotationMatrix;
+		rotate->rotateY(M_PI); // flip the detector so that the face is pointing upstream.
+		rotate->rotateZ(fRedAlphaBetaGamma[idx][2]);
+		rotate->rotateY(fRedAlphaBetaGamma[idx][1]);
+		rotate->rotateZ(fRedAlphaBetaGamma[idx][0]);
+		if(i==30||i==31||i==32){fAssemblyDescantStructure->AddPlacedVolume(logicBack, move, rotate);}
+		rotate->invert();
+		std::stringstream temp;
+		temp << "redSubtraction_" << i;
+		G4String name = temp.str();
+		if(i==28||i==30||i==31||i==32){
+			preSubtraction = descantShell.back();
+			postSubtraction = new G4SubtractionSolid(name, preSubtraction, polyRed, rotate, move);
+			//postSubtraction = new G4SubtractionSolid(name, preSubtraction, polyRedCut2, rotate, move);
+			descantShell.push_back(postSubtraction);
+		}
+	}
 
-    // subtract White Detector
-    for(G4int i=40; i<(detectorNumber-10); i++){
-        idx = i-40;
-        move = G4ThreeVector(0.0, 0.0, fStructureRadialDistance);
-        move.rotateZ(fWhiteAlphaBetaGamma[idx][2]);
-        move.rotateY(fWhiteAlphaBetaGamma[idx][1]);
-        move.rotateZ(fWhiteAlphaBetaGamma[idx][0]);
-        rotate = new G4RotationMatrix;
-        rotate->rotateY(M_PI); // flip the detector so that the face is pointing upstream.
-        rotate->rotateZ(fWhiteAlphaBetaGamma[idx][2]);
-        rotate->rotateY(fWhiteAlphaBetaGamma[idx][1]);
-        rotate->rotateZ(fWhiteAlphaBetaGamma[idx][0]);
-        if(i==48||i==49||i==50||i==51){fAssemblyDescantStructure->AddPlacedVolume(logicBack, move, rotate);}
-        rotate->invert();
-        std::stringstream temp;
-        temp << "whiteSubtraction_" << i;
-        G4String name = temp.str();
-        if(i==48||i==49||i==50||i==51){
-        preSubtraction = descantShell.back();
-        postSubtraction = new G4SubtractionSolid(name, preSubtraction, polyWhite, rotate, move);
-        descantShell.push_back(postSubtraction);
-        }
-    }
-    // subtract Yellow Detector
-    for(G4int i=60; i<(detectorNumber); i++){
-        idx = i-60;
-        move = G4ThreeVector(0.0, 0.0, fStructureRadialDistance);
-        move.rotateZ(fYellowAlphaBetaGamma[idx][2]);
-        move.rotateY(fYellowAlphaBetaGamma[idx][1]);
-        move.rotateZ(fYellowAlphaBetaGamma[idx][0]);
-        rotate = new G4RotationMatrix;
-        rotate->rotateY(M_PI); // flip the detector so that the face is pointing upstream.
-        rotate->rotateZ(fYellowAlphaBetaGamma[idx][2]);
-        rotate->rotateY(fYellowAlphaBetaGamma[idx][1]);
-        rotate->rotateZ(fYellowAlphaBetaGamma[idx][0]);
-        if(i==62||i==63){fAssemblyDescantStructure->AddPlacedVolume(logicBackYellow, move, rotate);}
-        rotate->invert();
-        std::stringstream temp;
-        temp << "yellowSubtraction_" << i;
-        G4String name = temp.str();
-        if(i==62||i==63){
-        preSubtraction = descantShell.back();
-        postSubtraction = new G4SubtractionSolid(name, preSubtraction, polyYellowCut, rotate, move);
-        descantShell.push_back(postSubtraction);
-        }
-    }
+	// subtract White Detector
+	for(G4int i=40; i<(detectorNumber-10); i++){
+		idx = i-40;
+		move = G4ThreeVector(0.0, 0.0, fStructureRadialDistance);
+		move.rotateZ(fWhiteAlphaBetaGamma[idx][2]);
+		move.rotateY(fWhiteAlphaBetaGamma[idx][1]);
+		move.rotateZ(fWhiteAlphaBetaGamma[idx][0]);
+		rotate = new G4RotationMatrix;
+		rotate->rotateY(M_PI); // flip the detector so that the face is pointing upstream.
+		rotate->rotateZ(fWhiteAlphaBetaGamma[idx][2]);
+		rotate->rotateY(fWhiteAlphaBetaGamma[idx][1]);
+		rotate->rotateZ(fWhiteAlphaBetaGamma[idx][0]);
+		if(i==48||i==49||i==50||i==51){fAssemblyDescantStructure->AddPlacedVolume(logicBack, move, rotate);}
+		rotate->invert();
+		std::stringstream temp;
+		temp << "whiteSubtraction_" << i;
+		G4String name = temp.str();
+		if(i==48||i==49||i==50||i==51){
+			preSubtraction = descantShell.back();
+			postSubtraction = new G4SubtractionSolid(name, preSubtraction, polyWhite, rotate, move);
+			descantShell.push_back(postSubtraction);
+		}
+	}
+	// subtract Yellow Detector
+	for(G4int i=60; i<(detectorNumber); i++){
+		idx = i-60;
+		move = G4ThreeVector(0.0, 0.0, fStructureRadialDistance);
+		move.rotateZ(fYellowAlphaBetaGamma[idx][2]);
+		move.rotateY(fYellowAlphaBetaGamma[idx][1]);
+		move.rotateZ(fYellowAlphaBetaGamma[idx][0]);
+		rotate = new G4RotationMatrix;
+		rotate->rotateY(M_PI); // flip the detector so that the face is pointing upstream.
+		rotate->rotateZ(fYellowAlphaBetaGamma[idx][2]);
+		rotate->rotateY(fYellowAlphaBetaGamma[idx][1]);
+		rotate->rotateZ(fYellowAlphaBetaGamma[idx][0]);
+		if(i==62||i==63){fAssemblyDescantStructure->AddPlacedVolume(logicBackYellow, move, rotate);}
+		rotate->invert();
+		std::stringstream temp;
+		temp << "yellowSubtraction_" << i;
+		G4String name = temp.str();
+		if(i==62||i==63){
+			preSubtraction = descantShell.back();
+			postSubtraction = new G4SubtractionSolid(name, preSubtraction, polyYellowCut, rotate, move);
+			descantShell.push_back(postSubtraction);
+		}
+	}
 
 	// Logical Volume
-	if( fDescantStructureLog == NULL ){
-        fDescantStructureLog = new G4LogicalVolume(descantShell.back(), structureG4material, "descantStructureLog", 0, 0, 0);
-		  fDescantStructureLog->SetVisAttributes(greyVisAtt);
-    	}
+	if(fDescantStructureLog == nullptr){
+		fDescantStructureLog = new G4LogicalVolume(descantShell.back(), structureG4material, "descantStructureLog", 0, 0, 0);
+		fDescantStructureLog->SetVisAttributes(greyVisAtt);
+	}
 
-        rotate = new G4RotationMatrix;
-        move = G4ThreeVector(0.0,0.0,0.0);
-        fAssemblyDescantStructure->AddPlacedVolume(fDescantStructureLog, move, rotate);
+	rotate = new G4RotationMatrix;
+	move = G4ThreeVector(0.0,0.0,0.0);
+	fAssemblyDescantStructure->AddPlacedVolume(fDescantStructureLog, move, rotate);
 
-    return 1;
+	return 1;
 }
 
 

--- a/src/ApparatusGenericTarget.cc
+++ b/src/ApparatusGenericTarget.cc
@@ -25,10 +25,10 @@ ApparatusGenericTarget::ApparatusGenericTarget() :
     // LogicalVolumes 
     fTargetLog(0)
 { 
-  this->fTargetMaterial = "Gold";
-  this->fTargetLengthX = 0.0*cm; 
-  this->fTargetLengthY = 0.0*cm;
-  this->fTargetLengthZ = 0.0*cm;
+  fTargetMaterial = "Gold";
+  fTargetLengthX = 0.0*cm; 
+  fTargetLengthY = 0.0*cm;
+  fTargetLengthZ = 0.0*cm;
 }
 
 ApparatusGenericTarget::~ApparatusGenericTarget()
@@ -37,38 +37,33 @@ ApparatusGenericTarget::~ApparatusGenericTarget()
     delete fTargetLog;    
 }
 
-G4int ApparatusGenericTarget::Build(G4String target_material_in, G4double target_length_x_in, G4double target_length_y_in, G4double target_length_z_in)
+void ApparatusGenericTarget::Build(G4String target_material_in, G4double target_length_x_in, G4double target_length_y_in, G4double target_length_z_in)
 {
-  this->fTargetMaterial = target_material_in;
-  this->fTargetLengthX = target_length_x_in*mm;
-  this->fTargetLengthY = target_length_y_in*mm;
-  this->fTargetLengthZ = target_length_z_in*mm;
+  fTargetMaterial = target_material_in;
+  fTargetLengthX = target_length_x_in*mm;
+  fTargetLengthY = target_length_y_in*mm;
+  fTargetLengthZ = target_length_z_in*mm;
 
   // Build assembly volume
-  G4AssemblyVolume* myAssembly = new G4AssemblyVolume();
-  this->fAssembly = myAssembly;
+  fAssembly = new G4AssemblyVolume();
 
-  G4cout << "BuildTargetVolume" << G4endl;
+  G4cout<<"BuildTargetVolume"<<G4endl;
   BuildTargetVolume();      
-
-  return 1;
 }
 
-G4int ApparatusGenericTarget::PlaceApparatus(G4LogicalVolume* exp_hall_log, G4ThreeVector move, G4RotationMatrix* rotate)
+void ApparatusGenericTarget::PlaceApparatus(G4LogicalVolume* exp_hall_log, G4ThreeVector move, G4RotationMatrix* rotate)
 {
   G4int copy_ID = 0;
 
-  this->fAssembly->MakeImprint(exp_hall_log, move, rotate, copy_ID);
-
-  return 1;
+  fAssembly->MakeImprint(exp_hall_log, move, rotate, copy_ID);
 }
 
-G4int ApparatusGenericTarget::BuildTargetVolume()
+void ApparatusGenericTarget::BuildTargetVolume()
 {
-  G4Material* material = G4Material::GetMaterial(this->fTargetMaterial);
-  if( !material ) {
-    G4cout << " ----> Material " << this->fTargetMaterial << " not found, cannot build!" << G4endl;
-    return 0;
+  G4Material* material = G4Material::GetMaterial(fTargetMaterial);
+  if(!material) {
+    G4cout<<" ----> Material "<<fTargetMaterial<<" not found, cannot build!"<<G4endl;
+    throw std::invalid_argument("Material not found, cannot build!");
   }
   
   // Set visualization attributes
@@ -81,25 +76,22 @@ G4int ApparatusGenericTarget::BuildTargetVolume()
   G4Box* target = BuildTarget(); 
 
   //logical volume
-  if( fTargetLog == NULL )
+  if(fTargetLog == nullptr)
   {
     fTargetLog = new G4LogicalVolume(target, material, "target_log", 0, 0, 0);
     fTargetLog->SetVisAttributes(vis_att);
   }
 
-  this->fAssembly->AddPlacedVolume(fTargetLog, move, rotate);
-
-  return 1;
+  fAssembly->AddPlacedVolume(fTargetLog, move, rotate);
 }
 
 G4Box* ApparatusGenericTarget::BuildTarget()
 {
-  G4double half_length_x = this->fTargetLengthX/2.0;
-  G4double half_length_y = this->fTargetLengthY/2.0;
-  G4double half_length_z = this->fTargetLengthZ/2.0;
+  G4double half_length_x = fTargetLengthX/2.0;
+  G4double half_length_y = fTargetLengthY/2.0;
+  G4double half_length_z = fTargetLengthZ/2.0;
 
-  G4Box* target = new G4Box("target", half_length_x, half_length_y, half_length_z);
-  return target;
+  return new G4Box("target", half_length_x, half_length_y, half_length_z);
 }
 
 //Calculate a direction vector from spherical theta & phi components
@@ -110,7 +102,5 @@ G4ThreeVector ApparatusGenericTarget::GetDirectionXYZ(G4double theta, G4double p
   y = sin(theta) * sin(phi);
   z = cos(theta);
 	
-  G4ThreeVector direction = G4ThreeVector(x,y,z);
-	
-  return direction;
+  return G4ThreeVector(x,y,z);
 }

--- a/src/ApparatusGriffinStructure.cc
+++ b/src/ApparatusGriffinStructure.cc
@@ -215,16 +215,16 @@ G4int ApparatusGriffinStructure::Build() {
     fAssemblyRing = new G4AssemblyVolume();
     fAssemblyRod = new G4AssemblyVolume();
 
-    G4cout << "BuildSquarePiece" << G4endl;
+    //G4cout << "BuildSquarePiece" << G4endl;
     BuildSquarePiece();
 
-    G4cout << "BuildTrianglePiece" << G4endl;
+    //G4cout << "BuildTrianglePiece" << G4endl;
     BuildTrianglePiece();
 
-    G4cout << "BuildLargeRingFrame" << G4endl;
+    //G4cout << "BuildLargeRingFrame" << G4endl;
     BuildLargeRingFrame();
 
-    G4cout << "BuildRodPiece" << G4endl;
+    //G4cout << "BuildRodPiece" << G4endl;
     BuildRodPiece();
 
     return 1;

--- a/src/ApparatusGriffinStructure.cc
+++ b/src/ApparatusGriffinStructure.cc
@@ -27,807 +27,807 @@
 #include "G4SystemOfUnits.hh" // new version geant4.10 requires units
 
 ApparatusGriffinStructure::ApparatusGriffinStructure() :
-    // LogicalVolumes
-    fSquarePieceLog(0),
-    fTrianglePieceLog(0),
-    fRingPieceLog(0),
-    fRodPieceLog(0)
+	// LogicalVolumes
+	fSquarePieceLog(0),
+	fTrianglePieceLog(0),
+	fRingPieceLog(0),
+	fRodPieceLog(0)
 {
-    fStructureMaterial = "G4_Al";
-    fRodMaterial = "G4_STAINLESS-STEEL";
-    fInnerDistanceToSquareFace = 470.0*mm; // inner radius to the centre of square plate - GOOD
-    fSquareAndTriangleFaceThickness = 95.0*mm; // thickness of the square and triangle plates. In reality these thicknesses are different, but we will approximate them to be the same. - GOOD.
-    fSquareHoleLength = 314.0*mm; // total legth of square hole, from inside structure. - GOOD.
-    fSquareHoleRoundedEdgeRadius = 20.0*mm; // the roundness of the square holes. This is approximated, won't have a large effect. - OKAY
-    fTriangleOuterHoleRadius = 120.65*mm; // a hole radius in the triangle face. Radius to the rounded edge, this is the larger radius. - GOOD.
-    fTriangleInnerHoleRadius = 101.7*mm; // a hole radius in the triangle face. Radius to the square edge, this is the smaller radius. - GOOD.
-    fSquareRodHoleRadius = (31.75*mm)/2.0; // the radius of the holes for the steel rods. - GOOD.
-    fSquareRodHoleInnerRadius = 568.14*mm; // the radius from the origin to the steel rod. - GOOD.
-    fSquareRodPositionFromCenterOfSquareFace = (350.0*mm)/2.0; // the position the holes are from the origin. This is NOT a radius, this is along x or y. - GOOD.
-    fSquareRodTotalLength = 570.0*mm; // the total length of the rods. - GOOD.
-    fSquareBgoCutLength = (118.5*mm)*2.0; // the length of the bgo slot. - GOOD.
-    fSquareBgoCutWidth = 30.0*mm; // the width of the bgo slot. - GOOD.
-    // ref http://en.wikipedia.org/wiki/Rhombicuboctahedron
-    fSquareSquareAngle = 144.74*deg; // the angle between square faces in a rhombicuboctahedron. - GOOD.
-    fSquareTriangleAngle = 135.0*deg; // the angle between a square face and a triangle face in a rhombicuboctahedron. - GOOD.
-    fLargeRingFrameInnerRadius = 850.0*mm; // the inner radius of one of the the large rings that holds up the structure. - GOOD.
-    fLargeRingFrameOuterRadius = 1100.0*mm; // the outer radius of one of the the large rings that holds up the structure. - GOOD.
-    fLargeRingFrameThickness = 50.8*mm; // the thickness of one of the the large rings that holds up the structure. - GOOD.
-    fLargeRingFrameZPosition = 240.0*mm; // the positive z distance the ring is from the origin. - GOOD.
-    //G4double triangleThetaAngle = (180/M_PI)*(atan((1/sqrt(3))/sqrt((11/12) + (1/sqrt(2))) )+atan((sqrt(2))/(1+sqrt(2))))*deg;
-    fTriangleThetaAngle = 54.735610317245360*deg;
+	fStructureMaterial = "G4_Al";
+	fRodMaterial = "G4_STAINLESS-STEEL";
+	fInnerDistanceToSquareFace = 470.0*mm; // inner radius to the centre of square plate - GOOD
+	fSquareAndTriangleFaceThickness = 95.0*mm; // thickness of the square and triangle plates. In reality these thicknesses are different, but we will approximate them to be the same. - GOOD.
+	fSquareHoleLength = 314.0*mm; // total legth of square hole, from inside structure. - GOOD.
+	fSquareHoleRoundedEdgeRadius = 20.0*mm; // the roundness of the square holes. This is approximated, won't have a large effect. - OKAY
+	fTriangleOuterHoleRadius = 120.65*mm; // a hole radius in the triangle face. Radius to the rounded edge, this is the larger radius. - GOOD.
+	fTriangleInnerHoleRadius = 101.7*mm; // a hole radius in the triangle face. Radius to the square edge, this is the smaller radius. - GOOD.
+	fSquareRodHoleRadius = (31.75*mm)/2.0; // the radius of the holes for the steel rods. - GOOD.
+	fSquareRodHoleInnerRadius = 568.14*mm; // the radius from the origin to the steel rod. - GOOD.
+	fSquareRodPositionFromCenterOfSquareFace = (350.0*mm)/2.0; // the position the holes are from the origin. This is NOT a radius, this is along x or y. - GOOD.
+	fSquareRodTotalLength = 570.0*mm; // the total length of the rods. - GOOD.
+	fSquareBgoCutLength = (118.5*mm)*2.0; // the length of the bgo slot. - GOOD.
+	fSquareBgoCutWidth = 30.0*mm; // the width of the bgo slot. - GOOD.
+	// ref http://en.wikipedia.org/wiki/Rhombicuboctahedron
+	fSquareSquareAngle = 144.74*deg; // the angle between square faces in a rhombicuboctahedron. - GOOD.
+	fSquareTriangleAngle = 135.0*deg; // the angle between a square face and a triangle face in a rhombicuboctahedron. - GOOD.
+	fLargeRingFrameInnerRadius = 850.0*mm; // the inner radius of one of the the large rings that holds up the structure. - GOOD.
+	fLargeRingFrameOuterRadius = 1100.0*mm; // the outer radius of one of the the large rings that holds up the structure. - GOOD.
+	fLargeRingFrameThickness = 50.8*mm; // the thickness of one of the the large rings that holds up the structure. - GOOD.
+	fLargeRingFrameZPosition = 240.0*mm; // the positive z distance the ring is from the origin. - GOOD.
+	//G4double triangleThetaAngle = (180/M_PI)*(atan((1/sqrt(3))/sqrt((11/12) + (1/sqrt(2))))+atan((sqrt(2))/(1+sqrt(2))))*deg;
+	fTriangleThetaAngle = 54.735610317245360*deg;
 
-    // Check surfaces to determine any problematic overlaps. Turn this on to have Geant4 check the surfaces.
-    // Do not leave this on, it will slow the DetectorConstruction process!
-    // This was last check on May 29th, 2015. - GOOD!
-    fSurfCheck = false;
+	// Check surfaces to determine any problematic overlaps. Turn this on to have Geant4 check the surfaces.
+	// Do not leave this on, it will slow the DetectorConstruction process!
+	// This was last check on May 29th, 2015. - GOOD!
+	fSurfCheck = false;
 
-    /////////////////////////////////////////////////////////////////////
-    // griffinCoords for GRIFFIN
-    // Note that the GRIFFIN lampshade angles are rotated by 45 degrees with respect to those of TIGRESS.
-    // Modified griffinCoords for TIGRESS are below!
-    /////////////////////////////////////////////////////////////////////
-    // theta
-    fGriffinCoords[0][0] 	= 45.0*deg;
-    fGriffinCoords[1][0] 	= 45.0*deg;
-    fGriffinCoords[2][0] 	= 45.0*deg;
-    fGriffinCoords[3][0] 	= 45.0*deg;
-    fGriffinCoords[4][0] 	= 90.0*deg;
-    fGriffinCoords[5][0] 	= 90.0*deg;
-    fGriffinCoords[6][0] 	= 90.0*deg;
-    fGriffinCoords[7][0] 	= 90.0*deg;
-    fGriffinCoords[8][0] 	= 90.0*deg;
-    fGriffinCoords[9][0] 	= 90.0*deg;
-    fGriffinCoords[10][0] 	= 90.0*deg;
-    fGriffinCoords[11][0] 	= 90.0*deg;
-    fGriffinCoords[12][0] 	= 135.0*deg;
-    fGriffinCoords[13][0] 	= 135.0*deg;
-    fGriffinCoords[14][0] 	= 135.0*deg;
-    fGriffinCoords[15][0] 	= 135.0*deg;
-    // phi
-    fGriffinCoords[0][1] 	= 67.5*deg;
-    fGriffinCoords[1][1] 	= 157.5*deg;
-    fGriffinCoords[2][1] 	= 247.5*deg;
-    fGriffinCoords[3][1] 	= 337.5*deg;
-    fGriffinCoords[4][1] 	= 22.5*deg;
-    fGriffinCoords[5][1] 	= 67.5*deg;
-    fGriffinCoords[6][1] 	= 112.5*deg;
-    fGriffinCoords[7][1] 	= 157.5*deg;
-    fGriffinCoords[8][1] 	= 202.5*deg;
-    fGriffinCoords[9][1] 	= 247.5*deg;
-    fGriffinCoords[10][1] 	= 292.5*deg;
-    fGriffinCoords[11][1] 	= 337.5*deg;
-    fGriffinCoords[12][1] 	= 67.5*deg;
-    fGriffinCoords[13][1] 	= 157.5*deg;
-    fGriffinCoords[14][1] 	= 247.5*deg;
-    fGriffinCoords[15][1] 	= 337.5*deg;
-    // yaw (alpha)
-    fGriffinCoords[0][2] 	= 0.0*deg;
-    fGriffinCoords[1][2] 	= 0.0*deg;
-    fGriffinCoords[2][2] 	= 0.0*deg;
-    fGriffinCoords[3][2] 	= 0.0*deg;
-    fGriffinCoords[4][2] 	= 0.0*deg;
-    fGriffinCoords[5][2] 	= 0.0*deg;
-    fGriffinCoords[6][2] 	= 0.0*deg;
-    fGriffinCoords[7][2] 	= 0.0*deg;
-    fGriffinCoords[8][2] 	= 0.0*deg;
-    fGriffinCoords[9][2] 	= 0.0*deg;
-    fGriffinCoords[10][2] 	= 0.0*deg;
-    fGriffinCoords[11][2] 	= 0.0*deg;
-    fGriffinCoords[12][2] 	= 0.0*deg;
-    fGriffinCoords[13][2] 	= 0.0*deg;
-    fGriffinCoords[14][2] 	= 0.0*deg;
-    fGriffinCoords[15][2] 	= 0.0*deg;
-    // pitch (beta)
-    fGriffinCoords[0][3] 	= -45.0*deg;
-    fGriffinCoords[1][3] 	= -45.0*deg;
-    fGriffinCoords[2][3] 	= -45.0*deg;
-    fGriffinCoords[3][3] 	= -45.0*deg;
-    fGriffinCoords[4][3] 	= 0.0*deg;
-    fGriffinCoords[5][3] 	= 0.0*deg;
-    fGriffinCoords[6][3] 	= 0.0*deg;
-    fGriffinCoords[7][3] 	= 0.0*deg;
-    fGriffinCoords[8][3] 	= 0.0*deg;
-    fGriffinCoords[9][3] 	= 0.0*deg;
-    fGriffinCoords[10][3] 	= 0.0*deg;
-    fGriffinCoords[11][3] 	= 0.0*deg;
-    fGriffinCoords[12][3] 	= 45.0*deg;
-    fGriffinCoords[13][3] 	= 45.0*deg;
-    fGriffinCoords[14][3] 	= 45.0*deg;
-    fGriffinCoords[15][3] 	= 45.0*deg;
-    // roll (gamma)
-    fGriffinCoords[0][4] 	= 67.5*deg;
-    fGriffinCoords[1][4] 	= 157.5*deg;
-    fGriffinCoords[2][4] 	= 247.5*deg;
-    fGriffinCoords[3][4] 	= 337.5*deg;
-    fGriffinCoords[4][4] 	= 22.5*deg;
-    fGriffinCoords[5][4] 	= 67.5*deg;
-    fGriffinCoords[6][4] 	= 112.5*deg;
-    fGriffinCoords[7][4] 	= 157.5*deg;
-    fGriffinCoords[8][4] 	= 202.5*deg;
-    fGriffinCoords[9][4] 	= 247.5*deg;
-    fGriffinCoords[10][4] 	= 292.5*deg;
-    fGriffinCoords[11][4] 	= 337.5*deg;
-    fGriffinCoords[12][4] 	= 67.5*deg;
-    fGriffinCoords[13][4] 	= 157.5*deg;
-    fGriffinCoords[14][4] 	= 247.5*deg;
-    fGriffinCoords[15][4] 	= 337.5*deg;
+	/////////////////////////////////////////////////////////////////////
+	// griffinCoords for GRIFFIN
+	// Note that the GRIFFIN lampshade angles are rotated by 45 degrees with respect to those of TIGRESS.
+	// Modified griffinCoords for TIGRESS are below!
+	/////////////////////////////////////////////////////////////////////
+	// theta
+	fGriffinCoords[0][0] 	= 45.0*deg;
+	fGriffinCoords[1][0] 	= 45.0*deg;
+	fGriffinCoords[2][0] 	= 45.0*deg;
+	fGriffinCoords[3][0] 	= 45.0*deg;
+	fGriffinCoords[4][0] 	= 90.0*deg;
+	fGriffinCoords[5][0] 	= 90.0*deg;
+	fGriffinCoords[6][0] 	= 90.0*deg;
+	fGriffinCoords[7][0] 	= 90.0*deg;
+	fGriffinCoords[8][0] 	= 90.0*deg;
+	fGriffinCoords[9][0] 	= 90.0*deg;
+	fGriffinCoords[10][0] 	= 90.0*deg;
+	fGriffinCoords[11][0] 	= 90.0*deg;
+	fGriffinCoords[12][0] 	= 135.0*deg;
+	fGriffinCoords[13][0] 	= 135.0*deg;
+	fGriffinCoords[14][0] 	= 135.0*deg;
+	fGriffinCoords[15][0] 	= 135.0*deg;
+	// phi
+	fGriffinCoords[0][1] 	= 67.5*deg;
+	fGriffinCoords[1][1] 	= 157.5*deg;
+	fGriffinCoords[2][1] 	= 247.5*deg;
+	fGriffinCoords[3][1] 	= 337.5*deg;
+	fGriffinCoords[4][1] 	= 22.5*deg;
+	fGriffinCoords[5][1] 	= 67.5*deg;
+	fGriffinCoords[6][1] 	= 112.5*deg;
+	fGriffinCoords[7][1] 	= 157.5*deg;
+	fGriffinCoords[8][1] 	= 202.5*deg;
+	fGriffinCoords[9][1] 	= 247.5*deg;
+	fGriffinCoords[10][1] 	= 292.5*deg;
+	fGriffinCoords[11][1] 	= 337.5*deg;
+	fGriffinCoords[12][1] 	= 67.5*deg;
+	fGriffinCoords[13][1] 	= 157.5*deg;
+	fGriffinCoords[14][1] 	= 247.5*deg;
+	fGriffinCoords[15][1] 	= 337.5*deg;
+	// yaw (alpha)
+	fGriffinCoords[0][2] 	= 0.0*deg;
+	fGriffinCoords[1][2] 	= 0.0*deg;
+	fGriffinCoords[2][2] 	= 0.0*deg;
+	fGriffinCoords[3][2] 	= 0.0*deg;
+	fGriffinCoords[4][2] 	= 0.0*deg;
+	fGriffinCoords[5][2] 	= 0.0*deg;
+	fGriffinCoords[6][2] 	= 0.0*deg;
+	fGriffinCoords[7][2] 	= 0.0*deg;
+	fGriffinCoords[8][2] 	= 0.0*deg;
+	fGriffinCoords[9][2] 	= 0.0*deg;
+	fGriffinCoords[10][2] 	= 0.0*deg;
+	fGriffinCoords[11][2] 	= 0.0*deg;
+	fGriffinCoords[12][2] 	= 0.0*deg;
+	fGriffinCoords[13][2] 	= 0.0*deg;
+	fGriffinCoords[14][2] 	= 0.0*deg;
+	fGriffinCoords[15][2] 	= 0.0*deg;
+	// pitch (beta)
+	fGriffinCoords[0][3] 	= -45.0*deg;
+	fGriffinCoords[1][3] 	= -45.0*deg;
+	fGriffinCoords[2][3] 	= -45.0*deg;
+	fGriffinCoords[3][3] 	= -45.0*deg;
+	fGriffinCoords[4][3] 	= 0.0*deg;
+	fGriffinCoords[5][3] 	= 0.0*deg;
+	fGriffinCoords[6][3] 	= 0.0*deg;
+	fGriffinCoords[7][3] 	= 0.0*deg;
+	fGriffinCoords[8][3] 	= 0.0*deg;
+	fGriffinCoords[9][3] 	= 0.0*deg;
+	fGriffinCoords[10][3] 	= 0.0*deg;
+	fGriffinCoords[11][3] 	= 0.0*deg;
+	fGriffinCoords[12][3] 	= 45.0*deg;
+	fGriffinCoords[13][3] 	= 45.0*deg;
+	fGriffinCoords[14][3] 	= 45.0*deg;
+	fGriffinCoords[15][3] 	= 45.0*deg;
+	// roll (gamma)
+	fGriffinCoords[0][4] 	= 67.5*deg;
+	fGriffinCoords[1][4] 	= 157.5*deg;
+	fGriffinCoords[2][4] 	= 247.5*deg;
+	fGriffinCoords[3][4] 	= 337.5*deg;
+	fGriffinCoords[4][4] 	= 22.5*deg;
+	fGriffinCoords[5][4] 	= 67.5*deg;
+	fGriffinCoords[6][4] 	= 112.5*deg;
+	fGriffinCoords[7][4] 	= 157.5*deg;
+	fGriffinCoords[8][4] 	= 202.5*deg;
+	fGriffinCoords[9][4] 	= 247.5*deg;
+	fGriffinCoords[10][4] 	= 292.5*deg;
+	fGriffinCoords[11][4] 	= 337.5*deg;
+	fGriffinCoords[12][4] 	= 67.5*deg;
+	fGriffinCoords[13][4] 	= 157.5*deg;
+	fGriffinCoords[14][4] 	= 247.5*deg;
+	fGriffinCoords[15][4] 	= 337.5*deg;
 
-    // Triangle sections for ancillary detectors coords
-    // theta
-    fAncillaryCoords[0][0] 	= fTriangleThetaAngle;
-    fAncillaryCoords[1][0] 	= fTriangleThetaAngle;
-    fAncillaryCoords[2][0] 	= fTriangleThetaAngle;
-    fAncillaryCoords[3][0] 	= fTriangleThetaAngle;
-    fAncillaryCoords[4][0] 	= 180.0*deg - fTriangleThetaAngle;
-    fAncillaryCoords[5][0] 	= 180.0*deg - fTriangleThetaAngle;
-    fAncillaryCoords[6][0] 	= 180.0*deg - fTriangleThetaAngle;
-    fAncillaryCoords[7][0] 	= 180.0*deg - fTriangleThetaAngle;
-    // phi
-    fAncillaryCoords[0][1] 	= 22.5*deg;
-    fAncillaryCoords[1][1] 	= 112.5*deg;
-    fAncillaryCoords[2][1] 	= 202.5*deg;
-    fAncillaryCoords[3][1] 	= 292.5*deg;
-    fAncillaryCoords[4][1] 	= 22.5*deg;
-    fAncillaryCoords[5][1] 	= 112.5*deg;
-    fAncillaryCoords[6][1] 	= 202.5*deg;
-    fAncillaryCoords[7][1] 	= 292.5*deg;
-    // yaw (alpha)
-    fAncillaryCoords[0][2] 	= 0.0*deg;
-    fAncillaryCoords[1][2] 	= 0.0*deg;
-    fAncillaryCoords[2][2] 	= 0.0*deg;
-    fAncillaryCoords[3][2] 	= 0.0*deg;
-    fAncillaryCoords[4][2] 	= 0.0*deg;
-    fAncillaryCoords[5][2] 	= 0.0*deg;
-    fAncillaryCoords[6][2] 	= 0.0*deg;
-    fAncillaryCoords[7][2] 	= 0.0*deg;
-    // pitch (beta)
-    fAncillaryCoords[0][3] 	= fTriangleThetaAngle;
-    fAncillaryCoords[1][3] 	= fTriangleThetaAngle;
-    fAncillaryCoords[2][3] 	= fTriangleThetaAngle;
-    fAncillaryCoords[3][3] 	= fTriangleThetaAngle;
-    fAncillaryCoords[4][3] 	= 180.0*deg - fTriangleThetaAngle;
-    fAncillaryCoords[5][3] 	= 180.0*deg - fTriangleThetaAngle;
-    fAncillaryCoords[6][3] 	= 180.0*deg - fTriangleThetaAngle;
-    fAncillaryCoords[7][3] 	= 180.0*deg - fTriangleThetaAngle;
-    // roll (gamma)
-    fAncillaryCoords[0][4] 	= 22.5*deg;
-    fAncillaryCoords[1][4] 	= 112.5*deg;
-    fAncillaryCoords[2][4] 	= 202.5*deg;
-    fAncillaryCoords[3][4] 	= 292.5*deg;
-    fAncillaryCoords[4][4] 	= 22.5*deg;
-    fAncillaryCoords[5][4] 	= 112.5*deg;
-    fAncillaryCoords[6][4] 	= 202.5*deg;
-    fAncillaryCoords[7][4] 	= 292.5*deg;
+	// Triangle sections for ancillary detectors coords
+	// theta
+	fAncillaryCoords[0][0] 	= fTriangleThetaAngle;
+	fAncillaryCoords[1][0] 	= fTriangleThetaAngle;
+	fAncillaryCoords[2][0] 	= fTriangleThetaAngle;
+	fAncillaryCoords[3][0] 	= fTriangleThetaAngle;
+	fAncillaryCoords[4][0] 	= 180.0*deg - fTriangleThetaAngle;
+	fAncillaryCoords[5][0] 	= 180.0*deg - fTriangleThetaAngle;
+	fAncillaryCoords[6][0] 	= 180.0*deg - fTriangleThetaAngle;
+	fAncillaryCoords[7][0] 	= 180.0*deg - fTriangleThetaAngle;
+	// phi
+	fAncillaryCoords[0][1] 	= 22.5*deg;
+	fAncillaryCoords[1][1] 	= 112.5*deg;
+	fAncillaryCoords[2][1] 	= 202.5*deg;
+	fAncillaryCoords[3][1] 	= 292.5*deg;
+	fAncillaryCoords[4][1] 	= 22.5*deg;
+	fAncillaryCoords[5][1] 	= 112.5*deg;
+	fAncillaryCoords[6][1] 	= 202.5*deg;
+	fAncillaryCoords[7][1] 	= 292.5*deg;
+	// yaw (alpha)
+	fAncillaryCoords[0][2] 	= 0.0*deg;
+	fAncillaryCoords[1][2] 	= 0.0*deg;
+	fAncillaryCoords[2][2] 	= 0.0*deg;
+	fAncillaryCoords[3][2] 	= 0.0*deg;
+	fAncillaryCoords[4][2] 	= 0.0*deg;
+	fAncillaryCoords[5][2] 	= 0.0*deg;
+	fAncillaryCoords[6][2] 	= 0.0*deg;
+	fAncillaryCoords[7][2] 	= 0.0*deg;
+	// pitch (beta)
+	fAncillaryCoords[0][3] 	= fTriangleThetaAngle;
+	fAncillaryCoords[1][3] 	= fTriangleThetaAngle;
+	fAncillaryCoords[2][3] 	= fTriangleThetaAngle;
+	fAncillaryCoords[3][3] 	= fTriangleThetaAngle;
+	fAncillaryCoords[4][3] 	= 180.0*deg - fTriangleThetaAngle;
+	fAncillaryCoords[5][3] 	= 180.0*deg - fTriangleThetaAngle;
+	fAncillaryCoords[6][3] 	= 180.0*deg - fTriangleThetaAngle;
+	fAncillaryCoords[7][3] 	= 180.0*deg - fTriangleThetaAngle;
+	// roll (gamma)
+	fAncillaryCoords[0][4] 	= 22.5*deg;
+	fAncillaryCoords[1][4] 	= 112.5*deg;
+	fAncillaryCoords[2][4] 	= 202.5*deg;
+	fAncillaryCoords[3][4] 	= 292.5*deg;
+	fAncillaryCoords[4][4] 	= 22.5*deg;
+	fAncillaryCoords[5][4] 	= 112.5*deg;
+	fAncillaryCoords[6][4] 	= 202.5*deg;
+	fAncillaryCoords[7][4] 	= 292.5*deg;
 }
 
 ApparatusGriffinStructure::~ApparatusGriffinStructure() {
-    delete fSquarePieceLog;
-    delete fTrianglePieceLog;
-    delete fRingPieceLog;
-    delete fRodPieceLog;
+	delete fSquarePieceLog;
+	delete fTrianglePieceLog;
+	delete fRingPieceLog;
+	delete fRodPieceLog;
 }
 
 G4int ApparatusGriffinStructure::Build() { 
-    // Setup assembly volumes
-    fAssemblySquare = new G4AssemblyVolume();
-    fAssemblyTriangle = new G4AssemblyVolume();
-    fAssemblyRing = new G4AssemblyVolume();
-    fAssemblyRod = new G4AssemblyVolume();
+	// Setup assembly volumes
+	fAssemblySquare = new G4AssemblyVolume();
+	fAssemblyTriangle = new G4AssemblyVolume();
+	fAssemblyRing = new G4AssemblyVolume();
+	fAssemblyRod = new G4AssemblyVolume();
 
-    //G4cout << "BuildSquarePiece" << G4endl;
-    BuildSquarePiece();
+	//G4cout<<"BuildSquarePiece"<<G4endl;
+	BuildSquarePiece();
 
-    //G4cout << "BuildTrianglePiece" << G4endl;
-    BuildTrianglePiece();
+	//G4cout<<"BuildTrianglePiece"<<G4endl;
+	BuildTrianglePiece();
 
-    //G4cout << "BuildLargeRingFrame" << G4endl;
-    BuildLargeRingFrame();
+	//G4cout<<"BuildLargeRingFrame"<<G4endl;
+	BuildLargeRingFrame();
 
-    //G4cout << "BuildRodPiece" << G4endl;
-    BuildRodPiece();
+	//G4cout<<"BuildRodPiece"<<G4endl;
+	BuildRodPiece();
 
-    return 1;
+	return 1;
 }//end ::Build
 
 
 G4int ApparatusGriffinStructure::Place(G4LogicalVolume* expHallLog, G4int selector) {
-    G4ThreeVector move = G4ThreeVector(0.0*mm, 0.0*mm, 0.0*mm);
-    G4RotationMatrix* rotate = new G4RotationMatrix;
+	G4ThreeVector move = G4ThreeVector(0.0*mm, 0.0*mm, 0.0*mm);
+	G4RotationMatrix* rotate = new G4RotationMatrix;
 
-    G4double alpha;
-    G4double beta;
-    G4double gamma;
+	G4double alpha;
+	G4double beta;
+	G4double gamma;
 
-    G4int iSquare1 = 0;
-    G4int iSquare2 = 15;
-    G4int iTriangle1 =0;
-    G4int iTriangle2 =7;
+	G4int iSquare1 = 0;
+	G4int iSquare2 = 15;
+	G4int iTriangle1 =0;
+	G4int iTriangle2 =7;
 
-    if(selector == 0) { // Full structure
-        iSquare1 = 0;
-        iSquare2 = 15;
-        iTriangle1 =0;
-        iTriangle2 =7;
-    } else if(selector == 1) { // upstream-half of structure: corona plus upstream lampshade
-        iSquare1 = 4;
-        iSquare2 = 15;
-        iTriangle1 =4;
-        iTriangle2 =7;
-    } else if(selector == 2) { // downstream-half of structure: corona plus downstream lampshade
-        iSquare1 = 0;
-        iSquare2 = 11;
-        iTriangle1 =0;
-        iTriangle2 =3;
-    } else if(selector == 3) { // just the corona, no lampshades
-        iSquare1 = 4;
-        iSquare2 = 11;
-        iTriangle1 =4;
-        iTriangle2 =3;
-    }
+	if(selector == 0) { // Full structure
+		iSquare1 = 0;
+		iSquare2 = 15;
+		iTriangle1 =0;
+		iTriangle2 =7;
+	} else if(selector == 1) { // upstream-half of structure: corona plus upstream lampshade
+		iSquare1 = 4;
+		iSquare2 = 15;
+		iTriangle1 =4;
+		iTriangle2 =7;
+	} else if(selector == 2) { // downstream-half of structure: corona plus downstream lampshade
+		iSquare1 = 0;
+		iSquare2 = 11;
+		iTriangle1 =0;
+		iTriangle2 =3;
+	} else if(selector == 3) { // just the corona, no lampshades
+		iSquare1 = 4;
+		iSquare2 = 11;
+		iTriangle1 =4;
+		iTriangle2 =3;
+	}
 
-    for(G4int i=iSquare1; i<=iSquare2; i++) { // loop over all square pieces
-        alpha  = fGriffinCoords[i][2]; // yaw
-        beta   = fGriffinCoords[i][3]; // pitch
-        gamma  = fGriffinCoords[i][4]; // roll
+	for(G4int i=iSquare1; i<=iSquare2; i++) { // loop over all square pieces
+		alpha  = fGriffinCoords[i][2]; // yaw
+		beta   = fGriffinCoords[i][3]; // pitch
+		gamma  = fGriffinCoords[i][4]; // roll
 
-        rotate = new G4RotationMatrix;
-        rotate->rotateY(M_PI/2.0);
-        rotate->rotateX(M_PI/2.0);
-        rotate->rotateX(alpha);
-        rotate->rotateY(beta);
-        rotate->rotateZ(gamma);
+		rotate = new G4RotationMatrix;
+		rotate->rotateY(M_PI/2.0);
+		rotate->rotateX(M_PI/2.0);
+		rotate->rotateX(alpha);
+		rotate->rotateY(beta);
+		rotate->rotateZ(gamma);
 
-        fAssemblySquare->MakeImprint(expHallLog, move, rotate, 0, fSurfCheck);
-    }
+		fAssemblySquare->MakeImprint(expHallLog, move, rotate, 0, fSurfCheck);
+	}
 
-    for(G4int i=iSquare1; i<=iSquare2; i++) { // loop over all rods
-        alpha  = fGriffinCoords[i][2]; // yaw
-        beta   = fGriffinCoords[i][3]; // pitch
-        gamma  = fGriffinCoords[i][4]; // roll
+	for(G4int i=iSquare1; i<=iSquare2; i++) { // loop over all rods
+		alpha  = fGriffinCoords[i][2]; // yaw
+		beta   = fGriffinCoords[i][3]; // pitch
+		gamma  = fGriffinCoords[i][4]; // roll
 
-        rotate = new G4RotationMatrix;
-        rotate->rotateY(M_PI/2.0);
-        rotate->rotateX(M_PI/2.0);
-        rotate->rotateX(alpha);
-        rotate->rotateY(beta);
-        rotate->rotateZ(gamma);
+		rotate = new G4RotationMatrix;
+		rotate->rotateY(M_PI/2.0);
+		rotate->rotateX(M_PI/2.0);
+		rotate->rotateX(alpha);
+		rotate->rotateY(beta);
+		rotate->rotateZ(gamma);
 
-        fAssemblyRod->MakeImprint(expHallLog, move, rotate, 0, fSurfCheck);
-    }
+		fAssemblyRod->MakeImprint(expHallLog, move, rotate, 0, fSurfCheck);
+	}
 
-    for(G4int i=iTriangle1; i<=iTriangle2; i++){ // loop over all triangle pieces
-        alpha  = fAncillaryCoords[i][2]; // yaw
-        beta   = fAncillaryCoords[i][3]; // pitch
-        gamma  = fAncillaryCoords[i][4]; // roll
+	for(G4int i=iTriangle1; i<=iTriangle2; i++){ // loop over all triangle pieces
+		alpha  = fAncillaryCoords[i][2]; // yaw
+		beta   = fAncillaryCoords[i][3]; // pitch
+		gamma  = fAncillaryCoords[i][4]; // roll
 
-        rotate = new G4RotationMatrix;
-        if(i>=4) rotate->rotateZ(60.0*deg);
-        rotate->rotateY(M_PI);
-        rotate->rotateY(M_PI+beta);
-        rotate->rotateZ(gamma);
+		rotate = new G4RotationMatrix;
+		if(i>=4) rotate->rotateZ(60.0*deg);
+		rotate->rotateY(M_PI);
+		rotate->rotateY(M_PI+beta);
+		rotate->rotateZ(gamma);
 
-        fAssemblyTriangle->MakeImprint(expHallLog, move, rotate, 0, fSurfCheck);
-    }
+		fAssemblyTriangle->MakeImprint(expHallLog, move, rotate, 0, fSurfCheck);
+	}
 
-    rotate = new G4RotationMatrix;
-    rotate->rotateY(0.0*deg);
-    fAssemblyRing->MakeImprint(expHallLog, move, rotate, 0, fSurfCheck);
+	rotate = new G4RotationMatrix;
+	rotate->rotateY(0.0*deg);
+	fAssemblyRing->MakeImprint(expHallLog, move, rotate, 0, fSurfCheck);
 
-    rotate = new G4RotationMatrix;
-    rotate->rotateY(180.0*deg);
-    fAssemblyRing->MakeImprint(expHallLog, move, rotate, 0, fSurfCheck);
+	rotate = new G4RotationMatrix;
+	rotate->rotateY(180.0*deg);
+	fAssemblyRing->MakeImprint(expHallLog, move, rotate, 0, fSurfCheck);
 
-    return 1;
+	return 1;
 }
 
 G4int ApparatusGriffinStructure::BuildSquarePiece() {
-    G4Material* material = G4Material::GetMaterial(fStructureMaterial);
-    if( !material ) {
-        G4cout << " ----> Material " << fStructureMaterial << " not found, cannot build the detector shell! " << G4endl;
-        return 0;
-    }
+	G4Material* material = G4Material::GetMaterial(fStructureMaterial);
+	if(!material) {
+		G4cout<<" ----> Material "<<fStructureMaterial<<" not found, cannot build the detector shell! "<<G4endl;
+		return 0;
+	}
 
-    // Set visualization attributes
-    G4VisAttributes* visAtt = new G4VisAttributes(G4Colour(0.9,0.9,0.9));
-    visAtt->SetVisibility(true);
+	// Set visualization attributes
+	G4VisAttributes* visAtt = new G4VisAttributes(G4Colour(0.9,0.9,0.9));
+	visAtt->SetVisibility(true);
 
-    G4SubtractionSolid* squarePiece = SquarePiece();
+	G4SubtractionSolid* squarePiece = SquarePiece();
 
-    // Define rotation and movement objects
-    G4ThreeVector direction = G4ThreeVector(0,0,1);
-    G4double zPosition		= fInnerDistanceToSquareFace + (fSquareAndTriangleFaceThickness)/2.0;
-    G4ThreeVector move 		= zPosition * direction;
+	// Define rotation and movement objects
+	G4ThreeVector direction = G4ThreeVector(0,0,1);
+	G4double zPosition		= fInnerDistanceToSquareFace + (fSquareAndTriangleFaceThickness)/2.0;
+	G4ThreeVector move 		= zPosition * direction;
 
-    G4RotationMatrix* rotate = new G4RotationMatrix;
+	G4RotationMatrix* rotate = new G4RotationMatrix;
 
-    //logical volume
-    if(fSquarePieceLog == NULL) {
-        fSquarePieceLog = new G4LogicalVolume(squarePiece, material, "squarePieceLog", 0, 0, 0);
-        fSquarePieceLog->SetVisAttributes(visAtt);
-    }
+	//logical volume
+	if(fSquarePieceLog == nullptr) {
+		fSquarePieceLog = new G4LogicalVolume(squarePiece, material, "squarePieceLog", 0, 0, 0);
+		fSquarePieceLog->SetVisAttributes(visAtt);
+	}
 
-    fAssemblySquare->AddPlacedVolume(fSquarePieceLog, move, rotate);
+	fAssemblySquare->AddPlacedVolume(fSquarePieceLog, move, rotate);
 
-    return 1;
+	return 1;
 }
 
 G4int ApparatusGriffinStructure::BuildTrianglePiece() {
-    G4Material* material = G4Material::GetMaterial(fStructureMaterial);
-    if( !material ) {
-        G4cout << " ----> Material " << fStructureMaterial << " not found, cannot build the detector shell! " << G4endl;
-        return 0;
-    }
+	G4Material* material = G4Material::GetMaterial(fStructureMaterial);
+	if(!material) {
+		G4cout<<" ----> Material "<<fStructureMaterial<<" not found, cannot build the detector shell! "<<G4endl;
+		return 0;
+	}
 
-    // Set visualization attributes
-    G4VisAttributes* visAtt = new G4VisAttributes(G4Colour(0.9,0.9,0.9));
-    visAtt->SetVisibility(true);
+	// Set visualization attributes
+	G4VisAttributes* visAtt = new G4VisAttributes(G4Colour(0.9,0.9,0.9));
+	visAtt->SetVisibility(true);
 
-    G4SubtractionSolid* trianglePiece = TrianglePiece();
+	G4SubtractionSolid* trianglePiece = TrianglePiece();
 
-    // Define rotation and movement objects
-    G4ThreeVector direction 	= G4ThreeVector(0,0,1);
+	// Define rotation and movement objects
+	G4ThreeVector direction 	= G4ThreeVector(0,0,1);
 
-    G4double r          = fInnerDistanceToSquareFace +  fSquareAndTriangleFaceThickness/2.0; // to centre
-    G4double x          = r*tan(22.5*deg); // half length of square side
-    G4double h          = (x)*tan(30.0*deg); // height from bottom of the triangle to origin.
-    G4double c          = x + h*sin(fTriangleThetaAngle);
-    G4double zPosition	= ((c)/(sin(90.0*deg - fTriangleThetaAngle)))  ;
+	G4double r          = fInnerDistanceToSquareFace +  fSquareAndTriangleFaceThickness/2.0; // to centre
+	G4double x          = r*tan(22.5*deg); // half length of square side
+	G4double h          = (x)*tan(30.0*deg); // height from bottom of the triangle to origin.
+	G4double c          = x + h*sin(fTriangleThetaAngle);
+	G4double zPosition	= ((c)/(sin(90.0*deg - fTriangleThetaAngle)))  ;
 
-    G4ThreeVector move 		= zPosition * direction;
+	G4ThreeVector move 		= zPosition * direction;
 
-    G4RotationMatrix* rotate = new G4RotationMatrix;
+	G4RotationMatrix* rotate = new G4RotationMatrix;
 
-    //logical volume
-    if(fTrianglePieceLog == NULL) {
-        fTrianglePieceLog = new G4LogicalVolume(trianglePiece, material, "trianglePieceLog", 0, 0, 0);
-        fTrianglePieceLog->SetVisAttributes(visAtt);
-    }
+	//logical volume
+	if(fTrianglePieceLog == nullptr) {
+		fTrianglePieceLog = new G4LogicalVolume(trianglePiece, material, "trianglePieceLog", 0, 0, 0);
+		fTrianglePieceLog->SetVisAttributes(visAtt);
+	}
 
-    fAssemblyTriangle->AddPlacedVolume(fTrianglePieceLog, move, rotate);
+	fAssemblyTriangle->AddPlacedVolume(fTrianglePieceLog, move, rotate);
 
-    return 1;
+	return 1;
 }
 
 G4int ApparatusGriffinStructure::BuildLargeRingFrame()
 {
-    G4Material* material = G4Material::GetMaterial(fStructureMaterial);
-    if( !material ) {
-        G4cout << " ----> Material " << fStructureMaterial << " not found, cannot build the detector shell! " << G4endl;
-        return 0;
-    }
+	G4Material* material = G4Material::GetMaterial(fStructureMaterial);
+	if(!material) {
+		G4cout<<" ----> Material "<<fStructureMaterial<<" not found, cannot build the detector shell! "<<G4endl;
+		return 0;
+	}
 
-    // Set visualization attributes
-    G4VisAttributes* visAtt = new G4VisAttributes(G4Colour(0.9,0.9,0.9));
-    visAtt->SetVisibility(true);
+	// Set visualization attributes
+	G4VisAttributes* visAtt = new G4VisAttributes(G4Colour(0.9,0.9,0.9));
+	visAtt->SetVisibility(true);
 
-    G4Tubs* ringPiece = LargeRingFrame();
+	G4Tubs* ringPiece = LargeRingFrame();
 
-    // Define rotation and movement objects
-    G4ThreeVector direction 	= G4ThreeVector(0,0,1);
-    G4double zPosition         = fLargeRingFrameZPosition + fLargeRingFrameThickness/2.0;
-    G4ThreeVector move          = zPosition * direction;
+	// Define rotation and movement objects
+	G4ThreeVector direction 	= G4ThreeVector(0,0,1);
+	G4double zPosition         = fLargeRingFrameZPosition + fLargeRingFrameThickness/2.0;
+	G4ThreeVector move          = zPosition * direction;
 
-    G4RotationMatrix* rotate = new G4RotationMatrix;
+	G4RotationMatrix* rotate = new G4RotationMatrix;
 
-    //logical volume
-    if(fRingPieceLog == NULL) {
-        fRingPieceLog = new G4LogicalVolume(ringPiece, material, "ringPieceLog", 0, 0, 0);
-        fRingPieceLog->SetVisAttributes(visAtt);
-    }
+	//logical volume
+	if(fRingPieceLog == nullptr) {
+		fRingPieceLog = new G4LogicalVolume(ringPiece, material, "ringPieceLog", 0, 0, 0);
+		fRingPieceLog->SetVisAttributes(visAtt);
+	}
 
-    fAssemblyRing->AddPlacedVolume(fRingPieceLog, move, rotate);
+	fAssemblyRing->AddPlacedVolume(fRingPieceLog, move, rotate);
 
-    return 1;
+	return 1;
 }
 
 G4int ApparatusGriffinStructure::BuildRodPiece() {
-    G4Material* material = G4Material::GetMaterial(fRodMaterial);
-    if( !material ) {
-        G4cout << " ----> Material " << fRodMaterial << " not found, cannot build the detector shell! " << G4endl;
-        return 0;
-    }
+	G4Material* material = G4Material::GetMaterial(fRodMaterial);
+	if(!material) {
+		G4cout<<" ----> Material "<<fRodMaterial<<" not found, cannot build the detector shell! "<<G4endl;
+		return 0;
+	}
 
-    // Set visualization attributes
-    G4VisAttributes* visAtt = new G4VisAttributes(G4Colour(0.30,0.30,0.30));
-    visAtt->SetVisibility(true);
+	// Set visualization attributes
+	G4VisAttributes* visAtt = new G4VisAttributes(G4Colour(0.30,0.30,0.30));
+	visAtt->SetVisibility(true);
 
-    G4Tubs* rodPiece = RodPiece();
+	G4Tubs* rodPiece = RodPiece();
 
-    // Define rotation and movement objects
-    G4ThreeVector move 	= G4ThreeVector(0.0*mm,0.0*mm,0.0*mm);
-    G4double zPosition = sqrt( (fSquareRodHoleInnerRadius * fSquareRodHoleInnerRadius ) - (fSquareRodPositionFromCenterOfSquareFace * fSquareRodPositionFromCenterOfSquareFace) ) + fSquareRodTotalLength/2.0 ;
+	// Define rotation and movement objects
+	G4ThreeVector move 	= G4ThreeVector(0.0*mm,0.0*mm,0.0*mm);
+	G4double zPosition = sqrt((fSquareRodHoleInnerRadius * fSquareRodHoleInnerRadius) - (fSquareRodPositionFromCenterOfSquareFace * fSquareRodPositionFromCenterOfSquareFace)) + fSquareRodTotalLength/2.0 ;
 
-    G4RotationMatrix* rotate = new G4RotationMatrix;
+	G4RotationMatrix* rotate = new G4RotationMatrix;
 
-    //logical volume
-    if(fRodPieceLog == NULL) {
-        fRodPieceLog = new G4LogicalVolume(rodPiece, material, "rodPieceLog", 0, 0, 0);
-        fRodPieceLog->SetVisAttributes(visAtt);
-    }
+	//logical volume
+	if(fRodPieceLog == nullptr) {
+		fRodPieceLog = new G4LogicalVolume(rodPiece, material, "rodPieceLog", 0, 0, 0);
+		fRodPieceLog->SetVisAttributes(visAtt);
+	}
 
-    move = G4ThreeVector(1.0*fSquareRodPositionFromCenterOfSquareFace,1.0*fSquareRodPositionFromCenterOfSquareFace,zPosition);
-    fAssemblyRod->AddPlacedVolume(fRodPieceLog, move, rotate);
+	move = G4ThreeVector(1.0*fSquareRodPositionFromCenterOfSquareFace,1.0*fSquareRodPositionFromCenterOfSquareFace,zPosition);
+	fAssemblyRod->AddPlacedVolume(fRodPieceLog, move, rotate);
 
-    move = G4ThreeVector(-1.0*fSquareRodPositionFromCenterOfSquareFace,1.0*fSquareRodPositionFromCenterOfSquareFace,zPosition);
-    fAssemblyRod->AddPlacedVolume(fRodPieceLog, move, rotate);
+	move = G4ThreeVector(-1.0*fSquareRodPositionFromCenterOfSquareFace,1.0*fSquareRodPositionFromCenterOfSquareFace,zPosition);
+	fAssemblyRod->AddPlacedVolume(fRodPieceLog, move, rotate);
 
-    move = G4ThreeVector(1.0*fSquareRodPositionFromCenterOfSquareFace,-1.0*fSquareRodPositionFromCenterOfSquareFace,zPosition);
-    fAssemblyRod->AddPlacedVolume(fRodPieceLog, move, rotate);
+	move = G4ThreeVector(1.0*fSquareRodPositionFromCenterOfSquareFace,-1.0*fSquareRodPositionFromCenterOfSquareFace,zPosition);
+	fAssemblyRod->AddPlacedVolume(fRodPieceLog, move, rotate);
 
-    move = G4ThreeVector(-1.0*fSquareRodPositionFromCenterOfSquareFace,-1.0*fSquareRodPositionFromCenterOfSquareFace,zPosition);
-    fAssemblyRod->AddPlacedVolume(fRodPieceLog, move, rotate);
+	move = G4ThreeVector(-1.0*fSquareRodPositionFromCenterOfSquareFace,-1.0*fSquareRodPositionFromCenterOfSquareFace,zPosition);
+	fAssemblyRod->AddPlacedVolume(fRodPieceLog, move, rotate);
 
-    return 1;
+	return 1;
 }
 
 G4SubtractionSolid* ApparatusGriffinStructure::SquarePiece() {
-    G4double innerRadius;
-    G4double outerRadius;
-    G4double startPhi = 0.0*deg;
-    G4double endPhi = 360.0*deg;
+	G4double innerRadius;
+	G4double outerRadius;
+	G4double startPhi = 0.0*deg;
+	G4double endPhi = 360.0*deg;
 
-    G4double r              = fInnerDistanceToSquareFace + fSquareAndTriangleFaceThickness/2.0; // to centre of square solid
-    G4double x              = r*tan(22.5*deg); // half length of square side
-    G4double xt             = (fSquareAndTriangleFaceThickness/2.0)*tan(22.5*deg); // add extra thickess for the edges
-    G4double halfLengthX  = x + xt;
-    G4double halfLengthY  = halfLengthX;
-    G4double halfLengthZ  = fSquareAndTriangleFaceThickness/2.0;
+	G4double r              = fInnerDistanceToSquareFace + fSquareAndTriangleFaceThickness/2.0; // to centre of square solid
+	G4double x              = r*tan(22.5*deg); // half length of square side
+	G4double xt             = (fSquareAndTriangleFaceThickness/2.0)*tan(22.5*deg); // add extra thickess for the edges
+	G4double halfLengthX  = x + xt;
+	G4double halfLengthY  = halfLengthX;
+	G4double halfLengthZ  = fSquareAndTriangleFaceThickness/2.0;
 
-    G4Box* griffinStructureSquarePlate = new G4Box("griffinStructureSquarePlate", halfLengthX, halfLengthY, halfLengthZ);
+	G4Box* griffinStructureSquarePlate = new G4Box("griffinStructureSquarePlate", halfLengthX, halfLengthY, halfLengthZ);
 
-    G4double cutHalfLengthX;
-    G4double cutHalfLengthY;
-    G4double cutHalfLengthZ;
-    G4double extraCut;
+	G4double cutHalfLengthX;
+	G4double cutHalfLengthY;
+	G4double cutHalfLengthZ;
+	G4double extraCut;
 
-    G4ThreeVector moveCut = G4ThreeVector(0.0*mm,0.0*mm,0.0*mm);
-    G4RotationMatrix* rotateCut;
-    rotateCut = new G4RotationMatrix;
+	G4ThreeVector moveCut = G4ThreeVector(0.0*mm,0.0*mm,0.0*mm);
+	G4RotationMatrix* rotateCut;
+	rotateCut = new G4RotationMatrix;
 
-    //Now cut bgo slots
-    extraCut           = 50.0*mm;
-    cutHalfLengthX   = ((fSquareBgoCutWidth/2.0 + extraCut)*cos(22.5*deg));
-    cutHalfLengthY   = fSquareBgoCutLength/2.0;
-    cutHalfLengthZ   = fSquareAndTriangleFaceThickness;
+	//Now cut bgo slots
+	extraCut           = 50.0*mm;
+	cutHalfLengthX   = ((fSquareBgoCutWidth/2.0 + extraCut)*cos(22.5*deg));
+	cutHalfLengthY   = fSquareBgoCutLength/2.0;
+	cutHalfLengthZ   = fSquareAndTriangleFaceThickness;
 
-    G4Box* cutBgo = new G4Box("cutBgo", cutHalfLengthX, cutHalfLengthY, cutHalfLengthZ);
+	G4Box* cutBgo = new G4Box("cutBgo", cutHalfLengthX, cutHalfLengthY, cutHalfLengthZ);
 
-    // snip first bgo slot
-    moveCut = G4ThreeVector(-1.0*(x-fSquareBgoCutWidth/2.0 + extraCut),0.0*mm,0.0*mm); // halfLengthX, the outer length of the original square
-    rotateCut = new G4RotationMatrix;
-    rotateCut->rotateY(22.5*deg);
+	// snip first bgo slot
+	moveCut = G4ThreeVector(-1.0*(x-fSquareBgoCutWidth/2.0 + extraCut),0.0*mm,0.0*mm); // halfLengthX, the outer length of the original square
+	rotateCut = new G4RotationMatrix;
+	rotateCut->rotateY(22.5*deg);
 
-    G4SubtractionSolid* griffinStructureSquarePlateCut1 = new G4SubtractionSolid("griffinStructureSquarePlateCut1", griffinStructureSquarePlate, cutBgo, rotateCut, moveCut);
+	G4SubtractionSolid* griffinStructureSquarePlateCut1 = new G4SubtractionSolid("griffinStructureSquarePlateCut1", griffinStructureSquarePlate, cutBgo, rotateCut, moveCut);
 
-    // snip first bgo slot
-    moveCut = G4ThreeVector(1.0*(x-fSquareBgoCutWidth/2.0 + extraCut),0.0*mm,0.0*mm); // halfLengthX, the outer length of the original square
-    rotateCut = new G4RotationMatrix;
-    rotateCut->rotateZ(180.0*deg);
-    rotateCut->rotateY(22.5*deg);
+	// snip first bgo slot
+	moveCut = G4ThreeVector(1.0*(x-fSquareBgoCutWidth/2.0 + extraCut),0.0*mm,0.0*mm); // halfLengthX, the outer length of the original square
+	rotateCut = new G4RotationMatrix;
+	rotateCut->rotateZ(180.0*deg);
+	rotateCut->rotateY(22.5*deg);
 
-    G4SubtractionSolid* griffinStructureSquarePlateCut2 = new G4SubtractionSolid("griffinStructureSquarePlateCut2", griffinStructureSquarePlateCut1, cutBgo, rotateCut, moveCut);
+	G4SubtractionSolid* griffinStructureSquarePlateCut2 = new G4SubtractionSolid("griffinStructureSquarePlateCut2", griffinStructureSquarePlateCut1, cutBgo, rotateCut, moveCut);
 
-    // snip next bgo slot
-    moveCut = G4ThreeVector(0.0*mm,1.0*(x-fSquareBgoCutWidth/2.0 + extraCut),0.0*mm); // halfLengthX, the outer length of the original square
-    rotateCut = new G4RotationMatrix;
-    rotateCut->rotateZ(90.0*deg);
-    rotateCut->rotateY(22.5*deg);
+	// snip next bgo slot
+	moveCut = G4ThreeVector(0.0*mm,1.0*(x-fSquareBgoCutWidth/2.0 + extraCut),0.0*mm); // halfLengthX, the outer length of the original square
+	rotateCut = new G4RotationMatrix;
+	rotateCut->rotateZ(90.0*deg);
+	rotateCut->rotateY(22.5*deg);
 
-    G4SubtractionSolid* griffinStructureSquarePlateCut3 = new G4SubtractionSolid("griffinStructureSquarePlateCut3", griffinStructureSquarePlateCut2, cutBgo, rotateCut, moveCut);
+	G4SubtractionSolid* griffinStructureSquarePlateCut3 = new G4SubtractionSolid("griffinStructureSquarePlateCut3", griffinStructureSquarePlateCut2, cutBgo, rotateCut, moveCut);
 
-    // snip last bgo slot
-    moveCut = G4ThreeVector(0.0*mm,-1.0*(x-fSquareBgoCutWidth/2.0 + extraCut),0.0*mm); // halfLengthX, the outer length of the original square
-    rotateCut = new G4RotationMatrix;
-    rotateCut->rotateZ(270.0*deg);
-    rotateCut->rotateY(22.5*deg);
+	// snip last bgo slot
+	moveCut = G4ThreeVector(0.0*mm,-1.0*(x-fSquareBgoCutWidth/2.0 + extraCut),0.0*mm); // halfLengthX, the outer length of the original square
+	rotateCut = new G4RotationMatrix;
+	rotateCut->rotateZ(270.0*deg);
+	rotateCut->rotateY(22.5*deg);
 
-    G4SubtractionSolid* griffinStructureSquarePlateCut4 = new G4SubtractionSolid("griffinStructureSquarePlateCut4", griffinStructureSquarePlateCut3, cutBgo, rotateCut, moveCut);
-
-
-    // Now cut the edges so that they fit nicely together
-    cutHalfLengthX = halfLengthZ;
-    cutHalfLengthY = 2.0*r;
-    cutHalfLengthZ = 2.0*r;
-
-    G4Box* cutSide = new G4Box("cutSide", cutHalfLengthX, cutHalfLengthY, cutHalfLengthZ);
-
-    moveCut = G4ThreeVector(-1.0*cutHalfLengthX/cos(22.5*deg),0.0*mm,-1.0*r);
-    rotateCut = new G4RotationMatrix;
-    rotateCut->rotateY(22.5*deg);
-
-    // snip 1st edge
-    G4SubtractionSolid* griffinStructureSquarePlateCut5 = new G4SubtractionSolid("griffinStructureSquarePlateCut5", griffinStructureSquarePlateCut4, cutSide, rotateCut, moveCut);
-
-    moveCut = G4ThreeVector(1.0*cutHalfLengthX/cos(22.5*deg),0.0*mm,-1.0*r);
-    rotateCut = new G4RotationMatrix;
-    rotateCut->rotateZ(180.0*deg);
-    rotateCut->rotateY(22.5*deg);
-
-    // snip next edge
-    G4SubtractionSolid* griffinStructureSquarePlateCut6 = new G4SubtractionSolid("griffinStructureSquarePlateCut6", griffinStructureSquarePlateCut5, cutSide, rotateCut, moveCut);
-
-    moveCut = G4ThreeVector(0.0*mm,1.0*cutHalfLengthX/cos(22.5*deg),-1.0*r);
-    rotateCut = new G4RotationMatrix;
-    rotateCut->rotateZ(90.0*deg);
-    rotateCut->rotateY(22.5*deg);
-
-    // snip next edge
-    G4SubtractionSolid* griffinStructureSquarePlateCut7 = new G4SubtractionSolid("griffinStructureSquarePlateCut7", griffinStructureSquarePlateCut6, cutSide, rotateCut, moveCut);
-
-    moveCut = G4ThreeVector(0.0*mm,-1.0*cutHalfLengthX/cos(22.5*deg),-1.0*r);
-    rotateCut = new G4RotationMatrix;
-    rotateCut->rotateZ(270.0*deg);
-    rotateCut->rotateY(22.5*deg);
-
-    // snip last edge
-    G4SubtractionSolid* griffinStructureSquarePlateCut8 = new G4SubtractionSolid("griffinStructureSquarePlateCut8", griffinStructureSquarePlateCut7, cutSide, rotateCut, moveCut);
+	G4SubtractionSolid* griffinStructureSquarePlateCut4 = new G4SubtractionSolid("griffinStructureSquarePlateCut4", griffinStructureSquarePlateCut3, cutBgo, rotateCut, moveCut);
 
 
-    // Now cut the holes for the steel rods
-    innerRadius = 0.0*mm;
-    outerRadius = fSquareRodHoleRadius;
-    halfLengthZ = fSquareRodTotalLength/2.0;
+	// Now cut the edges so that they fit nicely together
+	cutHalfLengthX = halfLengthZ;
+	cutHalfLengthY = 2.0*r;
+	cutHalfLengthZ = 2.0*r;
 
-    G4Tubs* rodHole = new G4Tubs("rodHole", innerRadius, outerRadius, halfLengthZ, startPhi, endPhi);
+	G4Box* cutSide = new G4Box("cutSide", cutHalfLengthX, cutHalfLengthY, cutHalfLengthZ);
+
+	moveCut = G4ThreeVector(-1.0*cutHalfLengthX/cos(22.5*deg),0.0*mm,-1.0*r);
+	rotateCut = new G4RotationMatrix;
+	rotateCut->rotateY(22.5*deg);
+
+	// snip 1st edge
+	G4SubtractionSolid* griffinStructureSquarePlateCut5 = new G4SubtractionSolid("griffinStructureSquarePlateCut5", griffinStructureSquarePlateCut4, cutSide, rotateCut, moveCut);
+
+	moveCut = G4ThreeVector(1.0*cutHalfLengthX/cos(22.5*deg),0.0*mm,-1.0*r);
+	rotateCut = new G4RotationMatrix;
+	rotateCut->rotateZ(180.0*deg);
+	rotateCut->rotateY(22.5*deg);
+
+	// snip next edge
+	G4SubtractionSolid* griffinStructureSquarePlateCut6 = new G4SubtractionSolid("griffinStructureSquarePlateCut6", griffinStructureSquarePlateCut5, cutSide, rotateCut, moveCut);
+
+	moveCut = G4ThreeVector(0.0*mm,1.0*cutHalfLengthX/cos(22.5*deg),-1.0*r);
+	rotateCut = new G4RotationMatrix;
+	rotateCut->rotateZ(90.0*deg);
+	rotateCut->rotateY(22.5*deg);
+
+	// snip next edge
+	G4SubtractionSolid* griffinStructureSquarePlateCut7 = new G4SubtractionSolid("griffinStructureSquarePlateCut7", griffinStructureSquarePlateCut6, cutSide, rotateCut, moveCut);
+
+	moveCut = G4ThreeVector(0.0*mm,-1.0*cutHalfLengthX/cos(22.5*deg),-1.0*r);
+	rotateCut = new G4RotationMatrix;
+	rotateCut->rotateZ(270.0*deg);
+	rotateCut->rotateY(22.5*deg);
+
+	// snip last edge
+	G4SubtractionSolid* griffinStructureSquarePlateCut8 = new G4SubtractionSolid("griffinStructureSquarePlateCut8", griffinStructureSquarePlateCut7, cutSide, rotateCut, moveCut);
 
 
-    G4double zPositionRod     = sqrt( (fSquareRodHoleInnerRadius * fSquareRodHoleInnerRadius ) - (fSquareRodPositionFromCenterOfSquareFace * fSquareRodPositionFromCenterOfSquareFace) ) + fSquareRodTotalLength/2.0 ;
-    G4double zPositionSquare  = fInnerDistanceToSquareFace + (fSquareAndTriangleFaceThickness)/2.0;
+	// Now cut the holes for the steel rods
+	innerRadius = 0.0*mm;
+	outerRadius = fSquareRodHoleRadius;
+	halfLengthZ = fSquareRodTotalLength/2.0;
 
-    // snip first hole
-    moveCut = G4ThreeVector(1.0*fSquareRodPositionFromCenterOfSquareFace,1.0*fSquareRodPositionFromCenterOfSquareFace,zPositionRod-zPositionSquare);
-
-    rotateCut = new G4RotationMatrix;
-
-    G4SubtractionSolid* griffinStructureSquarePlateCut9 = new G4SubtractionSolid("griffinStructureSquarePlateCut9", griffinStructureSquarePlateCut8, rodHole, rotateCut, moveCut);
-
-    // snip next hole
-    moveCut = G4ThreeVector(-1.0*fSquareRodPositionFromCenterOfSquareFace,1.0*fSquareRodPositionFromCenterOfSquareFace,zPositionRod-zPositionSquare);
-    rotateCut = new G4RotationMatrix;
-
-    G4SubtractionSolid* griffinStructureSquarePlateCut10 = new G4SubtractionSolid("griffinStructureSquarePlateCut10", griffinStructureSquarePlateCut9, rodHole, rotateCut, moveCut);
-
-    // snip next hole
-    moveCut = G4ThreeVector(1.0*fSquareRodPositionFromCenterOfSquareFace,-1.0*fSquareRodPositionFromCenterOfSquareFace,zPositionRod-zPositionSquare);
-    rotateCut = new G4RotationMatrix;
-
-    G4SubtractionSolid* griffinStructureSquarePlateCut11 = new G4SubtractionSolid("griffinStructureSquarePlateCut11", griffinStructureSquarePlateCut10, rodHole, rotateCut, moveCut);
-
-    // snip last hole
-    moveCut = G4ThreeVector(-1.0*fSquareRodPositionFromCenterOfSquareFace,-1.0*fSquareRodPositionFromCenterOfSquareFace,zPositionRod-zPositionSquare);
-    rotateCut = new G4RotationMatrix;
-
-    G4SubtractionSolid* griffinStructureSquarePlateCut12 = new G4SubtractionSolid("griffinStructureSquarePlateCut12", griffinStructureSquarePlateCut11, rodHole, rotateCut, moveCut);
+	G4Tubs* rodHole = new G4Tubs("rodHole", innerRadius, outerRadius, halfLengthZ, startPhi, endPhi);
 
 
-    // cut out the square hole with rounded corners
-    moveCut = G4ThreeVector(0.0*mm,0.0*mm,0.0*mm);
-    rotateCut = new G4RotationMatrix;
+	G4double zPositionRod     = sqrt((fSquareRodHoleInnerRadius * fSquareRodHoleInnerRadius) - (fSquareRodPositionFromCenterOfSquareFace * fSquareRodPositionFromCenterOfSquareFace)) + fSquareRodTotalLength/2.0 ;
+	G4double zPositionSquare  = fInnerDistanceToSquareFace + (fSquareAndTriangleFaceThickness)/2.0;
 
-    G4SubtractionSolid* squareWithRoundedCorners = SquareWithRoundedCorners();
+	// snip first hole
+	moveCut = G4ThreeVector(1.0*fSquareRodPositionFromCenterOfSquareFace,1.0*fSquareRodPositionFromCenterOfSquareFace,zPositionRod-zPositionSquare);
 
-    G4SubtractionSolid* griffinStructureSquarePlateCut13 = new G4SubtractionSolid("griffinStructureSquarePlateCut13", griffinStructureSquarePlateCut12, squareWithRoundedCorners, rotateCut, moveCut);
+	rotateCut = new G4RotationMatrix;
 
-    return griffinStructureSquarePlateCut13;
+	G4SubtractionSolid* griffinStructureSquarePlateCut9 = new G4SubtractionSolid("griffinStructureSquarePlateCut9", griffinStructureSquarePlateCut8, rodHole, rotateCut, moveCut);
+
+	// snip next hole
+	moveCut = G4ThreeVector(-1.0*fSquareRodPositionFromCenterOfSquareFace,1.0*fSquareRodPositionFromCenterOfSquareFace,zPositionRod-zPositionSquare);
+	rotateCut = new G4RotationMatrix;
+
+	G4SubtractionSolid* griffinStructureSquarePlateCut10 = new G4SubtractionSolid("griffinStructureSquarePlateCut10", griffinStructureSquarePlateCut9, rodHole, rotateCut, moveCut);
+
+	// snip next hole
+	moveCut = G4ThreeVector(1.0*fSquareRodPositionFromCenterOfSquareFace,-1.0*fSquareRodPositionFromCenterOfSquareFace,zPositionRod-zPositionSquare);
+	rotateCut = new G4RotationMatrix;
+
+	G4SubtractionSolid* griffinStructureSquarePlateCut11 = new G4SubtractionSolid("griffinStructureSquarePlateCut11", griffinStructureSquarePlateCut10, rodHole, rotateCut, moveCut);
+
+	// snip last hole
+	moveCut = G4ThreeVector(-1.0*fSquareRodPositionFromCenterOfSquareFace,-1.0*fSquareRodPositionFromCenterOfSquareFace,zPositionRod-zPositionSquare);
+	rotateCut = new G4RotationMatrix;
+
+	G4SubtractionSolid* griffinStructureSquarePlateCut12 = new G4SubtractionSolid("griffinStructureSquarePlateCut12", griffinStructureSquarePlateCut11, rodHole, rotateCut, moveCut);
+
+
+	// cut out the square hole with rounded corners
+	moveCut = G4ThreeVector(0.0*mm,0.0*mm,0.0*mm);
+	rotateCut = new G4RotationMatrix;
+
+	G4SubtractionSolid* squareWithRoundedCorners = SquareWithRoundedCorners();
+
+	G4SubtractionSolid* griffinStructureSquarePlateCut13 = new G4SubtractionSolid("griffinStructureSquarePlateCut13", griffinStructureSquarePlateCut12, squareWithRoundedCorners, rotateCut, moveCut);
+
+	return griffinStructureSquarePlateCut13;
 }
 
 
 G4SubtractionSolid* ApparatusGriffinStructure::TrianglePiece()
 {
-    // grab the scissors, time to cut.
-    G4double startPhi = 0.0*deg;
-    G4double endPhi = 360.0*deg;
-    G4double phi = 0.0*deg;
+	// grab the scissors, time to cut.
+	G4double startPhi = 0.0*deg;
+	G4double endPhi = 360.0*deg;
+	G4double phi = 0.0*deg;
 
-    G4double innerRadius;
-    G4double outerRadius;
-    G4double cutHalfLengthX;
-    G4double cutHalfLengthY;
-    G4double cutHalfLengthZ;
+	G4double innerRadius;
+	G4double outerRadius;
+	G4double cutHalfLengthX;
+	G4double cutHalfLengthY;
+	G4double cutHalfLengthZ;
 
-    G4ThreeVector move, moveCut;
-    G4RotationMatrix* rotateCut;
+	G4ThreeVector move, moveCut;
+	G4RotationMatrix* rotateCut;
 
-    // to centre
-    G4double r              = fInnerDistanceToSquareFace + fSquareAndTriangleFaceThickness/2.0;
-    G4double x              = r*tan(22.5*deg);
-    G4double xt             = (fSquareAndTriangleFaceThickness/2.0)*tan(22.5*deg); // add thickness for edges
-    G4double halfLengthX  = x + xt;
-    G4double halfLengthZ  = fSquareAndTriangleFaceThickness/2.0;
+	// to centre
+	G4double r              = fInnerDistanceToSquareFace + fSquareAndTriangleFaceThickness/2.0;
+	G4double x              = r*tan(22.5*deg);
+	G4double xt             = (fSquareAndTriangleFaceThickness/2.0)*tan(22.5*deg); // add thickness for edges
+	G4double halfLengthX  = x + xt;
+	G4double halfLengthZ  = fSquareAndTriangleFaceThickness/2.0;
 
-    // equilateral triangle is inscribed in a circle of radius a.
-    innerRadius = 0.0*mm;
-    outerRadius = (2.0*halfLengthX)/(sqrt(3));
-    G4Tubs* griffinStructureTrianglePlate = new G4Tubs("griffinStructureTrianglePlate", innerRadius, outerRadius, halfLengthZ, startPhi, endPhi);
+	// equilateral triangle is inscribed in a circle of radius a.
+	innerRadius = 0.0*mm;
+	outerRadius = (2.0*halfLengthX)/(sqrt(3));
+	G4Tubs* griffinStructureTrianglePlate = new G4Tubs("griffinStructureTrianglePlate", innerRadius, outerRadius, halfLengthZ, startPhi, endPhi);
 
-    G4SubtractionSolid* truncatedThreeSidedCylinder = TruncatedThreeSidedCylinder();
+	G4SubtractionSolid* truncatedThreeSidedCylinder = TruncatedThreeSidedCylinder();
 
-    move = G4ThreeVector(0.0*mm,0.0*mm,0.0*mm);
-    rotateCut = new G4RotationMatrix;
+	move = G4ThreeVector(0.0*mm,0.0*mm,0.0*mm);
+	rotateCut = new G4RotationMatrix;
 
-    // cut out inside truncatedThreeSidedCylinder hole
-    G4SubtractionSolid* griffinStructureTrianglePlateCut1 = new G4SubtractionSolid("griffinStructureTrianglePlateCut1", griffinStructureTrianglePlate, truncatedThreeSidedCylinder, rotateCut, move);
+	// cut out inside truncatedThreeSidedCylinder hole
+	G4SubtractionSolid* griffinStructureTrianglePlateCut1 = new G4SubtractionSolid("griffinStructureTrianglePlateCut1", griffinStructureTrianglePlate, truncatedThreeSidedCylinder, rotateCut, move);
 
-    r = fInnerDistanceToSquareFace + fSquareAndTriangleFaceThickness/2.0;
-    x = r*tan(22.5*deg);
+	r = fInnerDistanceToSquareFace + fSquareAndTriangleFaceThickness/2.0;
+	x = r*tan(22.5*deg);
 
-    // Now cut the edges so that the pieces fit nicely together
-    cutHalfLengthX = 1.0*r;
-    cutHalfLengthY = 2.0*r;
-    cutHalfLengthZ = 2.0*r;
-    G4Box* cutSide = new G4Box("cutSide", cutHalfLengthX, cutHalfLengthY, cutHalfLengthZ);
+	// Now cut the edges so that the pieces fit nicely together
+	cutHalfLengthX = 1.0*r;
+	cutHalfLengthY = 2.0*r;
+	cutHalfLengthZ = 2.0*r;
+	G4Box* cutSide = new G4Box("cutSide", cutHalfLengthX, cutHalfLengthY, cutHalfLengthZ);
 
-    G4double theta = ((90.0*deg - fTriangleThetaAngle) - 22.5*deg);
+	G4double theta = ((90.0*deg - fTriangleThetaAngle) - 22.5*deg);
 
-    move = G4ThreeVector(cutHalfLengthX/cos(theta),0.0*mm,-1.0*(x*tan(30.0*deg))/(tan(theta))); // phi = 0;
+	move = G4ThreeVector(cutHalfLengthX/cos(theta),0.0*mm,-1.0*(x*tan(30.0*deg))/(tan(theta))); // phi = 0;
 
-    // 1st edge
-    phi = 0.0*deg;
+	// 1st edge
+	phi = 0.0*deg;
 
-    rotateCut = new G4RotationMatrix;
-    rotateCut->rotateZ(-1.0*phi);
-    rotateCut->rotateY(-1.0*theta);
+	rotateCut = new G4RotationMatrix;
+	rotateCut->rotateZ(-1.0*phi);
+	rotateCut->rotateY(-1.0*theta);
 
-    moveCut 	= G4ThreeVector(move.x()*cos(phi),move.x()*sin(phi),move.z());
+	moveCut 	= G4ThreeVector(move.x()*cos(phi),move.x()*sin(phi),move.z());
 
-    // snip snip
-    G4SubtractionSolid* griffinStructureTrianglePlateCut2 = new G4SubtractionSolid("griffinStructureTrianglePlateCut2", griffinStructureTrianglePlateCut1, cutSide, rotateCut, moveCut);
+	// snip snip
+	G4SubtractionSolid* griffinStructureTrianglePlateCut2 = new G4SubtractionSolid("griffinStructureTrianglePlateCut2", griffinStructureTrianglePlateCut1, cutSide, rotateCut, moveCut);
 
-    // 2nd edge
-    phi = 120.0*deg;
-    rotateCut = new G4RotationMatrix;
-    rotateCut->rotateZ(-1.0*phi);
-    rotateCut->rotateY(-1.0*theta);
+	// 2nd edge
+	phi = 120.0*deg;
+	rotateCut = new G4RotationMatrix;
+	rotateCut->rotateZ(-1.0*phi);
+	rotateCut->rotateY(-1.0*theta);
 
-    moveCut 	= G4ThreeVector(move.x()*cos(phi),move.x()*sin(phi),move.z());
+	moveCut 	= G4ThreeVector(move.x()*cos(phi),move.x()*sin(phi),move.z());
 
-    // snip snip
-    G4SubtractionSolid* griffinStructureTrianglePlateCut3 = new G4SubtractionSolid("griffinStructureTrianglePlateCut3", griffinStructureTrianglePlateCut2, cutSide, rotateCut, moveCut);
+	// snip snip
+	G4SubtractionSolid* griffinStructureTrianglePlateCut3 = new G4SubtractionSolid("griffinStructureTrianglePlateCut3", griffinStructureTrianglePlateCut2, cutSide, rotateCut, moveCut);
 
-    // last edge
-    phi = 240.0*deg;
+	// last edge
+	phi = 240.0*deg;
 
-    rotateCut = new G4RotationMatrix;
-    rotateCut->rotateZ(-1.0*phi);
-    rotateCut->rotateY(-1.0*theta);
+	rotateCut = new G4RotationMatrix;
+	rotateCut->rotateZ(-1.0*phi);
+	rotateCut->rotateY(-1.0*theta);
 
-    moveCut 	= G4ThreeVector(move.x()*cos(phi),move.x()*sin(phi),move.z());
+	moveCut 	= G4ThreeVector(move.x()*cos(phi),move.x()*sin(phi),move.z());
 
-    // snip snip
-    G4SubtractionSolid* griffinStructureTrianglePlateCut4 = new G4SubtractionSolid("griffinStructureTrianglePlateCut4", griffinStructureTrianglePlateCut3, cutSide, rotateCut, moveCut);
+	// snip snip
+	G4SubtractionSolid* griffinStructureTrianglePlateCut4 = new G4SubtractionSolid("griffinStructureTrianglePlateCut4", griffinStructureTrianglePlateCut3, cutSide, rotateCut, moveCut);
 
-    return griffinStructureTrianglePlateCut4;
+	return griffinStructureTrianglePlateCut4;
 }
 
 G4Tubs* ApparatusGriffinStructure::LargeRingFrame()
 {
-    G4double startPhi = 0.0*deg;
-    G4double endPhi = 360.0*deg;
+	G4double startPhi = 0.0*deg;
+	G4double endPhi = 360.0*deg;
 
-    G4double innerRadius = fLargeRingFrameInnerRadius;
-    G4double outerRadius = fLargeRingFrameOuterRadius;
-    G4double halfLengthZ = fLargeRingFrameThickness/2.0;
+	G4double innerRadius = fLargeRingFrameInnerRadius;
+	G4double outerRadius = fLargeRingFrameOuterRadius;
+	G4double halfLengthZ = fLargeRingFrameThickness/2.0;
 
-    G4Tubs* ringCylinder = new G4Tubs("ringCylinder", innerRadius, outerRadius, halfLengthZ, startPhi, endPhi);
+	G4Tubs* ringCylinder = new G4Tubs("ringCylinder", innerRadius, outerRadius, halfLengthZ, startPhi, endPhi);
 
-    return ringCylinder;
+	return ringCylinder;
 }
 
 G4Tubs* ApparatusGriffinStructure::RodPiece()
 {
-    G4double startPhi = 0.0*deg;
-    G4double endPhi = 360.0*deg;
+	G4double startPhi = 0.0*deg;
+	G4double endPhi = 360.0*deg;
 
-    G4double innerRadius = 0.0*mm;
-    G4double outerRadius = fSquareRodHoleRadius;
-    G4double halfLengthZ = fSquareRodTotalLength/2.0;
+	G4double innerRadius = 0.0*mm;
+	G4double outerRadius = fSquareRodHoleRadius;
+	G4double halfLengthZ = fSquareRodTotalLength/2.0;
 
-    G4Tubs* rod = new G4Tubs("rod", innerRadius, outerRadius, halfLengthZ, startPhi, endPhi);
+	G4Tubs* rod = new G4Tubs("rod", innerRadius, outerRadius, halfLengthZ, startPhi, endPhi);
 
-    return rod;
+	return rod;
 }
 
 G4SubtractionSolid* ApparatusGriffinStructure::SquareWithRoundedCorners()
 {
-    G4double halfLengthX = fSquareHoleLength/2.0;
-    G4double halfLengthY = fSquareHoleLength/2.0;
-    G4double halfLengthZ = fSquareAndTriangleFaceThickness;
+	G4double halfLengthX = fSquareHoleLength/2.0;
+	G4double halfLengthY = fSquareHoleLength/2.0;
+	G4double halfLengthZ = fSquareAndTriangleFaceThickness;
 
-    G4ThreeVector move = G4ThreeVector(0.0*mm,0.0*mm,0.0*mm);
-    G4RotationMatrix* rotate;
+	G4ThreeVector move = G4ThreeVector(0.0*mm,0.0*mm,0.0*mm);
+	G4RotationMatrix* rotate;
 
-    G4Box* griffinStructureSquarePlate1 = new G4Box("griffinStructureSquarePlate1", halfLengthX, halfLengthY, halfLengthX);
+	G4Box* griffinStructureSquarePlate1 = new G4Box("griffinStructureSquarePlate1", halfLengthX, halfLengthY, halfLengthX);
 
-    // cut rounded corners
-    G4double startPhi = 0.0*deg;
-    G4double endPhi = 90.0*deg;
+	// cut rounded corners
+	G4double startPhi = 0.0*deg;
+	G4double endPhi = 90.0*deg;
 
-    G4double innerRadius = fSquareHoleRoundedEdgeRadius;
-    G4double outerRadius = fSquareHoleRoundedEdgeRadius + 2.0*halfLengthX;
+	G4double innerRadius = fSquareHoleRoundedEdgeRadius;
+	G4double outerRadius = fSquareHoleRoundedEdgeRadius + 2.0*halfLengthX;
 
-    G4Tubs* roundedCorner = new G4Tubs("roundedCorner", innerRadius, outerRadius, halfLengthZ, startPhi, endPhi);
+	G4Tubs* roundedCorner = new G4Tubs("roundedCorner", innerRadius, outerRadius, halfLengthZ, startPhi, endPhi);
 
-    // 1st corner
-    move = G4ThreeVector(1.0*(halfLengthX - fSquareHoleRoundedEdgeRadius),1.0*(halfLengthX - fSquareHoleRoundedEdgeRadius),0.0*mm);
-    rotate = new G4RotationMatrix;
+	// 1st corner
+	move = G4ThreeVector(1.0*(halfLengthX - fSquareHoleRoundedEdgeRadius),1.0*(halfLengthX - fSquareHoleRoundedEdgeRadius),0.0*mm);
+	rotate = new G4RotationMatrix;
 
-    G4SubtractionSolid* griffinStructureSquarePlate2 = new G4SubtractionSolid("griffinStructureSquarePlate2", griffinStructureSquarePlate1, roundedCorner, rotate, move);
+	G4SubtractionSolid* griffinStructureSquarePlate2 = new G4SubtractionSolid("griffinStructureSquarePlate2", griffinStructureSquarePlate1, roundedCorner, rotate, move);
 
-    // next corner
-    move = G4ThreeVector(1.0*(halfLengthX - fSquareHoleRoundedEdgeRadius),-1.0*(halfLengthX - fSquareHoleRoundedEdgeRadius),0.0*mm);
-    rotate = new G4RotationMatrix;
-    rotate->rotateZ(90.0*deg);
+	// next corner
+	move = G4ThreeVector(1.0*(halfLengthX - fSquareHoleRoundedEdgeRadius),-1.0*(halfLengthX - fSquareHoleRoundedEdgeRadius),0.0*mm);
+	rotate = new G4RotationMatrix;
+	rotate->rotateZ(90.0*deg);
 
-    G4SubtractionSolid* griffinStructureSquarePlate3 = new G4SubtractionSolid("griffinStructureSquarePlate3", griffinStructureSquarePlate2, roundedCorner, rotate, move);
+	G4SubtractionSolid* griffinStructureSquarePlate3 = new G4SubtractionSolid("griffinStructureSquarePlate3", griffinStructureSquarePlate2, roundedCorner, rotate, move);
 
-    // next corner
-    move = G4ThreeVector(-1.0*(halfLengthX - fSquareHoleRoundedEdgeRadius),-1.0*(halfLengthX - fSquareHoleRoundedEdgeRadius),0.0*mm);
-    rotate = new G4RotationMatrix;
-    rotate->rotateZ(180.0*deg);
+	// next corner
+	move = G4ThreeVector(-1.0*(halfLengthX - fSquareHoleRoundedEdgeRadius),-1.0*(halfLengthX - fSquareHoleRoundedEdgeRadius),0.0*mm);
+	rotate = new G4RotationMatrix;
+	rotate->rotateZ(180.0*deg);
 
-    G4SubtractionSolid* griffinStructureSquarePlate4 = new G4SubtractionSolid("griffinStructureSquarePlate4", griffinStructureSquarePlate3, roundedCorner, rotate, move);
+	G4SubtractionSolid* griffinStructureSquarePlate4 = new G4SubtractionSolid("griffinStructureSquarePlate4", griffinStructureSquarePlate3, roundedCorner, rotate, move);
 
-    // last corner
-    move = G4ThreeVector(-1.0*(halfLengthX - fSquareHoleRoundedEdgeRadius),1.0*(halfLengthX - fSquareHoleRoundedEdgeRadius),0.0*mm);
-    rotate = new G4RotationMatrix;
-    rotate->rotateZ(270.0*deg);
+	// last corner
+	move = G4ThreeVector(-1.0*(halfLengthX - fSquareHoleRoundedEdgeRadius),1.0*(halfLengthX - fSquareHoleRoundedEdgeRadius),0.0*mm);
+	rotate = new G4RotationMatrix;
+	rotate->rotateZ(270.0*deg);
 
-    G4SubtractionSolid* griffinStructureSquarePlate5 = new G4SubtractionSolid("griffinStructureSquarePlate5", griffinStructureSquarePlate4, roundedCorner, rotate, move);
+	G4SubtractionSolid* griffinStructureSquarePlate5 = new G4SubtractionSolid("griffinStructureSquarePlate5", griffinStructureSquarePlate4, roundedCorner, rotate, move);
 
-    return griffinStructureSquarePlate5;
+	return griffinStructureSquarePlate5;
 }
 
 G4SubtractionSolid* ApparatusGriffinStructure::TruncatedThreeSidedCylinder()
 {
-    G4double startPhi = 0.0*deg;
-    G4double endPhi = 360.0*deg;
+	G4double startPhi = 0.0*deg;
+	G4double endPhi = 360.0*deg;
 
-    G4double innerRadius = 0.0*mm;
-    G4double outerRadius = fTriangleOuterHoleRadius;
-    G4double halfLengthZ = fSquareAndTriangleFaceThickness;
+	G4double innerRadius = 0.0*mm;
+	G4double outerRadius = fTriangleOuterHoleRadius;
+	G4double halfLengthZ = fSquareAndTriangleFaceThickness;
 
-    G4double phi;
-    G4ThreeVector move, moveCut;
-    G4RotationMatrix* rotateCut;
+	G4double phi;
+	G4ThreeVector move, moveCut;
+	G4RotationMatrix* rotateCut;
 
-    G4Tubs* holeCylinder = new G4Tubs("holeCylinder", innerRadius, outerRadius, halfLengthZ, startPhi, endPhi);
+	G4Tubs* holeCylinder = new G4Tubs("holeCylinder", innerRadius, outerRadius, halfLengthZ, startPhi, endPhi);
 
-    // cut flat sides
-    G4double cutHalfLengthX = 2.0*outerRadius;
-    G4double cutHalfLengthY = 2.0*outerRadius;
-    G4double cutHalfLengthZ = 2.0*halfLengthZ;
+	// cut flat sides
+	G4double cutHalfLengthX = 2.0*outerRadius;
+	G4double cutHalfLengthY = 2.0*outerRadius;
+	G4double cutHalfLengthZ = 2.0*halfLengthZ;
 
-    G4Box* cutEdge = new G4Box("cutEdge", cutHalfLengthX, cutHalfLengthY, cutHalfLengthZ);
+	G4Box* cutEdge = new G4Box("cutEdge", cutHalfLengthX, cutHalfLengthY, cutHalfLengthZ);
 
-    move = G4ThreeVector(fTriangleInnerHoleRadius + cutHalfLengthX, 0.0*mm,0.0*mm);
+	move = G4ThreeVector(fTriangleInnerHoleRadius + cutHalfLengthX, 0.0*mm,0.0*mm);
 
-    // 1st cut
-    phi = 0.0*deg;
-    rotateCut = new G4RotationMatrix;
-    rotateCut->rotateZ(-1.0*phi);
+	// 1st cut
+	phi = 0.0*deg;
+	rotateCut = new G4RotationMatrix;
+	rotateCut->rotateZ(-1.0*phi);
 
-    moveCut = G4ThreeVector(move.x()*cos(phi),move.x()*sin(phi),move.z());
+	moveCut = G4ThreeVector(move.x()*cos(phi),move.x()*sin(phi),move.z());
 
-    G4SubtractionSolid* holeCylinder1 = new G4SubtractionSolid("holeCylinder1", holeCylinder, cutEdge, rotateCut, moveCut);
+	G4SubtractionSolid* holeCylinder1 = new G4SubtractionSolid("holeCylinder1", holeCylinder, cutEdge, rotateCut, moveCut);
 
-    // 2nd cut
-    phi = 120.0*deg;
-    rotateCut = new G4RotationMatrix;
-    rotateCut->rotateZ(-1.0*phi);
+	// 2nd cut
+	phi = 120.0*deg;
+	rotateCut = new G4RotationMatrix;
+	rotateCut->rotateZ(-1.0*phi);
 
-    moveCut = G4ThreeVector(move.x()*cos(phi),move.x()*sin(phi),move.z());
+	moveCut = G4ThreeVector(move.x()*cos(phi),move.x()*sin(phi),move.z());
 
-    G4SubtractionSolid* holeCylinder2 = new G4SubtractionSolid("holeCylinder2", holeCylinder1, cutEdge, rotateCut, moveCut);
+	G4SubtractionSolid* holeCylinder2 = new G4SubtractionSolid("holeCylinder2", holeCylinder1, cutEdge, rotateCut, moveCut);
 
-    // 3rd cut
-    phi = 240.0*deg;
-    rotateCut = new G4RotationMatrix;
-    rotateCut->rotateZ(-1.0*phi);
+	// 3rd cut
+	phi = 240.0*deg;
+	rotateCut = new G4RotationMatrix;
+	rotateCut->rotateZ(-1.0*phi);
 
-    moveCut = G4ThreeVector(move.x()*cos(phi),move.x()*sin(phi),move.z());
+	moveCut = G4ThreeVector(move.x()*cos(phi),move.x()*sin(phi),move.z());
 
-    G4SubtractionSolid* holeCylinder3 = new G4SubtractionSolid("holeCylinder3", holeCylinder2, cutEdge, rotateCut, moveCut);
+	G4SubtractionSolid* holeCylinder3 = new G4SubtractionSolid("holeCylinder3", holeCylinder2, cutEdge, rotateCut, moveCut);
 
-    return holeCylinder3;
+	return holeCylinder3;
 }

--- a/src/ApparatusLayeredTarget.cc
+++ b/src/ApparatusLayeredTarget.cc
@@ -26,18 +26,16 @@
 #include "ApparatusLayeredTarget.hh"
 
 ApparatusLayeredTarget::ApparatusLayeredTarget(G4double beaminput) { 
-  
-  fBeamPos = beaminput*mm;
-  fTargetRadius = 6.0*mm;
-  
-  G4double fMaxStep=10.*CLHEP::um; 
-  fStepLimit = new G4UserLimits(fMaxStep);
-  
+	fBeamPos = beaminput*mm;
+	fTargetRadius = 6.0*mm;
+
+	G4double fMaxStep=10.*CLHEP::um; 
+	fStepLimit = new G4UserLimits(fMaxStep);
 }
 
 ApparatusLayeredTarget::~ApparatusLayeredTarget()
 { 
-  // LogicalVolumes 
+	// LogicalVolumes 
 	for(unsigned int i=0;i<fTargetLayerLog.size();i++){
 		delete fTargetLayerLog[i];
 	}
@@ -47,68 +45,67 @@ ApparatusLayeredTarget::~ApparatusLayeredTarget()
 
 G4int ApparatusLayeredTarget::BuildTargetLayer(G4String LayerMaterial, G4double LayerArealDensity)
 {
-    //Get Materials 
-    
-    G4Material* material = G4Material::GetMaterial(LayerMaterial);
-    if( !material ) {
-      G4cout << " ----> Target Material " << LayerMaterial << " not found, cannot build!" << G4endl;
-      return 0;
-    } 
-    
-    G4double LayerMaterialDensity=material->GetDensity();
-    G4cout << "Target LayerMaterialDensity: " << LayerMaterialDensity/(g/cm3) <<" g/cm3"<< G4endl;
-    G4double LayerThickness = ((LayerArealDensity*(mg/cm2))/LayerMaterialDensity);
-    G4cout << "Target Thickness (um): " << LayerThickness/(um) << G4endl;
+	//Get Materials 
+	G4Material* material = G4Material::GetMaterial(LayerMaterial);
+	if(!material) {
+		G4cout<<" ----> Target Material "<<LayerMaterial<<" not found, cannot build!"<<G4endl;
+		return 0;
+	} 
 
-    // Build assembly volume
-    G4VisAttributes* vis_att = new G4VisAttributes(G4Colour(0.8+fTargetLayerLog.size()*0.1,0.0,0.2));
-    vis_att->SetVisibility(true);  
+	G4double LayerMaterialDensity=material->GetDensity();
+	G4cout<<"Target LayerMaterialDensity: "<<LayerMaterialDensity/(g/cm3) <<" g/cm3"<< G4endl;
+	G4double LayerThickness = ((LayerArealDensity*(mg/cm2))/LayerMaterialDensity);
+	G4cout<<"Target Thickness (um): "<<LayerThickness/(um)<<G4endl;
 
-    std::stringstream ss;
-    ss<<"TargetLayer"<<fTargetLayerLog.size();
-    G4Tubs* target = new G4Tubs(ss.str(), 0.0, fTargetRadius, std::abs(LayerThickness)/2.,0.0, 360*deg);
-    
-    //logical volume
-    std::stringstream SS;
-    SS<<"TargetLayerLog"<<fTargetLayerLog.size();
-      G4LogicalVolume* LayerLog = new G4LogicalVolume(target, material,SS.str(), 0, 0, 0);
-      LayerLog->SetVisAttributes(vis_att);
-      fTargetLayerLog.push_back(LayerLog);
-      fTargetLayerThick.push_back(LayerThickness);
-      
-      LayerLog->SetUserLimits(fStepLimit);
-      return 1;
+	// Build assembly volume
+	G4VisAttributes* vis_att = new G4VisAttributes(G4Colour(0.8+fTargetLayerLog.size()*0.1,0.0,0.2));
+	vis_att->SetVisibility(true);  
+
+	std::stringstream ss;
+	ss<<"TargetLayer"<<fTargetLayerLog.size();
+	G4Tubs* target = new G4Tubs(ss.str(), 0.0, fTargetRadius, std::abs(LayerThickness)/2.,0.0, 360*deg);
+
+	//logical volume
+	std::stringstream SS;
+	SS<<"TargetLayerLog"<<fTargetLayerLog.size();
+	G4LogicalVolume* LayerLog = new G4LogicalVolume(target, material,SS.str(), 0, 0, 0);
+	LayerLog->SetVisAttributes(vis_att);
+	fTargetLayerLog.push_back(LayerLog);
+	fTargetLayerThick.push_back(LayerThickness);
+
+	LayerLog->SetUserLimits(fStepLimit);
+	return 1;
 }
 
 void ApparatusLayeredTarget::PlaceTarget(G4LogicalVolume* oexpHallLog)
 {
-  if(fTargetLayerLog.size()<=fTargetLayerPhys.size())return;
-  G4cout << "Adding Target Layer " << G4endl;
+	if(fTargetLayerLog.size()<=fTargetLayerPhys.size())return;
+	G4cout<<"Adding Target Layer "<<G4endl;
 
-  G4double placement =LayerStart(fTargetLayerPhys.size()) - fTargetLayerThick[fTargetLayerPhys.size()]/2.;
-  G4cout << "Placement target : " << placement << " " << placement*mm << G4endl;
-  
-  G4ThreeVector move = G4ThreeVector(0.,0.,placement);//0 for now until read in 
-  G4RotationMatrix* sRotate = new G4RotationMatrix;
-  
-  std::stringstream ss;
-  ss<<"TargetLayer"<<fTargetLayerLog.size();
-  G4PVPlacement* TargetPhys = new G4PVPlacement(sRotate,                       //no rotation
-                    move,                    //at position
-                    fTargetLayerLog[fTargetLayerPhys.size()],             //its logical volume
-                    ss.str(),                //its name
-                    oexpHallLog,                //its mother  volume
-                    false,                   //no boolean operation
-                    false,                       //copy number
-                    0);          //overlaps checking
-  
-  fTargetLayerPhys.push_back(TargetPhys);
+	G4double placement =LayerStart(fTargetLayerPhys.size()) - fTargetLayerThick[fTargetLayerPhys.size()]/2.;
+	G4cout<<"Placement target : "<<placement<<" "<<placement*mm<<G4endl;
+
+	G4ThreeVector move = G4ThreeVector(0.,0.,placement);//0 for now until read in 
+	G4RotationMatrix* sRotate = new G4RotationMatrix;
+
+	std::stringstream ss;
+	ss<<"TargetLayer"<<fTargetLayerLog.size();
+	G4PVPlacement* TargetPhys = new G4PVPlacement(sRotate,                       //no rotation
+			move,                    //at position
+			fTargetLayerLog[fTargetLayerPhys.size()],             //its logical volume
+			ss.str(),                //its name
+			oexpHallLog,                //its mother  volume
+			false,                   //no boolean operation
+			false,                       //copy number
+			0);          //overlaps checking
+
+	fTargetLayerPhys.push_back(TargetPhys);
 }
 
 G4double ApparatusLayeredTarget::LayerStart(int layeri){
 	if(!fTargetLayerThick.size())return 0;
 	G4double ret = fBeamPos;
-	
+
 	for(int i=0;i<layeri;i++){
 		if((unsigned)i<fTargetLayerThick.size())ret-=fTargetLayerThick[i];
 	}

--- a/src/ApparatusSpiceTargetChamber.cc
+++ b/src/ApparatusSpiceTargetChamber.cc
@@ -44,10 +44,8 @@
 // define physical properties of ApparatusSpiceTargetChamber //
 //////////////////////////////////////////////////////
 
-
 G4int ApparatusSpiceTargetChamber::fTargetWheelTargetPos[6]={0,0,1,0,1,0};
 
-	
 //Z distance to Z=0 mm (actual target may be elsewhere)
 G4double ApparatusSpiceTargetChamber::fTargetChamberDistanceFromTarget = 1*CLHEP::mm;	
 G4double ApparatusSpiceTargetChamber::fTargetWheelFaceZ=0*CLHEP::mm;
@@ -55,8 +53,6 @@ G4double ApparatusSpiceTargetChamber::fTargetWheelFaceZ=0*CLHEP::mm;
 // The target assembly is placed in the world relative to the Z fTargetWheelFaceZ
 //
 // The rods connecting the two have been set such that they match and an error statement prints if distance changed.
-
-
 
 ApparatusSpiceTargetChamber::ApparatusSpiceTargetChamber(G4String Options)//parameter chooses which lens is in place.
 {
@@ -67,7 +63,7 @@ ApparatusSpiceTargetChamber::ApparatusSpiceTargetChamber(G4String Options)//para
 	Eff=false;
 	Source=false;
 	Col=false;
-	
+
 	G4cout<<G4endl<<"SPICE Command String : "<<Options;
 	if(Options.contains("Empty")||Options.contains("EMPTY")||Options.contains("empty")){
 		Empty=true;
@@ -85,12 +81,12 @@ ApparatusSpiceTargetChamber::ApparatusSpiceTargetChamber(G4String Options)//para
 			G4cout<<G4endl<<" ADDING NEW COLLIMATOR INSTALLED IN AUGUST 2017.";
 		}
 	}
-	
+
 	if(Options.contains("Light")||Options.contains("LIGHT")||Options.contains("light")||Options.contains("lite")||Options.contains("LITE")||Options.contains("Lite")){
 		Light=true;
 		G4cout<<G4endl<<" Building Only Crucial SPICE Components";
 	}
-	
+
 	if(Options.contains("Eff")||Options.contains("EFF")||Options.contains("eff")||Options.contains("efficiency")||Options.contains("efficiency")||Options.contains("EFFICIENCY")){
 		Eff=true;
 		G4cout<<G4endl<<" Building the SPICE On-Wheel Efficiency Source Holder.";
@@ -101,7 +97,7 @@ ApparatusSpiceTargetChamber::ApparatusSpiceTargetChamber(G4String Options)//para
 		Bunny=true;
 		G4cout<<G4endl<<" Building Bunny-ear Target Pedestals.";
 	}
-	
+
 	G4cout<<G4endl;
 
 	// Materials
@@ -111,7 +107,7 @@ ApparatusSpiceTargetChamber::ApparatusSpiceTargetChamber(G4String Options)//para
 	fElectroBoxMaterial = "Aluminum";
 	fColdFingerMaterial = "Copper"; 
 	fS3CableCaseMaterial = "Delrin";
-	
+
 	fMagnetMaterial = "NdFeB"; 
 	fPhotonShieldLayerOneMaterial = "WTa"; 
 	fPhotonShieldLayerTwoMaterial = "Tin"; 
@@ -120,24 +116,24 @@ ApparatusSpiceTargetChamber::ApparatusSpiceTargetChamber(G4String Options)//para
 	fShieldCoverMaterial = "Kapton";
 	fMagnetCoverMaterial = "Peek";
 	fPSBoltMaterial = "Brass"; 
-	
+
 	fTargetWheelMaterial = "Aluminum"; 
 	fTargetWheelGearMaterialA = "Delrin";
 	fTargetWheelGearMaterialB = "Aluminum";
 	fGearPlateMaterial = "Aluminum";
 	fTargetMountPlateMaterial = "Peek";
 	fGearStickMaterial = "Peek"; 
-	
+
 	fConicalCollimatorMaterial = "WTa";//11/8
 	fXRayInsertMaterial="Copper";
-	
+
 	if(Source)fTargetMountPlateMaterial = "Aluminum";
-	
+
 	//-----------------------------
 	// Dimensions of Target Chamber
 	//-----------------------------
 
-	
+
 	fTargetChamberCylinderInnerRadius = 97*CLHEP::mm;
 	fTargetChamberCylinderOuterRadius = 102*CLHEP::mm;
 	fTargetChamberCylinderLength = 89*CLHEP::mm;
@@ -145,7 +141,7 @@ ApparatusSpiceTargetChamber::ApparatusSpiceTargetChamber(G4String Options)//para
 	fTargetChamberMELTabRad= 34.5*CLHEP::mm;
 	fTargetChamberMELTabWidth= 11.8*CLHEP::mm;
 	fTargetChamberMagnetIndent= 3*CLHEP::mm;
-	
+
 	fTargetChamberCylinderLipInnerRadius = 48*CLHEP::mm;
 	fTargetChamberCylinderLipThickness = 6*CLHEP::mm;
 	fTargetChamberCylinderDetOuterRadius = 128*CLHEP::mm;
@@ -171,7 +167,7 @@ ApparatusSpiceTargetChamber::ApparatusSpiceTargetChamber(G4String Options)//para
 	fConeFrontInnerRad = 48.801*CLHEP::mm;
 	fConeFrontOuterRad = 52.801*CLHEP::mm;
 	fConeLength = 92.868*CLHEP::mm;
-	
+
 	// -------------------------
 	// Dimensions of ElectroBox
 	// -------------------------
@@ -190,14 +186,14 @@ ApparatusSpiceTargetChamber::ApparatusSpiceTargetChamber(G4String Options)//para
 	fColdfingerWidth = 200*CLHEP::mm  ; // CHECK
 	fColdfingerZOffset = -130*CLHEP::mm ; // CHECK
 	fColdfingerHoleRadius = 10*CLHEP::mm ; // CHECK
-	
+
 	// ----------------------
 	// Dimensions of Beam Pipe
 	// -----------------------
 	fPipeInnerRadius = 5.0*CLHEP::mm; // 5
 	fPipeOuterRadius = 16.0*CLHEP::mm;
 	fPipeZLength = 30.0*CLHEP::mm;
-	
+
 
 	// --------------------------
 	// Dimensions of Target Wheel
@@ -208,7 +204,7 @@ ApparatusSpiceTargetChamber::ApparatusSpiceTargetChamber(G4String Options)//para
 	fTargetWheelRadius = 40*CLHEP::mm;
 	fTargetWheelThickness = 3.1*CLHEP::mm;
 	fTargetWheelIndentRadius= 28.9*CLHEP::mm;
-	
+
 	fTargetWheelExtLength= 13.5*CLHEP::mm;
 	fTargetWheelExtInnerRad1= 32*CLHEP::mm;
 	fTargetWheelExtInnerRad2= 38*CLHEP::mm;
@@ -217,42 +213,42 @@ ApparatusSpiceTargetChamber::ApparatusSpiceTargetChamber(G4String Options)//para
 	fTargetWheelExtBaseLip= 3.2*CLHEP::mm;
 
 	fTargetOffsetRadius = 15*CLHEP::mm;
-	
+
 	// Mount Plate
 	fTargetMountPlateRadius = 87*CLHEP::mm;
 	fTargetMountPlateThickness = 5*CLHEP::mm;
 	fTargetMountPlateCutDepth = 3.1*CLHEP::mm;
 	fTargetMountPlateHoleRad = 40*CLHEP::mm;
-	
+
 	fMountPlateRodRadius=3.125*CLHEP::mm;
 	fMountPlateRodPlaceR=79*CLHEP::mm;
 	fMountPlateRodLength=14.5*CLHEP::mm;
-	
+
 	fTargetMountPlateZOffset = fTargetWheelFaceZ+fTargetWheelThickness+fTargetWheelExtLength-fTargetMountPlateCutDepth+fTargetMountPlateThickness/2.;
-	
+
 	fMountPlateRodZoffset=fTargetMountPlateZOffset-fTargetMountPlateThickness/2.-fMountPlateRodLength/2;
-	
+
 	G4double AlternatefMountPlateRodZoffset=-fTargetChamberDistanceFromTarget+fMountPlateRodLength/2;	
 	G4double delta=	abs((fMountPlateRodZoffset-AlternatefMountPlateRodZoffset)/CLHEP::mm);
 	if(delta>0.1)G4cout<<G4endl<<"BEWARE DIFFERENCE IN Z=0 BETWEEN LENS AND TARGET WHEEL CONSTRUCTIONS "<<delta<<" mm"<<G4endl;
-	
+
 	if(Eff||Bunny){
 		//Bunny ears baseplate
 		fTargetWheelIndentDepth= 1.4*CLHEP::mm;
 		fTargetWheelTargetHoleRad=9*CLHEP::mm;
 	}else{
-// 		Evaporator targets Z=0
+		// 		Evaporator targets Z=0
 		fTargetWheelIndentDepth= 0.4*CLHEP::mm;
 		fTargetWheelTargetHoleRad=5*CLHEP::mm;
 	}
 	//Old 5 hole "superman" baseplate
-// 	fTargetWheelTargetPos[1]=1;
-// 	fTargetWheelTargetPos[3]=1;
-// 	fTargetWheelTargetPos[5]=1;
-// 	fTargetWheelIndentDepth= 1.4*CLHEP::mm;
-// 	fTargetWheelTargetHoleRad=6*CLHEP::mm;
-	
-	
+	// 	fTargetWheelTargetPos[1]=1;
+	// 	fTargetWheelTargetPos[3]=1;
+	// 	fTargetWheelTargetPos[5]=1;
+	// 	fTargetWheelIndentDepth= 1.4*CLHEP::mm;
+	// 	fTargetWheelTargetHoleRad=6*CLHEP::mm;
+
+
 	//Collimator
 	fTargColRadius1=1*CLHEP::mm;
 	fTargColRadius2=2.5*CLHEP::mm;
@@ -261,7 +257,7 @@ ApparatusSpiceTargetChamber::ApparatusSpiceTargetChamber(G4String Options)//para
 	fTargColPlateThick=1*CLHEP::mm;
 	fTargColPlateFlat=10.8*CLHEP::mm;
 	fTargColPlateRad=19.8*CLHEP::mm;
-	
+
 	fTargetWheelOffset = fTargetOffsetRadius;
 
 	// Gears
@@ -287,7 +283,7 @@ ApparatusSpiceTargetChamber::ApparatusSpiceTargetChamber(G4String Options)//para
 	// Targets
 	fBunnyTargetThickness=0.5*CLHEP::mm;
 	fBunnyRodLength=7.5*CLHEP::mm;
-	
+
 	fEvapTargetThickness=0.5*CLHEP::mm;
 	fEvapTargetRadius=9.0*CLHEP::mm;
 	fEvapTargetInner=4.0*CLHEP::mm;
@@ -296,7 +292,7 @@ ApparatusSpiceTargetChamber::ApparatusSpiceTargetChamber(G4String Options)//para
 	fEvapTargetTabIndent=1.6*CLHEP::mm;
 	fEvapTargetScrewRad=2.0*CLHEP::mm;
 	fEvapTargetScrewHeight=1.6*CLHEP::mm;
-	
+
 	// ------------------------------------------
 	// Dimensions of Magnet Cover
 	// ------------------------------------------
@@ -306,20 +302,20 @@ ApparatusSpiceTargetChamber::ApparatusSpiceTargetChamber(G4String Options)//para
 	fPsClampThicknessInner = 3*CLHEP::mm;
 	fPsClampThicknessOuter = -4.9*CLHEP::mm;
 	fPsClampThicknessFace = 1*CLHEP::mm;
-	
+
 	// Note both Magnets & Magnet Cover overlap with Target Chamber
 	// This was much easier than making the relevant cut-outs of Target Chamber & Magnet Cover
 	// The exposed not overlapped geometries are correct as a result.
-	
+
 	//---------------------
 	// Dimensions of Magnet
 	//---------------------
-	
+
 	fPlateOneThickness = 3*CLHEP::mm;
 	fPlateOneLength = 75*CLHEP::mm; 
 	fPlateOneHeight = 50*CLHEP::mm; // z-component
 	fPlateOneLowerHeight = 20*CLHEP::mm;
-	
+
 	if(BuildMEL){
 		fPlateTwoThickness = 3.4*CLHEP::mm; // LEL is 5.0, MEL is 3.4
 		fPlateTwoLength = 55.0*CLHEP::mm; // LEL is 30.0, MEL is 55.0
@@ -330,22 +326,22 @@ ApparatusSpiceTargetChamber::ApparatusSpiceTargetChamber(G4String Options)//para
 	fPlateTwoHeight = fPlateOneHeight;
 
 	fCuttingBoxAngle = 60*CLHEP::deg;
-	
+
 	//Z direction of magnet nearest edge to Z=0 mm (actual target may be elsewhere)
 	fMagDistanceFromTarget =fTargetChamberDistanceFromTarget+fTargetChamberCylinderLipThickness-fTargetChamberMagnetIndent;
 
 	fMagnetRadiusClampOffset = 2.4*CLHEP::mm;
-	
+
 	//Radial distance to the outer edge of the magnet
 	fPlateOneEdgeX = (fTargetChamberCylinderFlatRadius - fPlateOneLength -fMagnetRadiusClampOffset); 
-	
+
 	// ------------------------------------
 	// Dimensions of Magnet Clamp (Chamber)
 	// ------------------------------------
 	fMclampChamberThickness = fPlateOneThickness+fPlateTwoThickness*2+7.1*CLHEP::mm;
 	fMclampChamberLength = 6.5*CLHEP::mm;
 	fMclampChamberHeight = fTargetChamberCylinderLength-fTargetChamberCylinderLipThickness;
-	
+
 	//----------------------------
 	// Dimensions of Photon Shield
 	//----------------------------
@@ -360,7 +356,7 @@ ApparatusSpiceTargetChamber::ApparatusSpiceTargetChamber(G4String Options)//para
 	fPhotonShieldLayerThreeThickness = fPhotonShieldLength-fPhotonShieldLayerOneThickness-fPhotonShieldLayerTwoThickness;
 
 	fPsClampTabHeight = fPhotonShieldLength;
-	
+
 	// ----------------------------------
 	// Dimensions of Photon Shield Clamps
 	// ----------------------------------
@@ -376,7 +372,7 @@ ApparatusSpiceTargetChamber::ApparatusSpiceTargetChamber(G4String Options)//para
 	// ---------------------------------
 	fPsBoltHoleRadius = 1.7*CLHEP::mm;
 	fPsBoltPlaceRadius = 9*CLHEP::mm;
-	
+
 	fPsBoltLength=50*CLHEP::mm;
 	fPsBoltRadius=1.5*CLHEP::mm;
 	fPsBoltBackShield=10.5*CLHEP::mm;
@@ -391,7 +387,7 @@ ApparatusSpiceTargetChamber::ApparatusSpiceTargetChamber(G4String Options)//para
 	// --------------------------
 	// Dimensions of Source 
 	// --------------------------
-	
+
 	fEffSourceHolderHeight=8.7*CLHEP::mm;
 	fEffSourceHolderRad=15.875*CLHEP::mm;
 	fEffSourceHolderInner=9.475*CLHEP::mm;
@@ -404,12 +400,12 @@ ApparatusSpiceTargetChamber::ApparatusSpiceTargetChamber(G4String Options)//para
 	fMEezagSourceRad=12.2*CLHEP::mm;
 	fMEezagSourceWall=0.5*CLHEP::mm;
 	fMEezagSourceRim=3.*CLHEP::mm;
-	
-	
+
+
 	G4Material* MatAc = G4Material::GetMaterial("Acrylic");
 	G4double fMEezagSourceAcrylic=0.2*CLHEP::mg / CLHEP::cm2;
 	fMEezagSourceAcrylicLength=fMEezagSourceAcrylic/MatAc->GetDensity();
-	
+
 	fBracketSideLength = 19.5*mm;
 	fBracketBackLength = 30.7*mm;
 	fBracketDepth = 3.2*mm;
@@ -419,34 +415,34 @@ ApparatusSpiceTargetChamber::ApparatusSpiceTargetChamber(G4String Options)//para
 	fBracketAngle = 180.*CLHEP::deg;
 	fBracketScrewRad = 2.9*mm;
 	fBracketScrewHeight = 2.5*mm;
-	
+
 	if(Eff){
 		fMEezagSourceZ=fTargetWheelFaceZ-fEffSourceHolderHeight+fMEezagSourceHeight/2.;
-	// 	fMEezagSourceZ=fTargetWheelFaceZ-fEffSourceHolderHeight+fEffSourceHoldPocket-fMEezagSourceHeight/2.;
+		// 	fMEezagSourceZ=fTargetWheelFaceZ-fEffSourceHolderHeight+fEffSourceHoldPocket-fMEezagSourceHeight/2.;
 	}else{		
 		fMEezagSourceZ=-fTargetChamberDistanceFromTarget+fMountPlateRodLength-11*CLHEP::mm-fMEezagSourceHeight/2.;
 	}
 	fMEezagSourceActiveZ=fMEezagSourceZ-fMEezagSourceHeight/2.+fMEezagSourceWall;
-	
+
 	// --------------------------------
 	// Dimensions of Conical Collimator
 	// --------------------------------
-	 fConicalInnerRad1=2.9*CLHEP::mm;
-	 fConicalInnerRad2=3.15*CLHEP::mm;
-	 fConicalOuterRad1=4.9*CLHEP::mm;
-	 fConicalOuterRad2=4.5*CLHEP::mm;
-	 fConicalLength1=15.5*CLHEP::mm;
-	 fConicalLength2=13*CLHEP::mm;
-	 fConicalLength3=12*CLHEP::mm;
-	 fConicalTabRad=6.9*CLHEP::mm;
-	 fConicalTabHeight=2*CLHEP::mm;
-	 fConicalTabWidth=4*CLHEP::mm;
+	fConicalInnerRad1=2.9*CLHEP::mm;
+	fConicalInnerRad2=3.15*CLHEP::mm;
+	fConicalOuterRad1=4.9*CLHEP::mm;
+	fConicalOuterRad2=4.5*CLHEP::mm;
+	fConicalLength1=15.5*CLHEP::mm;
+	fConicalLength2=13*CLHEP::mm;
+	fConicalLength3=12*CLHEP::mm;
+	fConicalTabRad=6.9*CLHEP::mm;
+	fConicalTabHeight=2*CLHEP::mm;
+	fConicalTabWidth=4*CLHEP::mm;
 
-	
+
 	// --------------------------
 	// Dimensions of X-ray Insert
 	// --------------------------
-		
+
 	fInsertCylOuterRadius=8.5*CLHEP::mm;
 	fInsertCylInnerRadius=4.55*CLHEP::mm;
 	fInsertCylZLength=3.2*CLHEP::mm;
@@ -565,10 +561,10 @@ void ApparatusSpiceTargetChamber::Build(G4LogicalVolume* expHallLog)
 
 	BuildS3CableHolder();
 	PlaceS3CableHolder(expHallLog);
-	
+
 	BuildTargetChamberCylinderDownstream(BuildMEL);
 	PlaceTargetChamberCylinderDownstream(expHallLog); 
-	
+
 	if(!Empty){
 		BuildMagnetClampChamber();
 		BuildCollectorMagnetandCover();
@@ -577,16 +573,16 @@ void ApparatusSpiceTargetChamber::Build(G4LogicalVolume* expHallLog)
 			PlaceMagnetAndCover(copyID, expHallLog);
 			PlacePhotonShieldClampBolts(copyID, expHallLog);
 		}
-		
+
 		BuildPhotonShield();
 		PlacePhotonShield(expHallLog); 
-		
+
 		BuildShieldCovering();
 		PlaceShieldCovering(expHallLog);
 
 		BuildPhotonShieldClamps();
 		PlacePhotonShieldClamps(expHallLog);
-		
+
 		if(Col){
 			BuildConicalCollimator();
 			PlaceConicalCollimator(expHallLog);
@@ -594,29 +590,28 @@ void ApparatusSpiceTargetChamber::Build(G4LogicalVolume* expHallLog)
 			PlaceXrayInsert(expHallLog);
 		}
 	}
-	
+
 	BuildTargetWheel();
 	PlaceTargetWheel(expHallLog); 	
 	if(!Light){
 		BuildGearStick();
 		PlaceGearStick(expHallLog); 
-		
+
 		BuildTargetMountPlate();
 		PlaceTargetMountPlate(expHallLog); 		
-		
+
 		if(!Source){
 			BuildTargetWheelGears();
 			PlaceTargetWheelGears(expHallLog); 
-			
+
 			BuildTargetWheelGearPlates();
 			PlaceTargetWheelGearPlates(expHallLog); 
-			
+
 			BuildCollimator();		
 			PlaceCollimator(expHallLog); 
 		}
 	}
-	
-	
+
 	if(Bunny){
 		BuildBunnyTarget();
 		PlaceBunnyTargets(expHallLog);
@@ -629,9 +624,6 @@ void ApparatusSpiceTargetChamber::Build(G4LogicalVolume* expHallLog)
 		BuildEvapTarget();
 		PlaceEvapTargets(expHallLog);
 	}
-
-	
-
 } // end Build
 
 ////////////////////////////////////////////////////
@@ -648,7 +640,7 @@ void ApparatusSpiceTargetChamber::BuildBunnyTarget() {
 	G4double sDimOuterRadius = 7.00*CLHEP::mm;
 	G4double sDimInnerRadius = 4.00*CLHEP::mm;
 	G4double sDimHalfThick = fBunnyTargetThickness/2.;
-	
+
 	// Shapes
 	G4Tubs* sTubs = new G4Tubs("sTubs", sDimInnerRadius, sDimOuterRadius, sDimHalfThick, 0, 360.*CLHEP::deg);
 	G4Tubs* sLimit = new G4Tubs("sLimit", 20.648, 25.0, 2*sDimHalfThick, 0, 360.*CLHEP::deg);
@@ -658,10 +650,10 @@ void ApparatusSpiceTargetChamber::BuildBunnyTarget() {
 
 	G4Box* sBox = new G4Box("sBox", 2.0*CLHEP::mm, 1.0*CLHEP::mm, sDimHalfThick);
 	G4Tubs* sRound = new G4Tubs("sTubs", 0, 1.0*CLHEP::mm, sDimHalfThick, -90.*CLHEP::deg, 180.*CLHEP::deg);
-	
-	
+
+
 	G4UnionSolid* sRoundBox = new G4UnionSolid("sRoundBox", sBox, sRound, 0, G4ThreeVector(2.0*CLHEP::mm,0,0));
-	
+
 	G4ThreeVector RoundP(8.0*CLHEP::mm, 0., 0.);
 	G4RotationMatrix* sRotate = new G4RotationMatrix;
 	sRotate->rotateZ(45.*CLHEP::deg);
@@ -677,9 +669,9 @@ void ApparatusSpiceTargetChamber::BuildBunnyTarget() {
 	G4Material* sMaterial = G4Material::GetMaterial("Aluminum");
 	fFrameLogical = new G4LogicalVolume(sUnion2, sMaterial, "TargetFrame", 0, 0, 0);
 	fFrameLogical->SetVisAttributes(sVisAtt);
-	
+
 	//Build Rods
-	
+
 	// Visualisation
 	sVisAtt = new G4VisAttributes(G4Colour(AL_COL));
 	sVisAtt->SetVisibility(true);
@@ -694,7 +686,6 @@ void ApparatusSpiceTargetChamber::BuildBunnyTarget() {
 	sMaterial = G4Material::GetMaterial(fTargetWheelMaterial);
 	fRodLogical = new G4LogicalVolume(sRodTubs, sMaterial, "TargetRodsLog", 0, 0, 0);
 	fRodLogical->SetVisAttributes(sVisAtt);
-	
 }
 
 void ApparatusSpiceTargetChamber::BuildEvapTarget(){
@@ -705,27 +696,27 @@ void ApparatusSpiceTargetChamber::BuildEvapTarget(){
 	// Dimensions
 	G4double sDimHalfThick = fEvapTargetThickness/2.;
 	G4double sTabHeightHalf = (fEvapTargetTabExtra+fEvapTargetRadius-fEvapTargetInner)/2.;
-	
+
 	// Shapes
 	G4Tubs* sTubs = new G4Tubs("sTubs", fEvapTargetInner, fEvapTargetRadius, sDimHalfThick, 0, 360.*CLHEP::deg);
 	G4Box* sTab = new G4Box("sTab",fEvapTargetTabWidth/2.,sTabHeightHalf, sDimHalfThick);
 
 	G4ThreeVector sTrans(0., -(sTabHeightHalf+fEvapTargetInner), 0.);
 	G4UnionSolid* sSub = new G4UnionSolid("sSub", sTubs, sTab, 0, sTrans);
-	
+
 
 	G4Box* sBox = new G4Box("sBox", fEvapTargetTabIndent,fEvapTargetTabExtra, fEvapTargetThickness);
 	G4Tubs* sRound = new G4Tubs("sTubs", 0, fEvapTargetTabIndent, fEvapTargetThickness, 0, 180.*CLHEP::deg);
-	
+
 	G4UnionSolid* sRoundBox = new G4UnionSolid("sRoundBox", sRound, sBox, 0, G4ThreeVector(0,-fEvapTargetTabExtra,0));
-	
+
 	G4SubtractionSolid* sTarg = new G4SubtractionSolid("sTarg", sSub, sRoundBox, 0, G4ThreeVector(0,-fEvapTargetRadius,0));
-	
+
 	// Logical
 	G4Material* sMaterial = G4Material::GetMaterial("Aluminum");
 	fFrameLogical = new G4LogicalVolume(sTarg, sMaterial, "TargetFrame", 0, 0, 0);
 	fFrameLogical->SetVisAttributes(sVisAtt);
-	
+
 	//Build Rods
 
 	// Visualisation
@@ -848,7 +839,7 @@ void ApparatusSpiceTargetChamber::BuildTargetChamberCylinderDownstream(bool MEL)
 	G4double FlatHalfZ = length;
 	G4double FlatHalfY = sqrt(pow(fTargetChamberCylinderInnerRadius,2)-pow(fTargetChamberCylinderFlatRadius,2));
 	G4double FlatHalfX = (fTargetChamberCylinderInnerRadius-fTargetChamberCylinderFlatRadius)/2.;	
-	
+
 	G4double MELTabHalfZ = TargetLipLength;
 	G4double MELTabHalfY = fTargetChamberMELTabWidth/2.;
 	G4double MELTabHalfX = fTargetChamberMELTabWidth;
@@ -861,10 +852,10 @@ void ApparatusSpiceTargetChamber::BuildTargetChamberCylinderDownstream(bool MEL)
 	G4Box* TargetLipCuttingBox = new G4Box("TargetLipCuttingBox", LipCuttingHalfX, LipCuttingHalfY, LipCuttingHalfZ);
 	G4Box* CylinderFlatBox = new G4Box("CylinderFlatBox", FlatHalfX, FlatHalfY, FlatHalfZ);
 	G4Box* MELTabBox = new G4Box("MELTabBox", MELTabHalfX, MELTabHalfY, MELTabHalfZ);
-	
+
 	// Union
-	
-	
+
+
 	G4VSolid* Lip=TargetLipCylinder;
 	G4VSolid* MainCylinderFlats=MainCylinder;
 	for(int i=0;i<4;i++){
@@ -873,14 +864,14 @@ void ApparatusSpiceTargetChamber::BuildTargetChamberCylinderDownstream(bool MEL)
 		G4ThreeVector trans(fTargetChamberCylinderFlatRadius+FlatHalfX,0,0);
 		trans.rotateZ(ang);
 		MainCylinderFlats = new G4UnionSolid("MainCylinderFlats", MainCylinderFlats, CylinderFlatBox, rotate, trans);
-		
+
 		if(MEL){
 			G4ThreeVector transs(fTargetChamberMELTabRad+MELTabHalfX,0,0);
 			transs.rotateZ(ang);
 			Lip = new G4UnionSolid("TargetDetChamber", Lip, MELTabBox, rotate, transs);
 		}
 	}
-	
+
 	G4ThreeVector trans(0,0, length-TargetLipLength);
 	G4UnionSolid* TargetDetCylinderPre = new G4UnionSolid("TargetDetCylinderPre", MainCylinderFlats, Lip, 0, trans);
 	trans.setZ(-(length-DetectorLipLength));
@@ -890,17 +881,6 @@ void ApparatusSpiceTargetChamber::BuildTargetChamberCylinderDownstream(bool MEL)
 	trans.setZ(length-TargetLipLength);
 	G4RotationMatrix* rotate = new G4RotationMatrix(-111.8*CLHEP::deg , 0, 0);
 	G4VSolid* TargetDetChamber = new G4SubtractionSolid("TargetDetChamber", TargetDetCylinder, TargetLipCuttingBox, rotate, trans);
-	
-// 	for(int i=0;i<4;i++){
-
-// 		
-// // 		if(MEL){
-// 			trans=G4ThreeVector(fTargetChamberMELTabRad+MELTabHalfX,0,length-TargetLipLength);
-// 			trans.rotateZ(ang);
-// 			TargetDetChamber = new G4UnionSolid("TargetDetChamber", TargetDetChamber, MELTabBox, rotate, trans);
-// // 		}
-// 	}
-	
 
 	// ** Logical Volume
 	G4Material* cylinderMaterial = G4Material::GetMaterial(fTargetChamberMaterial);
@@ -923,12 +903,12 @@ void ApparatusSpiceTargetChamber::BuildTargetWheel(){
 	// ** Shapes
 	G4Tubs* TargetWheelBase = new G4Tubs("TargetWheelBase", 0, fTargetWheelRadius, WheelHalfThickPlate, 0, 360*CLHEP::deg);
 	G4Tubs* targethole = new G4Tubs("targethole", 0, fTargetWheelTargetHoleRad, fTargetWheelThickness, 0, 360*CLHEP::deg);
-	
+
 	G4Tubs* ring1 = new G4Tubs("ring1", fTargetWheelIndentRadius, fTargetWheelRadius, WheelHalfThickRing1, 0, 360*CLHEP::deg);
 	G4Tubs* ring2 = new G4Tubs("ring2", fTargetWheelExtInnerRad1, fTargetWheelRadius, WheelHalfThickRing2, 0, 360*CLHEP::deg);
 	G4Tubs* ring3 = new G4Tubs("ring3", fTargetWheelExtInnerRad2, fTargetWheelRadius, WheelHalfThickRing3, 0, 360*CLHEP::deg);
 	G4Tubs* ring4 = new G4Tubs("ring4", fTargetWheelExtInnerRad2, fTargetWheelExtBaseRad, WheelHalfThickRing4, 0, 360*CLHEP::deg);
-	
+
 	G4VSolid* TargetWheel=TargetWheelBase;
 	for(int i=0;i<6;i++){
 		if(!fTargetWheelTargetPos[i])continue;
@@ -936,13 +916,13 @@ void ApparatusSpiceTargetChamber::BuildTargetWheel(){
 		trans.rotateZ(fTargetWheelHoleSpaceAng*i);
 		TargetWheel= new G4SubtractionSolid("TargetWheel", TargetWheel, targethole, 0, trans);
 	}
-	
+
 	G4double colholerad=fTargColRadius2+1.0*mm;
 	G4Box* colrect = new G4Box("colrect",fTargColHoleHalfSep,colholerad, fTargetWheelThickness);
 	G4Tubs* colcurv = new G4Tubs("colcurv", 0, colholerad, fTargetWheelThickness, 0, 360*CLHEP::deg);
 	G4UnionSolid* collimator = new G4UnionSolid("collimator", colrect, colcurv, 0, G4ThreeVector(fTargColHoleHalfSep+0.1*mm,0,0));
 	collimator = new G4UnionSolid("collimator", collimator, colcurv, 0, G4ThreeVector(-(fTargColHoleHalfSep+0.1*mm),0,0));
-	
+
 	G4double collimatoroffser=sqrt(pow(fTargetOffsetRadius,2)-pow(fTargColHoleHalfSep,2));
 	TargetWheel= new G4SubtractionSolid("TargetWheel", TargetWheel, collimator, 0, G4ThreeVector(0,-collimatoroffser,0));
 
@@ -969,24 +949,22 @@ void ApparatusSpiceTargetChamber::BuildCollimator() {
 	sVisAtt->SetVisibility(true);	
 
 	// Dimensions
-
-	
 	G4Tubs* platearc = new G4Tubs("platearc", 0, fTargColPlateRad, fTargColPlateThick/2., (270*CLHEP::deg)-(fTargColPlateAng/2.),fTargColPlateAng);
-	
-	
+
+
 	G4double flatdist=fTargColPlateFlat/(2*tan(fTargColPlateAng/2.));
 	G4Box* sRectangle = new G4Box("sRectangle", flatdist*2, flatdist,fTargColPlateThick);
-	
+
 	G4SubtractionSolid* plate = new G4SubtractionSolid("plate", platearc, sRectangle, 0, G4ThreeVector(0,0,0));
-	
+
 	G4double collimatoroffser=sqrt(pow(fTargetOffsetRadius,2)-pow(fTargColHoleHalfSep,2));
 	G4Tubs* sTubs1 = new G4Tubs("sTubs1", 0., fTargColRadius1, fTargColPlateThick, 0., 360.*CLHEP::deg);
 	G4SubtractionSolid* sSub = new G4SubtractionSolid("sSub", plate, sTubs1, 0, G4ThreeVector(-fTargColHoleHalfSep,-collimatoroffser,0));
 
 	G4Tubs* sTubs5 = new G4Tubs("sTubs5", 0., fTargColRadius2,fTargColPlateThick, 0., 360.*CLHEP::deg);
 	G4SubtractionSolid* sSub2 = new G4SubtractionSolid("sSub2", sSub, sTubs5, 0, G4ThreeVector(fTargColHoleHalfSep,-collimatoroffser,0));	
-	
-	
+
+
 	// Logical
 	G4Material* CollimatorMaterial = G4Material::GetMaterial("Titanium"); 
 	fCollimLogical = new G4LogicalVolume(sSub2, CollimatorMaterial, "collimator", 0, 0, 0);
@@ -1082,7 +1060,7 @@ void ApparatusSpiceTargetChamber::BuildTargetMountPlate(){
 	G4Material* targetMountPlateMaterial = G4Material::GetMaterial(fTargetMountPlateMaterial);
 	fTargetMountPlateLog = new G4LogicalVolume(MountPlate, targetMountPlateMaterial, "TargetMountPlateLog", 0, 0, 0);
 	fTargetMountPlateLog->SetVisAttributes(VisAtt);
-	
+
 	G4Tubs* MountRod = new G4Tubs("MountRod", 0, fMountPlateRodRadius, fMountPlateRodLength/2., 0, 360*CLHEP::deg);
 	fTargetMountRodLog = new G4LogicalVolume(MountRod, targetMountPlateMaterial, "MountRodLog", 0, 0, 0);
 	fTargetMountRodLog->SetVisAttributes(VisAtt);	
@@ -1202,8 +1180,8 @@ void ApparatusSpiceTargetChamber::BuildShieldCovering()
 	G4double BackOuterRadius = fPhotonShieldBackRadius;
 	G4double HalfLength = fPhotonShieldLength/2.;  
 	G4Cons* PhotonShield = new G4Cons("PhotonShield", (BackOuterRadius + 0.1*CLHEP::mm), (BackOuterRadius + 0.2*CLHEP::mm),(FrontOuterRadius + 0.1*CLHEP::mm),
-					  (FrontOuterRadius + 0.2*CLHEP::mm), HalfLength, 0, 2*CLHEP::pi);//made smaller
-	
+			(FrontOuterRadius + 0.2*CLHEP::mm), HalfLength, 0, 2*CLHEP::pi);//made smaller
+
 	/*// ------ 																							
 	// Photon Shield Clamps
 	// -- Dimensions  																							
@@ -1223,16 +1201,16 @@ void ApparatusSpiceTargetChamber::BuildShieldCovering()
 	// ------*/
 
 
-/*	// ** Build Shield Covering
-	G4double theta = atan(2 * HalfLength / (BackOuterRadius - FrontOuterRadius));
-	G4double alpha = 90*CLHEP::deg - theta;
-	G4double CoverFrontRadius = FrontOuterRadius - (fShieldCoatingThickness / tan(theta)) +
+	/*	// ** Build Shield Covering
+		G4double theta = atan(2 * HalfLength / (BackOuterRadius - FrontOuterRadius));
+		G4double alpha = 90*CLHEP::deg - theta;
+		G4double CoverFrontRadius = FrontOuterRadius - (fShieldCoatingThickness / tan(theta)) +
 		(fShieldCoatingThickness * cos(alpha));
-	G4double CoverBackRadius = BackOuterRadius + (fShieldCoatingThickness / tan(theta)) +
+		G4double CoverBackRadius = BackOuterRadius + (fShieldCoatingThickness / tan(theta)) +
 		(fShieldCoatingThickness * cos(alpha));
 
-	G4Cons* ShieldCoverPre = new G4Cons("ShieldCoverPre", 0, CoverBackRadius, 0, CoverFrontRadius,	
-			HalfLength + fShieldCoatingThickness, 0, 2*CLHEP::pi);
+		G4Cons* ShieldCoverPre = new G4Cons("ShieldCoverPre", 0, CoverBackRadius, 0, CoverFrontRadius,	
+		HalfLength + fShieldCoatingThickness, 0, 2*CLHEP::pi);
 
 	// ** Deduct Shield from Cover
 	G4SubtractionSolid* ShieldCover = new G4SubtractionSolid("ShieldCover", ShieldCoverPre, PhotonShield_3);//LOOP*/
@@ -1307,7 +1285,7 @@ void ApparatusSpiceTargetChamber::BuildPhotonShieldClamps() {
 		G4ThreeVector move(fPsTargetClampExtension-ExtHalfLength, 0, 0);
 		move.rotateZ(-Ang);
 		TargetEndClamp = new G4UnionSolid("TargetClamp", TargetEndClamp, TargetClampExt,rotation,move);
-		
+
 		G4ThreeVector boltplace(fPsBoltPlaceRadius, 0, 0);
 		boltplace.rotateZ(-Ang);
 		TargetEndClamp = new G4SubtractionSolid("TargetClamp", TargetEndClamp, TargetBolt,0,boltplace);
@@ -1328,16 +1306,16 @@ void ApparatusSpiceTargetChamber::BuildPhotonShieldClampBolts() {
 	G4VisAttributes* SmallVisAtt = new G4VisAttributes(G4Colour(CU_COL));
 	SmallVisAtt->SetVisibility(true);
 
-// 	// ** Dimensions
-	
+	// 	// ** Dimensions
+
 	G4double BoltHalfLength = fPsBoltLength/2.;
 	G4double NutHalfLength = fPsNutLength/2.;
-	
+
 	G4Tubs* BoltShaft = new G4Tubs("BoltShaft", 0, fPsBoltRadius, BoltHalfLength, 0, 360*CLHEP::deg);
 	G4Tubs* Nut = new G4Tubs("Nut", 0, fPsNutRad, NutHalfLength, 0, 360*CLHEP::deg);
 	G4ThreeVector BoltVecOne(0,0,-BoltHalfLength+fPsBoltBackShield-fPsDetClampThickness-NutHalfLength);
 	G4ThreeVector BoltVecTwo(0,0,-BoltHalfLength+fPsBoltBackShield+fPhotonShieldLength+fPsTargetClampThickness+NutHalfLength);
-	
+
 	G4UnionSolid* TargetBolt1 = new G4UnionSolid("TargetBolt1", BoltShaft, Nut, 0, BoltVecOne);
 	G4UnionSolid* TargetBolt2 = new G4UnionSolid("TargetBolt2", TargetBolt1, Nut, 0, BoltVecTwo);
 
@@ -1350,7 +1328,6 @@ void ApparatusSpiceTargetChamber::BuildPhotonShieldClampBolts() {
 
 void ApparatusSpiceTargetChamber::BuildCollectorMagnetandCover()
 {
-
 	// ** Visualisation
 	G4VisAttributes* VisAtt = new G4VisAttributes(G4Colour(NDFEB_COL));
 	VisAtt->SetVisibility(true);
@@ -1361,7 +1338,7 @@ void ApparatusSpiceTargetChamber::BuildCollectorMagnetandCover()
 	G4Box* PlateOneCutBox = new G4Box("PlateOneCutBox", fPlateOneLength/2., 
 			fPlateOneThickness/2. + 1., fPlateOneHeight/2.);
 
-	// ( Cut box is rotated and moved, exact movement calculated below )
+	// (Cut box is rotated and moved, exact movement calculated below)
 	G4double AngleToCorner = atan(fPlateOneLength/fPlateOneHeight);
 	G4double HypotenuseToCorner = sqrt(pow(fPlateOneHeight/2., 2) + pow(fPlateOneLength/2., 2));
 	G4double AngleDifference, TranslateCutX, TranslateCutZ;
@@ -1371,7 +1348,7 @@ void ApparatusSpiceTargetChamber::BuildCollectorMagnetandCover()
 		TranslateCutZ = (HypotenuseToCorner * cos(AngleDifference)) - fPlateOneHeight/2.
 			+ fPlateOneLowerHeight;
 	}
-// 	else if(AngleToCorner > fCuttingBoxAngle)
+	// 	else if(AngleToCorner > fCuttingBoxAngle)
 	else
 	{
 		AngleDifference = AngleToCorner - fCuttingBoxAngle;
@@ -1398,7 +1375,7 @@ void ApparatusSpiceTargetChamber::BuildCollectorMagnetandCover()
 	G4Material* magnetMaterial = G4Material::GetMaterial(fMagnetMaterial);
 	fMagnetLog = new G4LogicalVolume(PlateCombo, magnetMaterial, "MagnetLog", 0, 0, 0);
 	fMagnetLog->SetVisAttributes(VisAtt);
-	
+
 	BuildMagnetCovering(PlateCombo);
 } // end:BuildCollectorMagnet()
 
@@ -1411,7 +1388,7 @@ void ApparatusSpiceTargetChamber::BuildMagnetCovering(G4VSolid* Magnet)
 	G4double PlateOneHalfLength = (fPlateOneLength+fPsClampThicknessInner+fPsClampThicknessOuter)/2;
 	G4double PlateOneHalfThickness  = (fPlateOneThickness/2.)+fPsClampThicknessFace;
 	G4double PlateOneHalfHeight = (fPlateOneHeight+fPsClampThicknessBottom+fPsClampThicknessTop)/2; 
-	
+
 	// ** Build Plate One
 	G4Box* PlateOnePreCut = new G4Box("PlateOnePreCut", PlateOneHalfLength, 
 			PlateOneHalfThickness, PlateOneHalfHeight);
@@ -1425,47 +1402,47 @@ void ApparatusSpiceTargetChamber::BuildMagnetCovering(G4VSolid* Magnet)
 	CutBottomCornerZ-=(fPlateOneLowerHeight+cos(fCuttingBoxAngle)*fPsClampThicknessCut);
 
 	G4ThreeVector CutBottomCorner(-CutBottomCornerX, 0,-CutBottomCornerZ);
- 	G4ThreeVector Offset(-PlateOneHalfHeight*sin(fCuttingBoxAngle),0,PlateOneHalfHeight*cos(fCuttingBoxAngle));
- 	G4ThreeVector OffsetSlide(PlateOneHalfHeight*0.5*cos(fCuttingBoxAngle),0,PlateOneHalfHeight*0.5*sin(fCuttingBoxAngle));	
-	
+	G4ThreeVector Offset(-PlateOneHalfHeight*sin(fCuttingBoxAngle),0,PlateOneHalfHeight*cos(fCuttingBoxAngle));
+	G4ThreeVector OffsetSlide(PlateOneHalfHeight*0.5*cos(fCuttingBoxAngle),0,PlateOneHalfHeight*0.5*sin(fCuttingBoxAngle));	
+
 	G4ThreeVector TranslateCutBox=CutBottomCorner+Offset+OffsetSlide;
 	G4RotationMatrix* RotateCutBox = new G4RotationMatrix;
 	RotateCutBox->rotateY(fCuttingBoxAngle);
 	G4VSolid* PlateOne = new G4SubtractionSolid("PlateOne", PlateOnePreCut, PlateOneCutBox,
 			RotateCutBox, TranslateCutBox);	
-	
+
 	G4ThreeVector TranslateTabBox(-PlateOneHalfLength+fPsClampTabHeight/2.,0,-PlateOneHalfHeight+fPsClampTabHeight/2.);
 	G4VSolid* PlateOneTab = new G4UnionSolid("PlateOne", PlateOne, PlateOneTabBox,0, TranslateTabBox);		
-	
+
 	G4double PlateTwoHalfLength = (fPlateTwoLength+fPsClampThicknessFace+fPsClampThicknessOuter)/2;
 	G4double PlateTwoHalfThickness  = fPlateTwoThickness+(fPlateOneThickness/2.)+fPsClampThicknessFace;
 	G4double PlateTwoHalfHeight = PlateOneHalfHeight; 
-	
+
 	// ** Build Plate Two
 	G4Box* PlateTwo = new G4Box("PlateTwo", PlateTwoHalfLength,PlateTwoHalfThickness,PlateTwoHalfHeight);
 
 	// ** Combine Plates
 	G4ThreeVector TranslatePlateTwo(PlateOneHalfLength - PlateTwoHalfLength, 0, 0);
 	G4UnionSolid* PlateCombo = new G4UnionSolid("PlateCombo", PlateOneTab, PlateTwo, 0, TranslatePlateTwo);
-	
+
 	G4Material* magnetCoverMaterial = G4Material::GetMaterial(fMagnetCoverMaterial);
-	
+
 	// ** Logical Volume
 	fMagnetCoverLog = new G4LogicalVolume(PlateCombo, magnetCoverMaterial, "MagnetCoverLog", 0, 0, 0);
-	
+
 	//ONLY for viewing internal thickness is correct
-// 	G4Box* xray = new G4Box("xray", 5*cm,5*cm,5*cm);
-// 	G4VSolid* XRAY = new G4SubtractionSolid("MagnetCover", PlateCombo, xray,0,G4ThreeVector(0,-5*cm,0));
-// 	fMagnetCoverLog = new G4LogicalVolume(XRAY, magnetCoverMaterial, "MagnetCoverLog", 0, 0, 0);
-	
-// This is the way it should be done but it has some glitches, so have left overlap with magnet rather than cutout
-// 	G4double MagCoverOffsetX = -(fPsClampThicknessInner-fPsClampThicknessOuter)/2;
-// 	G4double MagCoverOffsetZ = -(fPsClampThicknessBottom-fPsClampThicknessTop)/2; 
-// 	G4ThreeVector MagOffset(MagCoverOffsetX,0,-MagCoverOffsetZ);
-// 	G4VSolid* MagnetCover = new G4SubtractionSolid("MagnetCover", PlateCombo, Magnet,0,MagOffset);
-// 	fMagnetCoverLog = new G4LogicalVolume(MagnetCover, magnetCoverMaterial, "MagnetCoverLog", 0, 0, 0);
+	// 	G4Box* xray = new G4Box("xray", 5*cm,5*cm,5*cm);
+	// 	G4VSolid* XRAY = new G4SubtractionSolid("MagnetCover", PlateCombo, xray,0,G4ThreeVector(0,-5*cm,0));
+	// 	fMagnetCoverLog = new G4LogicalVolume(XRAY, magnetCoverMaterial, "MagnetCoverLog", 0, 0, 0);
+
+	// This is the way it should be done but it has some glitches, so have left overlap with magnet rather than cutout
+	// 	G4double MagCoverOffsetX = -(fPsClampThicknessInner-fPsClampThicknessOuter)/2;
+	// 	G4double MagCoverOffsetZ = -(fPsClampThicknessBottom-fPsClampThicknessTop)/2; 
+	// 	G4ThreeVector MagOffset(MagCoverOffsetX,0,-MagCoverOffsetZ);
+	// 	G4VSolid* MagnetCover = new G4SubtractionSolid("MagnetCover", PlateCombo, Magnet,0,MagOffset);
+	// 	fMagnetCoverLog = new G4LogicalVolume(MagnetCover, magnetCoverMaterial, "MagnetCoverLog", 0, 0, 0);
 	Magnet->GetName();//Just here to suppress warning;
-	
+
 	fMagnetCoverLog->SetVisAttributes(VisAtt);
 }
 
@@ -1497,7 +1474,7 @@ void ApparatusSpiceTargetChamber::BuildMagnetClampChamber(){
 	fMclampChamberLog = new G4LogicalVolume(MagnetClamp, clampMaterial, "MagnetClampChamberLog", 0, 0, 0);
 	fMclampChamberLog->SetVisAttributes(VisAtt);
 } // end::BuildMagnetClampChamber()
-	
+
 
 void ApparatusSpiceTargetChamber::BuildElectroBox()
 {
@@ -1559,7 +1536,7 @@ void ApparatusSpiceTargetChamber::BuildS3CableHolder()
 
 	// Dimensions
 	// Shapes
-// 	G4Box* sBox = new G4Box("sBox", 8.1*CLHEP::mm, 12.*CLHEP::mm, 40.5*CLHEP::mm);
+	// 	G4Box* sBox = new G4Box("sBox", 8.1*CLHEP::mm, 12.*CLHEP::mm, 40.5*CLHEP::mm);
 	G4Box* sBox = new G4Box("sBox", 6.3*CLHEP::mm, 12.*CLHEP::mm, fTargetChamberCylinderLength/2.);
 
 	// Logical
@@ -1601,7 +1578,7 @@ void ApparatusSpiceTargetChamber::BuildConicalCollimator() {
 }
 
 void ApparatusSpiceTargetChamber::BuildXrayInsert(){
-  	G4VisAttributes* sVisAtt = new G4VisAttributes(G4Colour(CU_COL));
+	G4VisAttributes* sVisAtt = new G4VisAttributes(G4Colour(CU_COL));
 	sVisAtt->SetVisibility(true);
 
 	G4Cons* InnerCone = new G4Cons("InnerCone",fInsertConeR1, fInsertCylInnerRadius, fInsertConeR2, fInsertCylInnerRadius,fInsertConeZLength/2., 0, 2*CLHEP::pi);
@@ -1621,19 +1598,19 @@ void ApparatusSpiceTargetChamber::BuildXrayInsert(){
 		moveH.rotateZ(90*CLHEP::deg);
 		topcyl = new G4SubtractionSolid("topcyl", topcyl, solid_insert_holes, 0, moveH);
 	}
-	
+
 	G4SubtractionSolid* edgetrim = new G4SubtractionSolid("edgetrim", topcyl, OuterCut, 0, G4ThreeVector());
 	G4UnionSolid* incone = new G4UnionSolid("incone", edgetrim, InnerCone, 0, G4ThreeVector(0,0,(fInsertConeZLength-fInsertCylZLength)/2.));
 
- 
-  	G4VSolid* fullcyl =incone;
+
+	G4VSolid* fullcyl =incone;
 	G4ThreeVector moveR(0, 0, (fInsertCylZLength+fInsertEdgeZLength)/2.);
 	G4RotationMatrix* sRotate1 = new G4RotationMatrix();
 	for(int i=0;i<4;i++){
 		sRotate1->rotateZ(90*CLHEP::deg);
 		fullcyl = new G4UnionSolid("fullcyl", fullcyl, solid_insert_edges, sRotate1, moveR);
 	}
-	
+
 	// ** Logical  
 	G4Material* sMaterial = G4Material::GetMaterial(this->fXRayInsertMaterial);
 	fXRayInsertLog = new G4LogicalVolume(fullcyl,sMaterial,"fXRayInsertLog");
@@ -1644,15 +1621,15 @@ void ApparatusSpiceTargetChamber::BuildXrayInsert(){
 
 
 void ApparatusSpiceTargetChamber::BuildPlaceEfficiencySource(G4LogicalVolume* expHallLog){
-	
+
 	//Build shapes for the source holder
-	
+
 	G4double base=fEffSourceHolderHeight-fEffSourceHoldPocket;
 	G4Tubs* Base = new G4Tubs("Base", fEffSourceHolderInner,fEffSourceHolderRad, base/2., 0, 360*CLHEP::deg);
 	G4Tubs* Pocket = new G4Tubs("insert_cyl", fEffSourceHoldPocketRad, fEffSourceHolderRad, fEffSourceHoldPocket/2., 0, 360*CLHEP::deg);
 	G4UnionSolid* Teflon = new G4UnionSolid("Teflon", Base, Pocket, 0, G4ThreeVector(0,0,-fEffSourceHolderHeight/2.));
 	G4Tubs* Screw = new G4Tubs("SourcePlate", 0, fEffSourceScrewRad, fEffSourceScrewHeight/2., 0, 360*CLHEP::deg);
-	
+
 	//Build logical and place the source holder
 	G4VisAttributes* sVisAtt = new G4VisAttributes(G4Colour(PEEK_COL));
 	sVisAtt->SetVisibility(true);
@@ -1660,7 +1637,7 @@ void ApparatusSpiceTargetChamber::BuildPlaceEfficiencySource(G4LogicalVolume* ex
 	G4LogicalVolume* TLog = new G4LogicalVolume(Teflon,sMaterialT,"TLog"); 
 	TLog->SetVisAttributes(sVisAtt);
 	new G4PVPlacement(new G4RotationMatrix,G4ThreeVector(0,0,fTargetWheelFaceZ-base/2.), TLog, "SourceHolderEff", expHallLog, false, 0);
-	
+
 	//Build logical and place the source holder screws
 	sVisAtt = new G4VisAttributes(G4Colour(CU_COL));
 	G4Material* sMaterialSR = G4Material::GetMaterial("Brass");
@@ -1669,41 +1646,41 @@ void ApparatusSpiceTargetChamber::BuildPlaceEfficiencySource(G4LogicalVolume* ex
 	G4double screwradplacement=((fEffSourceHoldPocketRad-fEffSourceHolderRad)/2.) + fEffSourceHolderRad;
 	new G4PVPlacement(new G4RotationMatrix,G4ThreeVector(0,screwradplacement,fTargetWheelFaceZ-fEffSourceHolderHeight-fEffSourceScrewHeight/2.), SScrewLog, "SourceHolderScrew1", expHallLog, false, 0);
 	new G4PVPlacement(new G4RotationMatrix,G4ThreeVector(0,-screwradplacement,fTargetWheelFaceZ-fEffSourceHolderHeight-fEffSourceScrewHeight/2.), SScrewLog, "SourceHolderScrew2", expHallLog, false, 0);
-	
-	
+
+
 	BuildMEezagSource(expHallLog);
 }
-	
+
 void  ApparatusSpiceTargetChamber::BuildMEezagSource(G4LogicalVolume* expHallLog){
 	//Build shapes for the source frame
-	
+
 	G4Tubs* SourceWall = new G4Tubs("SourceWall", fMEezagSourceRad-fMEezagSourceWall,fMEezagSourceRad, fMEezagSourceHeight/2., 0, 360*CLHEP::deg);
 	G4Tubs* SourceRim = new G4Tubs("SourceRim", fMEezagSourceRad-fMEezagSourceRim, fMEezagSourceRad, fMEezagSourceWall/2., 0, 360*CLHEP::deg);
 	G4Tubs* SourcePlate = new G4Tubs("SourcePlate", 0, fMEezagSourceRad-0.1*mm, fMEezagSourceWall/2., 0, 360*CLHEP::deg);
-	
-	
+
+
 	G4UnionSolid* WallRim = new G4UnionSolid("WallRim", SourceWall, SourceRim, 0, G4ThreeVector(0,0,fMEezagSourceWall/2.-fMEezagSourceHeight/2.));
 	G4UnionSolid* WallRimPlate = new G4UnionSolid("WallRimPlate", WallRim, SourcePlate, 0, G4ThreeVector(0,0,fMEezagSourceWall*1.5-fMEezagSourceHeight/2.));
-	
+
 	G4VisAttributes* sVisAtt = new G4VisAttributes(G4Colour(AL_COL));
 	sVisAtt->SetVisibility(true);
 	G4Material* sMaterialsf = G4Material::GetMaterial("Aluminum");
 	G4LogicalVolume* SFlog = new G4LogicalVolume(WallRimPlate,sMaterialsf,"SFlog");
 	SFlog->SetVisAttributes(sVisAtt);	
 	new G4PVPlacement(new G4RotationMatrix,G4ThreeVector(0,0,fMEezagSourceZ), SFlog, "SourceFrame", expHallLog, false, 0);
-	
+
 	G4Tubs* Acrylic = new G4Tubs("Acrylic", 0, fMEezagSourceRad-fMEezagSourceRim-0.5*mm, fMEezagSourceAcrylicLength/2., 0, 360*CLHEP::deg);
 
 	G4double AcrylicZ=fMEezagSourceActiveZ-fMEezagSourceAcrylicLength/2.;
 	G4Material* sMaterialAc = G4Material::GetMaterial("Acrylic");
 	G4LogicalVolume* Acrlog = new G4LogicalVolume(Acrylic,sMaterialAc,"Acrlog");
 	new G4PVPlacement(new G4RotationMatrix,G4ThreeVector(0,0,AcrylicZ), Acrlog, "SourceAcrylic", expHallLog, false, 0);
-	
-	
+
+
 }
 void  ApparatusSpiceTargetChamber::BuildPlaceSource(G4LogicalVolume* expHallLog){
 	//Build shapes for the source frame
-	
+
 	G4VisAttributes* vis_att = new G4VisAttributes(G4Colour(AL_COL));
 	vis_att->SetVisibility(true); 
 
@@ -1722,21 +1699,21 @@ void  ApparatusSpiceTargetChamber::BuildPlaceSource(G4LogicalVolume* expHallLog)
 	G4Material* material = G4Material::GetMaterial("Aluminum");
 	G4LogicalVolume* fSourceBracketLog = new G4LogicalVolume(Bracket, material, "Source_Bracket", 0, 0, 0);
 	fSourceBracketLog->SetVisAttributes(vis_att);
-	
+
 	vis_att = new G4VisAttributes(G4Colour(CU_COL));
 	vis_att->SetVisibility(true); 
 	material = G4Material::GetMaterial("Brass");
 	G4LogicalVolume* fScrewLog = new G4LogicalVolume(screw, material, "screw", 0, 0, 0);
 	fScrewLog->SetVisAttributes(vis_att);	
 
-	
+
 	G4double placeZ = fMEezagSourceZ-fMEezagSourceHeight/2.-fBracketDepth/2.;
 	G4ThreeVector move = G4ThreeVector(fBracketoffset,0.,placeZ);
 	move.rotateZ(fBracketAngle);  
 	G4RotationMatrix* rot=new G4RotationMatrix();
 	rot->rotateZ(-fBracketAngle);  
 	new G4PVPlacement(rot,move,fSourceBracketLog, "Source_Bracket", expHallLog,false, 0); 
-	
+
 	placeZ -= (fBracketScrewHeight+fBracketDepth)/2.;
 	G4double placeX = fBracketoffset+(fBracketSideLength)/2.-fBracketScrewRad;
 	G4double placeY =fBracketBackLength/2.-fBracketScrewRad;
@@ -1744,12 +1721,12 @@ void  ApparatusSpiceTargetChamber::BuildPlaceSource(G4LogicalVolume* expHallLog)
 	G4ThreeVector moveC = G4ThreeVector(placeX,-placeY,placeZ);
 	moveB.rotateZ(fBracketAngle);  
 	moveC.rotateZ(fBracketAngle); 
-	
+
 	new G4PVPlacement(new G4RotationMatrix,moveB,fScrewLog, "bracket_screw", expHallLog,false, 0); 
 	new G4PVPlacement(new G4RotationMatrix,moveC,fScrewLog, "bracket_screw", expHallLog,false, 0); 
-	
+
 	BuildMEezagSource(expHallLog);
-	
+
 }
 
 // **************************************************************************************************
@@ -1765,34 +1742,34 @@ void ApparatusSpiceTargetChamber::PlaceBunnyTargets(G4LogicalVolume* expHallLog)
 }
 
 void ApparatusSpiceTargetChamber::PlaceBunnyTarget(G4int i, G4LogicalVolume* expHallLog) {
-	
-	
+
+
 	G4ThreeVector WheelOffest(-fTargetOffsetRadius,0,0);
-	
+
 	G4ThreeVector TargetOffset(0,-fTargetOffsetRadius,fTargetWheelFaceZ-fBunnyRodLength-fBunnyTargetThickness/2.);
-	
+
 	double ang=fTargetWheelRotation+fTargetWheelHoleSpaceAng*i;
 	TargetOffset.rotateZ(-ang);
-	
+
 	TargetOffset+=WheelOffest;
-	
+
 	G4RotationMatrix* sRotate = new G4RotationMatrix;
 	sRotate->rotateZ(ang-90*CLHEP::deg);   
 
 	fFramePhysical = new G4PVPlacement(sRotate, TargetOffset, fFrameLogical, "BunnyTargetFrame", expHallLog, false, 0);
-	
-	
+
+
 
 	sRotate = new G4RotationMatrix;
 	G4ThreeVector RodOffset(0,10*CLHEP::mm,(fBunnyRodLength+fBunnyTargetThickness)/2.);
 	RodOffset.rotateZ(-45*CLHEP::deg);
 	RodOffset.rotateZ(-ang);
-		
+
 	fRodPhysical = new G4PVPlacement(sRotate, TargetOffset+RodOffset, fRodLogical, "BunnyTargetRods", expHallLog, false, 0);
 	RodOffset.rotateZ(90*CLHEP::deg);
 	fRodPhysical = new G4PVPlacement(sRotate, TargetOffset+RodOffset, fRodLogical, "BunnyTargetRods", expHallLog, false, 0);
 
-	
+
 }
 
 
@@ -1804,14 +1781,14 @@ void ApparatusSpiceTargetChamber::PlaceEvapTargets(G4LogicalVolume* expHallLog){
 void ApparatusSpiceTargetChamber::PlaceEvapTarget(G4int i, G4LogicalVolume* expHallLog) {
 
 	G4ThreeVector WheelOffest(-fTargetOffsetRadius,0,0);
-	
+
 	G4ThreeVector TargetOffset(0,-fTargetOffsetRadius,fTargetWheelFaceZ-fEvapTargetThickness/2.);
-	
+
 	double ang=fTargetWheelRotation+fTargetWheelHoleSpaceAng*i;
 	TargetOffset.rotateZ(-ang);
-	
+
 	TargetOffset+=WheelOffest;
-	
+
 	G4RotationMatrix* sRotate = new G4RotationMatrix;
 	sRotate->rotateZ(fTargetWheelRotation);   
 
@@ -1820,7 +1797,7 @@ void ApparatusSpiceTargetChamber::PlaceEvapTarget(G4int i, G4LogicalVolume* expH
 	sRotate = new G4RotationMatrix;
 	G4ThreeVector RodOffset(0,-fEvapTargetRadius,-(fEvapTargetThickness+fEvapTargetScrewHeight)/2.);
 	RodOffset.rotateZ(-fTargetWheelRotation);
-		
+
 	fRodPhysical = new G4PVPlacement(sRotate, TargetOffset+RodOffset, fRodLogical, "EvapTargetScrew", expHallLog, false, 0);
 
 }
@@ -1879,7 +1856,7 @@ void ApparatusSpiceTargetChamber::PlaceCollimator(G4LogicalVolume* expHallLog) {
 
 	G4double offset = -fTargetWheelOffset;
 	G4double ZPosition =fTargetWheelFaceZ-(fTargColPlateThick/2.); 
-		G4ThreeVector move(offset, 0, ZPosition);
+	G4ThreeVector move(offset, 0, ZPosition);
 
 	fCollimPhysical = new G4PVPlacement(rotate, move, fCollimLogical, "collimator", expHallLog, false, 0);
 }
@@ -1942,14 +1919,14 @@ void ApparatusSpiceTargetChamber::PlaceTargetMountPlate(G4LogicalVolume* expHall
 	fTargetMountPlatePhys = new G4PVPlacement(rotate, move, fTargetMountPlateLog,
 			"TargetMountPlate", expHallLog,
 			false,0);
-	
+
 	for(int i=0;i<7;i++){
 		G4double ang=(22.5+i*45)*CLHEP::deg;
 		G4ThreeVector moveR(fMountPlateRodPlaceR, 0, fMountPlateRodZoffset);
 		moveR.rotateZ(ang);
 		fTargetMountRodPhys = new G4PVPlacement(rotate, moveR, fTargetMountRodLog,"TargetMountRod", expHallLog,false,0);
 	}
-	
+
 } // end PlaceTargetMountPlate()
 
 void ApparatusSpiceTargetChamber::PlacePhotonShield(G4LogicalVolume* expHallLog)
@@ -2026,7 +2003,7 @@ void ApparatusSpiceTargetChamber::PlacePhotonShieldClampBolts(G4int copyID, G4Lo
 	G4double Ang=(45+copyID*90)*deg;
 	G4ThreeVector move(fPsBoltPlaceRadius, 0, fPhotonShieldBackFacePos+fPsBoltLength/2.-fPsBoltBackShield);
 	move.rotateZ(-Ang);
-	
+
 	fTargetBoltPhys = new G4PVPlacement(0, move, fShieldBoltLog,
 			"ShieldBolt", expHallLog, 
 			false,0);
@@ -2044,7 +2021,7 @@ void ApparatusSpiceTargetChamber::PlaceMagnetAndCover(G4int copyID, G4LogicalVol
 	G4ThreeVector move(magnetPosX, 0, magnetPosZ);
 	move.rotateZ(-Ang);
 	fMagnetPhys = new G4PVPlacement(rotation, move, fMagnetLog,"CollectorMagnet",expHallLog,false,0);
-	
+
 	G4double MagCoverOffsetX = -(fPsClampThicknessInner-fPsClampThicknessOuter)/2;
 	G4double MagCoverOffsetZ = -(fPsClampThicknessBottom-fPsClampThicknessTop)/2; 
 	G4ThreeVector movecov(magnetPosX+MagCoverOffsetX, 0, magnetPosZ+MagCoverOffsetZ);
@@ -2092,7 +2069,7 @@ void ApparatusSpiceTargetChamber::PlaceS3CableHolder(G4LogicalVolume* expHallLog
 	fS3CasePhysical = new G4PVPlacement(sRotate, sTranslate, fS3CaseLogical, "s3CableCase", expHallLog, false, 0);
 }
 void ApparatusSpiceTargetChamber::PlaceConicalCollimator(G4LogicalVolume* expHallLog) {
-	
+
 	G4double ZPosition = fPhotonShieldBackFacePos + fMiddleRingOffset+ fPhotonShieldLength + fPsTargetClampThickness;
 	ZPosition+=fConicalTabHeight-fConicalLength1/2.;
 	fConicalCollimatorPhys = new G4PVPlacement(0,G4ThreeVector(0, 0, ZPosition),fConicalCollimatorLog,"ConicalCollimator",expHallLog,false,0);
@@ -2100,19 +2077,19 @@ void ApparatusSpiceTargetChamber::PlaceConicalCollimator(G4LogicalVolume* expHal
 }
 
 void ApparatusSpiceTargetChamber::PlaceXrayInsert(G4LogicalVolume* expHallLog){
-    
+
 	G4double CollimatorEnd = fPhotonShieldBackFacePos + fMiddleRingOffset+ fPhotonShieldLength + fPsTargetClampThickness;
 	CollimatorEnd+=fConicalTabHeight-fConicalLength1-fConicalLength2-fConicalLength3;
 	CollimatorEnd-=fInsertCylZLength/2.;
 	CollimatorEnd+=fInsertCylZLength-fInsertConeZLength;
-	
+
 	G4double ShieldBack = fPhotonShieldBackFacePos + fMiddleRingOffset- fPsDetClampThickness;
 	ShieldBack-=(fInsertEdgeZLength+fInsertCylZLength/2);
-	
+
 	G4double ZPosition = CollimatorEnd;
 	if(ShieldBack<ZPosition)ZPosition=ShieldBack;
 	G4ThreeVector move(0, 0, ZPosition);
-	
+
 	fXRayInsertPhys = new G4PVPlacement(new G4RotationMatrix(),                       //rotation
 			move,                    //at position
 			fXRayInsertLog,             //its logical volume
@@ -2122,6 +2099,6 @@ void ApparatusSpiceTargetChamber::PlaceXrayInsert(G4LogicalVolume* expHallLog){
 			false,                       //copy number
 			0);          //overlaps checking
 
-    
+
 }
 

--- a/src/BeamDistribution.cc
+++ b/src/BeamDistribution.cc
@@ -29,7 +29,7 @@ void BeamDistribution::LoadDistribution(G4String filename){//Reads in the data f
 	std::ifstream distrodata;//create input object
 	distrodata.open(filename.c_str());//open data file
 	if(!distrodata.is_open()){
-		std::cout << "File "<<filename<<" not opened." << std::endl; 
+		std::cout<<"File "<<filename<<" not opened."<<std::endl; 
 		return;
 	}
 
@@ -45,7 +45,7 @@ void BeamDistribution::LoadDistribution(G4String filename){//Reads in the data f
 	distrodata.close();
 
 	if(xv.size()<2){
-		std::cout << "Insufficient data points." << std::endl; 
+		std::cout<<"Insufficient data points."<<std::endl; 
 		return;
 	}
 		

--- a/src/DetectionSystem8pi.cc
+++ b/src/DetectionSystem8pi.cc
@@ -152,8 +152,8 @@ G4ThreeVector DetectionSystem8pi::GetDirectionXYZ(G4double theta, G4double phi) 
 G4int DetectionSystem8pi::AddGermanium() {
     //material
     G4Material* material = G4Material::GetMaterial("Germanium");
-    if( !material ) {
-        G4cout << " ----> Material " << "Germanium" << " not found, cannot build the detector shell! " << G4endl;
+    if(!material) {
+        G4cout<<" ----> Material "<<"Germanium"<<" not found, cannot build the detector shell! "<<G4endl;
         return 0;
     }
 
@@ -191,7 +191,7 @@ G4int DetectionSystem8pi::AddGermanium() {
     G4ThreeVector move = zPosition * direction;
 
     //logical volume
-    if(fGermaniumBlockLog == NULL) {
+    if(fGermaniumBlockLog == nullptr) {
         fGermaniumBlockLog = new G4LogicalVolume(germaniumBlockWithCavity, material, "8piGermaniumBlockLog", 0, 0, 0);
         fGermaniumBlockLog->SetVisAttributes(germaniumBlockVisAtt);
     }
@@ -210,8 +210,8 @@ G4int DetectionSystem8pi::AddGermanium() {
 G4int DetectionSystem8pi::AddGermaniumDeadLayer() {
     //material
     G4Material* material = G4Material::GetMaterial("Germanium");
-    if( !material ) {
-        G4cout << " ----> Material " << "Germanium" << " not found, cannot build the detector shell! " << G4endl;
+    if(!material) {
+        G4cout<<" ----> Material "<<"Germanium"<<" not found, cannot build the detector shell! "<<G4endl;
         return 0;
     }
 
@@ -249,7 +249,7 @@ G4int DetectionSystem8pi::AddGermaniumDeadLayer() {
     G4ThreeVector move = G4ThreeVector(0, 0, zPosition);
 
     //logical volume
-    if(fGermaniumDeadLayerLog == NULL) {
+    if(fGermaniumDeadLayerLog == nullptr) {
 		fGermaniumDeadLayerLog = new G4LogicalVolume(germaniumDeadLayerWithCavity, material, "germaniumDeadLayerLog", 0, 0, 0);
 		fGermaniumDeadLayerLog->SetVisAttributes(visAtt);
     }
@@ -269,8 +269,8 @@ G4int DetectionSystem8pi::AddGermaniumDeadLayer() {
 G4int DetectionSystem8pi::AddGermaniumCore() {
     //material
     G4Material* material = G4Material::GetMaterial("Vacuum");
-    if( !material ) {
-        G4cout << " ----> Material " << "Vacuum" << " not found, cannot build the detector shell! " << G4endl;
+    if(!material) {
+        G4cout<<" ----> Material "<<"Vacuum"<<" not found, cannot build the detector shell! "<<G4endl;
         return 0;
     }
 
@@ -309,7 +309,7 @@ G4int DetectionSystem8pi::AddGermaniumCore() {
     G4ThreeVector move = G4ThreeVector(0, 0, zPosition);
 
     //logical volume
-    if(fGermaniumVacuumCoreLog == NULL) {
+    if(fGermaniumVacuumCoreLog == nullptr) {
 		fGermaniumVacuumCoreLog = new G4LogicalVolume(germaniumVacuumCoreWithCavity, material, "germaniumVacuumCoreLog", 0, 0, 0);
 		fGermaniumVacuumCoreLog->SetVisAttributes(visAtt);
     }
@@ -329,8 +329,8 @@ G4int DetectionSystem8pi::AddGermaniumCore() {
 G4int DetectionSystem8pi::AddElectrodeMatElectrode() {
     //material
     G4Material* material = G4Material::GetMaterial(fElectrodeMat);
-    if( !material ) {
-        G4cout << " ----> Material " << fElectrodeMat << " not found, cannot build the detector shell! " << G4endl;
+    if(!material) {
+        G4cout<<" ----> Material "<<fElectrodeMat<<" not found, cannot build the detector shell! "<<G4endl;
         return 0;
     }
 
@@ -351,7 +351,7 @@ G4int DetectionSystem8pi::AddElectrodeMatElectrode() {
     G4double lowerZPosition = fCrystalDistFromOrigin + fHoleStartingDepth/2.0; // check this! // adjust position
 
     //logical volume
-    if(fLowerElectrodeMatElectrodeLog == NULL) {
+    if(fLowerElectrodeMatElectrodeLog == nullptr) {
         fLowerElectrodeMatElectrodeLog = new G4LogicalVolume(lowerElectrodeMatCylinder, material, "lowerElectrodeMatElectrodeLog", 0, 0, 0);
         fLowerElectrodeMatElectrodeLog->SetVisAttributes(visAtt);
     }
@@ -367,7 +367,7 @@ G4int DetectionSystem8pi::AddElectrodeMatElectrode() {
     G4double zPosition = fCrystalDistFromOrigin + fCrystalLength/2.0 + halfLengthZ;
 
     //logical volume
-    if(fUpperElectrodeMatElectrodeLog == NULL) {
+    if(fUpperElectrodeMatElectrodeLog == nullptr) {
         fUpperElectrodeMatElectrodeLog = new G4LogicalVolume(upperElectrodeMatCylinder, material, "upperElectrodeMatElectrodeLog", 0, 0, 0);
         fUpperElectrodeMatElectrodeLog->SetVisAttributes(visAtt);
     }
@@ -392,8 +392,8 @@ G4int DetectionSystem8pi::AddElectrodeMatElectrode() {
 G4int DetectionSystem8pi::AddStructureMatCage() {
     //material
     G4Material* material = G4Material::GetMaterial(fStructureMat);
-    if( !material ) {
-        G4cout << " ----> Material " << fStructureMat << " not found, cannot build the detector shell! " << G4endl;
+    if(!material) {
+        G4cout<<" ----> Material "<<fStructureMat<<" not found, cannot build the detector shell! "<<G4endl;
         return 0;
     }
 
@@ -416,7 +416,7 @@ G4int DetectionSystem8pi::AddStructureMatCage() {
     G4ThreeVector move = zPosition * direction;
 
     //4 logical sides (quadrants)
-    if(fInnerCage1Log == NULL && fInnerCage2Log == NULL && fInnerCage3Log == NULL && fInnerCage4Log == NULL) {
+    if(fInnerCage1Log == nullptr && fInnerCage2Log == nullptr && fInnerCage3Log == nullptr && fInnerCage4Log == nullptr) {
         fInnerCage1Log = new G4LogicalVolume(innerCage1, material, "innerCage1Log", 0, 0, 0);
         fInnerCage1Log->SetVisAttributes(visAtt);
         fInnerCage2Log = new G4LogicalVolume(innerCage2, material, "innerCage2Log", 0, 0, 0);
@@ -445,7 +445,7 @@ G4int DetectionSystem8pi::AddStructureMatCage() {
     move =  zPosition * direction;
 
     //logical volume
-    if(fInnerCageBottomLog == NULL) {
+    if(fInnerCageBottomLog == nullptr) {
         fInnerCageBottomLog = new G4LogicalVolume(innerCageBottom, material, "innerCageBottomLog", 0, 0, 0);
         fInnerCageBottomLog->SetVisAttributes(visAtt);
     }
@@ -458,8 +458,8 @@ G4int DetectionSystem8pi::AddStructureMatCage() {
 G4int DetectionSystem8pi::AddInnerStructureMatLids() {
     //material
     G4Material* material = G4Material::GetMaterial(fStructureMat);
-    if( !material ) {
-        G4cout << " ----> Material " << "StructureMat" << " not found, cannot build the detector shell! " << G4endl;
+    if(!material) {
+        G4cout<<" ----> Material "<<"StructureMat"<<" not found, cannot build the detector shell! "<<G4endl;
         return 0;
     }
 
@@ -479,7 +479,7 @@ G4int DetectionSystem8pi::AddInnerStructureMatLids() {
     G4ThreeVector move = zPosition * direction;
 
     //logical volume
-    if(fInnerCageLidLog == NULL) {
+    if(fInnerCageLidLog == nullptr) {
         fInnerCageLidLog = new G4LogicalVolume(lid, material, "innerCageLidLog", 0, 0, 0);
         fInnerCageLidLog->SetVisAttributes(visAtt);
     }
@@ -500,8 +500,8 @@ G4int DetectionSystem8pi::AddInnerStructureMatLids() {
 G4int DetectionSystem8pi::AddStructureMatCoolingRod() {
     //material
     G4Material* material = G4Material::GetMaterial(fStructureMat);
-    if( !material ) {
-        G4cout << " ----> Material " << fStructureMat << " not found, cannot build the detector shell! " << G4endl;
+    if(!material) {
+        G4cout<<" ----> Material "<<fStructureMat<<" not found, cannot build the detector shell! "<<G4endl;
         return 0;
     }
 
@@ -511,7 +511,7 @@ G4int DetectionSystem8pi::AddStructureMatCoolingRod() {
     //ring measurements
     G4double innerRadius = 0.0*mm;
     G4double outerRadius = fStructureMatCoolingRodRadius;
-    G4double halfLengthZ = (fOuterCanExtendsPastCrystal - fInnerCanExtendsPastCrystal )/2.0;
+    G4double halfLengthZ = (fOuterCanExtendsPastCrystal - fInnerCanExtendsPastCrystal)/2.0;
 
     G4Tubs* coolingRod = new G4Tubs("coolingRod", innerRadius, outerRadius, halfLengthZ, 0.0*deg, fDetailViewEndAngle);
 
@@ -522,7 +522,7 @@ G4int DetectionSystem8pi::AddStructureMatCoolingRod() {
     G4ThreeVector move = zPosition * direction;
 
     //logical volume
-    if(fStructureMatCoolingRodLog == NULL) {
+    if(fStructureMatCoolingRodLog == nullptr) {
         fStructureMatCoolingRodLog = new G4LogicalVolume(coolingRod, material, "structureMatCoolingRodLog", 0, 0, 0);
         fStructureMatCoolingRodLog->SetVisAttributes(visAtt);
     }
@@ -537,8 +537,8 @@ G4int DetectionSystem8pi::AddElectrodeMatCoolingRod()
 {
     //material
     G4Material* material = G4Material::GetMaterial(fElectrodeMat);
-    if( !material ) {
-        G4cout << " ----> Material " << fElectrodeMat << " not found, cannot build the detector shell! " << G4endl;
+    if(!material) {
+        G4cout<<" ----> Material "<<fElectrodeMat<<" not found, cannot build the detector shell! "<<G4endl;
         return 0;
     }
 
@@ -559,7 +559,7 @@ G4int DetectionSystem8pi::AddElectrodeMatCoolingRod()
     G4ThreeVector move = zPosition * direction;
 
     //logical volume
-    if(fElectrodeMatCoolingRodLog == NULL) {
+    if(fElectrodeMatCoolingRodLog == nullptr) {
         fElectrodeMatCoolingRodLog = new G4LogicalVolume(coolingRod, material, "electrodeMatCoolingRodLog", 0, 0, 0);
         fElectrodeMatCoolingRodLog->SetVisAttributes(visAtt);
     }
@@ -575,8 +575,8 @@ G4int DetectionSystem8pi::AddElectrodeMatCoolingRod()
 G4int DetectionSystem8pi::AddBerylliumWindow() {
     //material
     G4Material* material = G4Material::GetMaterial("Beryllium");
-    if( !material ) {
-        G4cout << " ----> Material " << "Beryllium" << " not found, cannot build the detector shell! " << G4endl;
+    if(!material) {
+        G4cout<<" ----> Material "<<"Beryllium"<<" not found, cannot build the detector shell! "<<G4endl;
         return 0;
     }
 
@@ -596,7 +596,7 @@ G4int DetectionSystem8pi::AddBerylliumWindow() {
     G4ThreeVector move = zPosition * direction;
 
     //logical volume
-    if(fBerylliumWindowLog == NULL) {
+    if(fBerylliumWindowLog == nullptr) {
         fBerylliumWindowLog = new G4LogicalVolume(berylliumWindow, material, "berylliumWindowLog", 0, 0, 0);
         fBerylliumWindowLog->SetVisAttributes(visAtt);
     }
@@ -610,8 +610,8 @@ G4int DetectionSystem8pi::AddBerylliumWindow() {
 G4int DetectionSystem8pi::AddOuterStructureMatCan() {
     //material
     G4Material* material = G4Material::GetMaterial(fStructureMat);
-    if( !material ) {
-        G4cout << " ----> Material " << fStructureMat << " not found, cannot build the detector shell! " << G4endl;
+    if(!material) {
+        G4cout<<" ----> Material "<<fStructureMat<<" not found, cannot build the detector shell! "<<G4endl;
         return 0;
     }
 
@@ -631,7 +631,7 @@ G4int DetectionSystem8pi::AddOuterStructureMatCan() {
     G4ThreeVector move = zPosition * direction;
 
     //logical volume
-    if(fOuterCanSideLog == NULL) {
+    if(fOuterCanSideLog == nullptr) {
         fOuterCanSideLog = new G4LogicalVolume(outerCanSide, material, "outerCanSideLog", 0, 0, 0);
         fOuterCanSideLog->SetVisAttributes(visAtt);
     }
@@ -647,7 +647,7 @@ G4int DetectionSystem8pi::AddOuterStructureMatCan() {
     G4Tubs* outerCanLid = new G4Tubs("outerCanLid", innerRadius, outerRadius, halfLengthZ, 0.0*deg, fDetailViewEndAngle);
 
     //logical volume
-    if(fOuterCanLidLog == NULL) {
+    if(fOuterCanLidLog == nullptr) {
         fOuterCanLidLog = new G4LogicalVolume(outerCanLid, material, "outerCanLidLog", 0, 0, 0);
         fOuterCanLidLog->SetVisAttributes(visAtt);
     }
@@ -665,8 +665,8 @@ G4int DetectionSystem8pi::AddCoolingRodCover()
 {
     //material
     G4Material* material = G4Material::GetMaterial(fStructureMat);
-    if( !material ) {
-        G4cout << " ----> Material " << "StructureMat" << " not found, cannot build the detector shell! " << G4endl;
+    if(!material) {
+        G4cout<<" ----> Material "<<"StructureMat"<<" not found, cannot build the detector shell! "<<G4endl;
         return 0;
     }
 
@@ -686,7 +686,7 @@ G4int DetectionSystem8pi::AddCoolingRodCover()
     G4ThreeVector move = zPosition * direction;
 
     //logical volume
-    if( fCoolingRodCoverLog == NULL )
+    if(fCoolingRodCoverLog == nullptr)
     {
         fCoolingRodCoverLog = new G4LogicalVolume(coolingRodCover, material, "coolingRodCoverLog", 0, 0, 0);
         fCoolingRodCoverLog->SetVisAttributes(visAtt);
@@ -705,7 +705,7 @@ G4int DetectionSystem8pi::AddCoolingRodCover()
     G4Tubs* coolingRodCoverLid = new G4Tubs("coolingRodLid", innerRadius, outerRadius, halfLengthZ, 0.0*deg, fDetailViewEndAngle);
 
     //logical volume
-    if( fCoolingRodCoverLidLog == NULL )
+    if(fCoolingRodCoverLidLog == nullptr)
     {
         fCoolingRodCoverLidLog = new G4LogicalVolume(coolingRodCoverLid, material, "coolingRodCoverLidLog", 0, 0, 0);
         fCoolingRodCoverLidLog->SetVisAttributes(visAtt);
@@ -725,8 +725,8 @@ G4int DetectionSystem8pi::AddCoolingRodCover()
 G4int DetectionSystem8pi::AddInnerBGOAnnulus() {
     //material
     G4Material* material = G4Material::GetMaterial("BGO");
-    if( !material ) {
-        G4cout << " ----> Material " << "BGO" << " not found, cannot build the detector shell! " << G4endl;
+    if(!material) {
+        G4cout<<" ----> Material "<<"BGO"<<" not found, cannot build the detector shell! "<<G4endl;
         return 0;
     }
 
@@ -747,7 +747,7 @@ G4int DetectionSystem8pi::AddInnerBGOAnnulus() {
     G4ThreeVector move = zPosition * direction;
 
     //logical volume
-    if(fInnerBGOAnnulusLog == NULL) {
+    if(fInnerBGOAnnulusLog == nullptr) {
         fInnerBGOAnnulusLog = new G4LogicalVolume(innerBGOAnnulus, material, "8piInnerBGOAnnulus", 0, 0, 0);
         fInnerBGOAnnulusLog->SetVisAttributes(visAtt);
     }
@@ -761,8 +761,8 @@ G4int DetectionSystem8pi::AddInnerBGOAnnulus() {
 G4int DetectionSystem8pi::AddStructureMatBGOSheath() {
     //material
     G4Material* material = G4Material::GetMaterial(fStructureMat);
-    if( !material ) {
-        G4cout << " ----> Material " << fStructureMat << " not found, cannot build the detector shell! " << G4endl;
+    if(!material) {
+        G4cout<<" ----> Material "<<fStructureMat<<" not found, cannot build the detector shell! "<<G4endl;
         return 0;
     }
 
@@ -782,7 +782,7 @@ G4int DetectionSystem8pi::AddStructureMatBGOSheath() {
     G4ThreeVector move = zPosition * direction;
 
     //logical volume
-    if(fStructureMatSheathLog == NULL) {
+    if(fStructureMatSheathLog == nullptr) {
         fStructureMatSheathLog = new G4LogicalVolume(structureMatSheath, material, "structureMatSheathLog", 0, 0, 0);
         fStructureMatSheathLog->SetVisAttributes(visAtt);
     }
@@ -797,8 +797,8 @@ G4int DetectionSystem8pi::AddStructureMatBGOSheath() {
 G4int DetectionSystem8pi::AddOuterBGOAnnulus() {
     //material
     G4Material* material = G4Material::GetMaterial("BGO");
-    if( !material ) {
-        G4cout << " ----> Material " << "BGO" << " not found, cannot build the detector shell! " << G4endl;
+    if(!material) {
+        G4cout<<" ----> Material "<<"BGO"<<" not found, cannot build the detector shell! "<<G4endl;
         return 0;
     }
 
@@ -820,7 +820,7 @@ G4int DetectionSystem8pi::AddOuterBGOAnnulus() {
     G4ThreeVector move = zPosition * direction;
 
     //logical volume
-    if(fOuterLowerBGOAnnulusLog == NULL) {
+    if(fOuterLowerBGOAnnulusLog == nullptr) {
 		  fOuterLowerBGOAnnulusLog = new G4LogicalVolume(outerLowerBGOAnnulus, material, "8piOuterLowerBGOAnnulus", 0, 0, 0);
         fOuterLowerBGOAnnulusLog->SetVisAttributes(visAtt);
     }
@@ -836,7 +836,7 @@ G4int DetectionSystem8pi::AddOuterBGOAnnulus() {
     move = zPosition * direction;
 
     //logical volume
-    if(fOuterUpperBGOAnnulusLog == NULL) {
+    if(fOuterUpperBGOAnnulusLog == nullptr) {
         fOuterUpperBGOAnnulusLog = new G4LogicalVolume(outerUpperBGOAnnulus, material, "8piOuterUpperBGOAnnulus", 0, 0, 0);
         fOuterUpperBGOAnnulusLog->SetVisAttributes(visAtt);
     }
@@ -850,8 +850,8 @@ G4int DetectionSystem8pi::AddOuterBGOAnnulus() {
 G4int DetectionSystem8pi::AddLiquidN2Container() {
     //material
     G4Material* material = G4Material::GetMaterial("LiquidN2");
-    if( !material ) {
-        G4cout << " ----> Material " << "LiquidN2" << " not found, cannot build the detector shell! " << G4endl;
+    if(!material) {
+        G4cout<<" ----> Material "<<"LiquidN2"<<" not found, cannot build the detector shell! "<<G4endl;
         return 0;
     }
 
@@ -873,7 +873,7 @@ G4int DetectionSystem8pi::AddLiquidN2Container() {
     G4ThreeVector move = zPosition * direction;
 
     //logical volume
-    if(fLiquidN2Log == NULL) {
+    if(fLiquidN2Log == nullptr) {
         fLiquidN2Log = new G4LogicalVolume(liquidN2, material, "liquidN2Log", 0, 0, 0);
         fLiquidN2Log->SetVisAttributes(N2VisAtt);
     }
@@ -884,7 +884,7 @@ G4int DetectionSystem8pi::AddLiquidN2Container() {
     //material
     material = G4Material::GetMaterial(fStructureMat);
     if(!material) {
-        G4cout << " ----> Material " << fStructureMat << " not found, cannot build the detector shell! " << G4endl;
+        G4cout<<" ----> Material "<<fStructureMat<<" not found, cannot build the detector shell! "<<G4endl;
         return 0;
     }
 
@@ -902,7 +902,7 @@ G4int DetectionSystem8pi::AddLiquidN2Container() {
     move = zPosition * direction;
 
     //logical volume
-    if(fLiquidN2BottomLog == NULL) {
+    if(fLiquidN2BottomLog == nullptr) {
         fLiquidN2BottomLog = new G4LogicalVolume(liquidN2Bottom, material, "liquidN2BottomLog", 0, 0, 0);
         fLiquidN2BottomLog->SetVisAttributes(visAtt);
     }
@@ -923,7 +923,7 @@ G4int DetectionSystem8pi::AddLiquidN2Container() {
     move = zPosition * direction;
 
     //logical volume
-    if(fLiquidN2SideLog == NULL) {
+    if(fLiquidN2SideLog == nullptr) {
         fLiquidN2SideLog = new G4LogicalVolume(liquidN2Side, material, "liquidN2SideLog", 0, 0, 0);
         fLiquidN2SideLog->SetVisAttributes(visAtt);
     }
@@ -945,7 +945,7 @@ G4int DetectionSystem8pi::AddLiquidN2Container() {
     move = zPosition * direction;
 
     //logical volume
-    if(fLiquidN2LidLog == NULL) {
+    if(fLiquidN2LidLog == nullptr) {
         fLiquidN2LidLog = new G4LogicalVolume(liquidN2Lid, material, "liquidN2LidLog", 0, 0, 0);
         fLiquidN2LidLog->SetVisAttributes(visAtt);
     }
@@ -959,8 +959,8 @@ G4int DetectionSystem8pi::AddLiquidN2Container() {
 G4int DetectionSystem8pi::AddHevimetalCollimator() {
     //material
     G4Material* material = G4Material::GetMaterial("Hevimetal");
-    if( !material ) {
-        G4cout << " ----> Material " << "Hevimetal" << " not found, cannot build the detector shell! " << G4endl;
+    if(!material) {
+        G4cout<<" ----> Material "<<"Hevimetal"<<" not found, cannot build the detector shell! "<<G4endl;
         return 0;
     }
 
@@ -1005,7 +1005,7 @@ G4int DetectionSystem8pi::AddHevimetalCollimator() {
     G4ThreeVector move = zPosition * direction;
 
     //logical volume
-    if(fHevimetalLog == NULL) {
+    if(fHevimetalLog == nullptr) {
         fHevimetalLog = new G4LogicalVolume(hevimetalWithCavity, material, "hevimetalLog", 0, 0, 0);
         fHevimetalLog->SetVisAttributes(hevimetalVisAtt);
     }
@@ -1019,8 +1019,8 @@ G4int DetectionSystem8pi::AddHevimetalCollimator() {
 G4int DetectionSystem8pi::AddAuxMatPlug() {
     //material
     G4Material* material = G4Material::GetMaterial(fAuxMat);
-    if( !material ) {
-        G4cout << " ----> Material " << fAuxMat << " not found, cannot build the detector shell! " << G4endl;
+    if(!material) {
+        G4cout<<" ----> Material "<<fAuxMat<<" not found, cannot build the detector shell! "<<G4endl;
         return 0;
     }
 
@@ -1045,7 +1045,7 @@ G4int DetectionSystem8pi::AddAuxMatPlug() {
     G4ThreeVector move = zPosition * direction ; // check this!
 
     //logical volume
-    if(fAuxMatPlugLog == NULL) {
+    if(fAuxMatPlugLog == nullptr) {
         fAuxMatPlugLog = new G4LogicalVolume(auxMatPlug, material, "auxMatPlugLog", 0, 0, 0);
         fAuxMatPlugLog->SetVisAttributes(visAtt);
     }
@@ -1060,8 +1060,8 @@ G4int DetectionSystem8pi::AddAuxMatPlug() {
 G4int DetectionSystem8pi::AddThinAuxMatLayer() {
     //material
     G4Material* material = G4Material::GetMaterial(fAuxMat);
-    if( !material ) {
-        G4cout << " ----> Material " << fAuxMat << " not found, cannot build the detector shell! " << G4endl;
+    if(!material) {
+        G4cout<<" ----> Material "<<fAuxMat<<" not found, cannot build the detector shell! "<<G4endl;
         return 0;
     }
 
@@ -1091,7 +1091,7 @@ G4int DetectionSystem8pi::AddThinAuxMatLayer() {
     G4ThreeVector move = zPosition * direction;
 
     //logical volume
-    if(fAuxMatLayerLog == NULL) {
+    if(fAuxMatLayerLog == nullptr) {
         fAuxMatLayerLog = new G4LogicalVolume(auxMatLayer, material, "auxMatLayerLog", 0, 0, 0);
         fAuxMatLayerLog->SetVisAttributes(visAtt);
     }

--- a/src/DetectionSystemAncillaryBGO.cc
+++ b/src/DetectionSystemAncillaryBGO.cc
@@ -28,613 +28,613 @@
 
 
 DetectionSystemAncillaryBGO::DetectionSystemAncillaryBGO() :
-    // LogicalVolumes
-    fDetectorVolumeLog(0),
-    fBgoBlockLog(0),
-    fVacuumBlockLog(0),
-    fCanCylinderLog(0),
-    fCanCylinderBackCoverLog(0),
-    fHevimetBlockLog(0)
+	// LogicalVolumes
+	fDetectorVolumeLog(0),
+	fBgoBlockLog(0),
+	fVacuumBlockLog(0),
+	fCanCylinderLog(0),
+	fCanCylinderBackCoverLog(0),
+	fHevimetBlockLog(0)
 {
-    // can //
-    fCanLength              = 190.0*mm;
-    fCanThickness           = 0.5*mm;
-    fCanThicknessFront     = 3.0*mm;
-    fCanInnerRadius        = 32.5*mm;
-    fCanMaterial            = "G4_Al";
-    // BGO //
-    fBgoLength              = 106.5*mm;
-    fBgoThickness           = 20.0*mm;
-    fBgoMaterial            = "G4_BGO";
-    // Gap (Vacuum) //
-    fGapThickness           = 0.5*mm;
-    fGapThicknessOuter     = 3.5*mm;
-    fGapMaterial            = "Vacuum";
+	// can //
+	fCanLength              = 190.0*mm;
+	fCanThickness           = 0.5*mm;
+	fCanThicknessFront     = 3.0*mm;
+	fCanInnerRadius        = 32.5*mm;
+	fCanMaterial            = "G4_Al";
+	// BGO //
+	fBgoLength              = 106.5*mm;
+	fBgoThickness           = 20.0*mm;
+	fBgoMaterial            = "G4_BGO";
+	// Gap (Vacuum) //
+	fGapThickness           = 0.5*mm;
+	fGapThicknessOuter     = 3.5*mm;
+	fGapMaterial            = "Vacuum";
 
-    // distance used in chopping process //
-    fCanFaceToBuildOrigin= 165.0*mm;
-    // Chopping angles //
-    fChoppingOuterAngle    = 12.76*deg;
-    fChoppingInnerAngle    = 8.0*deg;
-    // Hevimet //
-    fHevimetThickness       = 10.0*mm;
-    fHevimetMaterial        = "Hevimetal";
+	// distance used in chopping process //
+	fCanFaceToBuildOrigin= 165.0*mm;
+	// Chopping angles //
+	fChoppingOuterAngle    = 12.76*deg;
+	fChoppingInnerAngle    = 8.0*deg;
+	// Hevimet //
+	fHevimetThickness       = 10.0*mm;
+	fHevimetMaterial        = "Hevimetal";
 
-    //G4double triangleThetaAngle = (180/M_PI)*(atan((1/sqrt(3))/sqrt((11/12) + (1/sqrt(2))) )+atan((sqrt(2))/(1+sqrt(2))))*deg;
-    G4double triangleThetaAngle = 54.735610317245360*deg;
+	//G4double triangleThetaAngle = (180/M_PI)*(atan((1/sqrt(3))/sqrt((11/12) + (1/sqrt(2))))+atan((sqrt(2))/(1+sqrt(2))))*deg;
+	G4double triangleThetaAngle = 54.735610317245360*deg;
 
-    // theta
-    fDetectorAngles[0][0] 	= triangleThetaAngle;
-    fDetectorAngles[1][0] 	= triangleThetaAngle;
-    fDetectorAngles[2][0] 	= triangleThetaAngle;
-    fDetectorAngles[3][0] 	= triangleThetaAngle;
-    fDetectorAngles[4][0] 	= 180.0*deg - triangleThetaAngle;
-    fDetectorAngles[5][0] 	= 180.0*deg - triangleThetaAngle;
-    fDetectorAngles[6][0] 	= 180.0*deg - triangleThetaAngle;
-    fDetectorAngles[7][0] 	= 180.0*deg - triangleThetaAngle;
-    // phi
-    fDetectorAngles[0][1] 	= 22.5*deg;
-    fDetectorAngles[1][1] 	= 112.5*deg;
-    fDetectorAngles[2][1] 	= 202.5*deg;
-    fDetectorAngles[3][1] 	= 292.5*deg;
-    fDetectorAngles[4][1] 	= 22.5*deg;
-    fDetectorAngles[5][1] 	= 112.5*deg;
-    fDetectorAngles[6][1] 	= 202.5*deg;
-    fDetectorAngles[7][1] 	= 292.5*deg;
-    // yaw (alpha)
-    fDetectorAngles[0][2] 	= 0.0*deg;
-    fDetectorAngles[1][2] 	= 0.0*deg;
-    fDetectorAngles[2][2] 	= 0.0*deg;
-    fDetectorAngles[3][2] 	= 0.0*deg;
-    fDetectorAngles[4][2] 	= 0.0*deg;
-    fDetectorAngles[5][2] 	= 0.0*deg;
-    fDetectorAngles[6][2] 	= 0.0*deg;
-    fDetectorAngles[7][2] 	= 0.0*deg;
-    // pitch (beta)
-    fDetectorAngles[0][3] 	= triangleThetaAngle;
-    fDetectorAngles[1][3] 	= triangleThetaAngle;
-    fDetectorAngles[2][3] 	= triangleThetaAngle;
-    fDetectorAngles[3][3] 	= triangleThetaAngle;
-    fDetectorAngles[4][3] 	= 180.0*deg - triangleThetaAngle;
-    fDetectorAngles[5][3] 	= 180.0*deg - triangleThetaAngle;
-    fDetectorAngles[6][3] 	= 180.0*deg - triangleThetaAngle;
-    fDetectorAngles[7][3] 	= 180.0*deg - triangleThetaAngle;
-    // roll (gamma)
-    fDetectorAngles[0][4] 	= 22.5*deg;
-    fDetectorAngles[1][4] 	= 112.5*deg;
-    fDetectorAngles[2][4] 	= 202.5*deg;
-    fDetectorAngles[3][4] 	= 292.5*deg;
-    fDetectorAngles[4][4] 	= 22.5*deg;
-    fDetectorAngles[5][4] 	= 112.5*deg;
-    fDetectorAngles[6][4] 	= 202.5*deg;
-    fDetectorAngles[7][4] 	= 292.5*deg;
+	// theta
+	fDetectorAngles[0][0] 	= triangleThetaAngle;
+	fDetectorAngles[1][0] 	= triangleThetaAngle;
+	fDetectorAngles[2][0] 	= triangleThetaAngle;
+	fDetectorAngles[3][0] 	= triangleThetaAngle;
+	fDetectorAngles[4][0] 	= 180.0*deg - triangleThetaAngle;
+	fDetectorAngles[5][0] 	= 180.0*deg - triangleThetaAngle;
+	fDetectorAngles[6][0] 	= 180.0*deg - triangleThetaAngle;
+	fDetectorAngles[7][0] 	= 180.0*deg - triangleThetaAngle;
+	// phi
+	fDetectorAngles[0][1] 	= 22.5*deg;
+	fDetectorAngles[1][1] 	= 112.5*deg;
+	fDetectorAngles[2][1] 	= 202.5*deg;
+	fDetectorAngles[3][1] 	= 292.5*deg;
+	fDetectorAngles[4][1] 	= 22.5*deg;
+	fDetectorAngles[5][1] 	= 112.5*deg;
+	fDetectorAngles[6][1] 	= 202.5*deg;
+	fDetectorAngles[7][1] 	= 292.5*deg;
+	// yaw (alpha)
+	fDetectorAngles[0][2] 	= 0.0*deg;
+	fDetectorAngles[1][2] 	= 0.0*deg;
+	fDetectorAngles[2][2] 	= 0.0*deg;
+	fDetectorAngles[3][2] 	= 0.0*deg;
+	fDetectorAngles[4][2] 	= 0.0*deg;
+	fDetectorAngles[5][2] 	= 0.0*deg;
+	fDetectorAngles[6][2] 	= 0.0*deg;
+	fDetectorAngles[7][2] 	= 0.0*deg;
+	// pitch (beta)
+	fDetectorAngles[0][3] 	= triangleThetaAngle;
+	fDetectorAngles[1][3] 	= triangleThetaAngle;
+	fDetectorAngles[2][3] 	= triangleThetaAngle;
+	fDetectorAngles[3][3] 	= triangleThetaAngle;
+	fDetectorAngles[4][3] 	= 180.0*deg - triangleThetaAngle;
+	fDetectorAngles[5][3] 	= 180.0*deg - triangleThetaAngle;
+	fDetectorAngles[6][3] 	= 180.0*deg - triangleThetaAngle;
+	fDetectorAngles[7][3] 	= 180.0*deg - triangleThetaAngle;
+	// roll (gamma)
+	fDetectorAngles[0][4] 	= 22.5*deg;
+	fDetectorAngles[1][4] 	= 112.5*deg;
+	fDetectorAngles[2][4] 	= 202.5*deg;
+	fDetectorAngles[3][4] 	= 292.5*deg;
+	fDetectorAngles[4][4] 	= 22.5*deg;
+	fDetectorAngles[5][4] 	= 112.5*deg;
+	fDetectorAngles[6][4] 	= 202.5*deg;
+	fDetectorAngles[7][4] 	= 292.5*deg;
 }
 
 DetectionSystemAncillaryBGO::~DetectionSystemAncillaryBGO() {
-    // LogicalVolumes
-    delete fDetectorVolumeLog;
-    delete fBgoBlockLog;
-    delete fVacuumBlockLog;
-    delete fCanCylinderLog;
-    delete fCanCylinderBackCoverLog;
-    delete fHevimetBlockLog;
+	// LogicalVolumes
+	delete fDetectorVolumeLog;
+	delete fBgoBlockLog;
+	delete fVacuumBlockLog;
+	delete fCanCylinderLog;
+	delete fCanCylinderBackCoverLog;
+	delete fHevimetBlockLog;
 }
 
 
 G4int DetectionSystemAncillaryBGO::Build() {
-    // Build assembly volume
-    fAssembly = new G4AssemblyVolume();
-    fAssemblyHevimet = new G4AssemblyVolume();
+	// Build assembly volume
+	fAssembly = new G4AssemblyVolume();
+	fAssemblyHevimet = new G4AssemblyVolume();
 
-    G4cout << "BuildBGOVolume" << G4endl;
-    BuildBGOVolume();
-    G4cout << "BuildVacuumVolume" << G4endl;
-    BuildVacuumVolume();
-    G4cout << "BuildAluminumCanVolume" << G4endl;
-    BuildAluminumCanVolume();
-    G4cout << "BuildAluminumCanBackCoverVolume" << G4endl;
-    BuildAluminumCanBackCoverVolume();
-    G4cout << "BuildHevimetPiece" << G4endl;
-    BuildHevimetPiece();
+	G4cout<<"BuildBGOVolume"<<G4endl;
+	BuildBGOVolume();
+	G4cout<<"BuildVacuumVolume"<<G4endl;
+	BuildVacuumVolume();
+	G4cout<<"BuildAluminumCanVolume"<<G4endl;
+	BuildAluminumCanVolume();
+	G4cout<<"BuildAluminumCanBackCoverVolume"<<G4endl;
+	BuildAluminumCanBackCoverVolume();
+	G4cout<<"BuildHevimetPiece"<<G4endl;
+	BuildHevimetPiece();
 
-    //  G4cout << "BuildAluminumCanVolume" << G4endl;
-    //  BuildAluminumCanVolume();
-    //  G4cout << "BuildPackingVolume" << G4endl;
-    //  BuildPackingVolume();
-    //  G4cout << "BuildDiscVolume" << G4endl;
-    //  BuildDiscVolume();
-    //  G4cout << "BuildSealVolume" << G4endl;
-    //  BuildSealVolume();
+	//  G4cout<<"BuildAluminumCanVolume"<<G4endl;
+	//  BuildAluminumCanVolume();
+	//  G4cout<<"BuildPackingVolume"<<G4endl;
+	//  BuildPackingVolume();
+	//  G4cout<<"BuildDiscVolume"<<G4endl;
+	//  BuildDiscVolume();
+	//  G4cout<<"BuildSealVolume"<<G4endl;
+	//  BuildSealVolume();
 
-    return 1;
+	return 1;
 }
 
 G4int DetectionSystemAncillaryBGO::PlaceDetector(G4LogicalVolume* expHallLog, G4int detectorNumber, G4double radialpos, G4int hevimetopt) {
-    G4int detectorCopyID = 0;
+	G4int detectorCopyID = 0;
 
-    G4cout << "AncillaryBGO Detector Number = " << detectorNumber << G4endl;
+	G4cout<<"AncillaryBGO Detector Number = "<<detectorNumber<<G4endl;
 
-    G4int copyNumber = detectorCopyID + detectorNumber;
+	G4int copyNumber = detectorCopyID + detectorNumber;
 
-    G4double position = radialpos + ( fCanLength / 2.0 ) ;
+	G4double position = radialpos + (fCanLength / 2.0) ;
 
-    G4double theta  = fDetectorAngles[detectorNumber][0];
-    G4double phi    = fDetectorAngles[detectorNumber][1];
-    //G4double alpha  = fDetectorAngles[detectorNumber][2]; // yaw
-    G4double beta   = fDetectorAngles[detectorNumber][3]; // pitch
-    G4double gamma  = fDetectorAngles[detectorNumber][4]; // roll
+	G4double theta  = fDetectorAngles[detectorNumber][0];
+	G4double phi    = fDetectorAngles[detectorNumber][1];
+	//G4double alpha  = fDetectorAngles[detectorNumber][2]; // yaw
+	G4double beta   = fDetectorAngles[detectorNumber][3]; // pitch
+	G4double gamma  = fDetectorAngles[detectorNumber][4]; // roll
 
-    G4double x = 0;
-    G4double y = 0;
-    G4double z = position;
+	G4double x = 0;
+	G4double y = 0;
+	G4double z = position;
 
-    G4RotationMatrix* rotate = new G4RotationMatrix;    // rotation matrix corresponding to direction vector
-    G4ThreeVector move;
-    for (G4int i=0; i<3; i++) {
-        rotate->set(0,0,0);
-        rotate->rotateZ((120*deg)*i);
-        if(detectorNumber > 3) {
-            rotate->rotateZ(180*deg);
-        }
-        rotate->rotateY(M_PI);
-        rotate->rotateY(M_PI+beta);
-        rotate->rotateZ(gamma);
-        move = G4ThreeVector(TransX(x,y,z,theta,phi), TransY(x,y,z,theta,phi), TransZ(x,y,z,theta));
-        fAssembly->MakeImprint(expHallLog, move, rotate, copyNumber);
-    }
+	G4RotationMatrix* rotate = new G4RotationMatrix;    // rotation matrix corresponding to direction vector
+	G4ThreeVector move;
+	for(G4int i=0; i<3; i++) {
+		rotate->set(0,0,0);
+		rotate->rotateZ((120*deg)*i);
+		if(detectorNumber > 3) {
+			rotate->rotateZ(180*deg);
+		}
+		rotate->rotateY(M_PI);
+		rotate->rotateY(M_PI+beta);
+		rotate->rotateZ(gamma);
+		move = G4ThreeVector(TransX(x,y,z,theta,phi), TransY(x,y,z,theta,phi), TransZ(x,y,z,theta));
+		fAssembly->MakeImprint(expHallLog, move, rotate, copyNumber);
+	}
 
-    if(hevimetopt == 1) {
-        for (G4int i=0; i<3; i++) {
-            rotate->set(0,0,0);
-            rotate->rotateZ((120*deg)*i);
-            if(detectorNumber > 3) {
-                rotate->rotateZ(180*deg);
-            }
-            rotate->rotateY(M_PI);
-            rotate->rotateY(M_PI+beta);
-            rotate->rotateZ(gamma);
-            move = G4ThreeVector(TransX(x,y,z,theta,phi), TransY(x,y,z,theta,phi), TransZ(x,y,z,theta));
-            fAssemblyHevimet->MakeImprint(expHallLog, move, rotate, copyNumber);
-        }
-    }
+	if(hevimetopt == 1) {
+		for(G4int i=0; i<3; i++) {
+			rotate->set(0,0,0);
+			rotate->rotateZ((120*deg)*i);
+			if(detectorNumber > 3) {
+				rotate->rotateZ(180*deg);
+			}
+			rotate->rotateY(M_PI);
+			rotate->rotateY(M_PI+beta);
+			rotate->rotateZ(gamma);
+			move = G4ThreeVector(TransX(x,y,z,theta,phi), TransY(x,y,z,theta,phi), TransZ(x,y,z,theta));
+			fAssemblyHevimet->MakeImprint(expHallLog, move, rotate, copyNumber);
+		}
+	}
 
-    return 1;
+	return 1;
 }
 
 G4int DetectionSystemAncillaryBGO::BuildBGOVolume() {
-    G4Material* material = G4Material::GetMaterial(fBgoMaterial);
-    if( !material ) {
-        G4cout << " ----> Material " << fBgoMaterial << " not found, cannot build the detector shell! " << G4endl;
-        return 0;
-    }
+	G4Material* material = G4Material::GetMaterial(fBgoMaterial);
+	if(!material) {
+		G4cout<<" ----> Material "<<fBgoMaterial<<" not found, cannot build the detector shell! "<<G4endl;
+		return 0;
+	}
 
-    // Set visualization attributes
-    G4VisAttributes* visAtt = new G4VisAttributes(G4Colour(0.2,1.0,0.3));
-    visAtt->SetVisibility(true);
+	// Set visualization attributes
+	G4VisAttributes* visAtt = new G4VisAttributes(G4Colour(0.2,1.0,0.3));
+	visAtt->SetVisibility(true);
 
-    G4SubtractionSolid* bgoBlock = BGOPiece();
+	G4SubtractionSolid* bgoBlock = BGOPiece();
 
-    // Define rotation and movement objects
-    G4ThreeVector direction 	= G4ThreeVector(0,0,1);
-    G4double zPosition		= fCanThicknessFront + fGapThickness + (fBgoLength - fCanLength)/2.0;
-    G4ThreeVector move 		= zPosition * direction;
+	// Define rotation and movement objects
+	G4ThreeVector direction 	= G4ThreeVector(0,0,1);
+	G4double zPosition		= fCanThicknessFront + fGapThickness + (fBgoLength - fCanLength)/2.0;
+	G4ThreeVector move 		= zPosition * direction;
 
-    G4RotationMatrix* rotate = new G4RotationMatrix;
+	G4RotationMatrix* rotate = new G4RotationMatrix;
 
-    //logical volume
-    if( fBgoBlockLog == NULL ) {
-        fBgoBlockLog = new G4LogicalVolume(bgoBlock, material, "ancillaryBgoBlockLog", 0, 0, 0);
-        fBgoBlockLog->SetVisAttributes(visAtt);
-    }
+	//logical volume
+	if(fBgoBlockLog == nullptr) {
+		fBgoBlockLog = new G4LogicalVolume(bgoBlock, material, "ancillaryBgoBlockLog", 0, 0, 0);
+		fBgoBlockLog->SetVisAttributes(visAtt);
+	}
 
-    fAssembly->AddPlacedVolume(fBgoBlockLog, move, rotate);
+	fAssembly->AddPlacedVolume(fBgoBlockLog, move, rotate);
 
-    return 1;
+	return 1;
 }
 
 
 G4int DetectionSystemAncillaryBGO::BuildVacuumVolume() {
-    G4Material* material = G4Material::GetMaterial(fGapMaterial);
-    if( !material ) {
-        G4cout << " ----> Material " << fGapMaterial << " not found, cannot build the detector shell! " << G4endl;
-        return 0;
-    }
+	G4Material* material = G4Material::GetMaterial(fGapMaterial);
+	if(!material) {
+		G4cout<<" ----> Material "<<fGapMaterial<<" not found, cannot build the detector shell! "<<G4endl;
+		return 0;
+	}
 
-    // Set visualization attributes
-    G4VisAttributes* visAtt = new G4VisAttributes(G4Colour(0.0,0.0,1.0));
-    visAtt->SetVisibility(true);
+	// Set visualization attributes
+	G4VisAttributes* visAtt = new G4VisAttributes(G4Colour(0.0,0.0,1.0));
+	visAtt->SetVisibility(true);
 
-    G4SubtractionSolid* vacuumBlock = VacuumPiece();
+	G4SubtractionSolid* vacuumBlock = VacuumPiece();
 
-    // Define rotation and movement objects
-    G4ThreeVector direction 	= G4ThreeVector(0,0,1);
-    G4double zPosition		= fCanThicknessFront + (fBgoLength + fGapThickness - fCanLength)/2.0;
-    G4ThreeVector move 		= zPosition * direction;
+	// Define rotation and movement objects
+	G4ThreeVector direction 	= G4ThreeVector(0,0,1);
+	G4double zPosition		= fCanThicknessFront + (fBgoLength + fGapThickness - fCanLength)/2.0;
+	G4ThreeVector move 		= zPosition * direction;
 
-    G4RotationMatrix* rotate = new G4RotationMatrix;
+	G4RotationMatrix* rotate = new G4RotationMatrix;
 
-    //logical volume
-    if( fVacuumBlockLog == NULL ) {
-        fVacuumBlockLog = new G4LogicalVolume(vacuumBlock, material, "ancillaryVacuumBlockLog", 0, 0, 0);
-        fVacuumBlockLog->SetVisAttributes(visAtt);
-    }
+	//logical volume
+	if(fVacuumBlockLog == nullptr) {
+		fVacuumBlockLog = new G4LogicalVolume(vacuumBlock, material, "ancillaryVacuumBlockLog", 0, 0, 0);
+		fVacuumBlockLog->SetVisAttributes(visAtt);
+	}
 
-    fAssembly->AddPlacedVolume(fVacuumBlockLog, move, rotate);
+	fAssembly->AddPlacedVolume(fVacuumBlockLog, move, rotate);
 
-    return 1;
+	return 1;
 }
 
 G4int DetectionSystemAncillaryBGO::BuildAluminumCanVolume() {
-    G4Material* material = G4Material::GetMaterial(fCanMaterial);
-    if( !material ) {
-        G4cout << " ----> Material " << fCanMaterial << " not found, cannot build the detector shell! " << G4endl;
-        return 0;
-    }
+	G4Material* material = G4Material::GetMaterial(fCanMaterial);
+	if(!material) {
+		G4cout<<" ----> Material "<<fCanMaterial<<" not found, cannot build the detector shell! "<<G4endl;
+		return 0;
+	}
 
-    // Set visualization attributes
-    G4VisAttributes* visAtt = new G4VisAttributes(G4Colour(1.0,1.0,1.0));
-    visAtt->SetVisibility(true);
+	// Set visualization attributes
+	G4VisAttributes* visAtt = new G4VisAttributes(G4Colour(1.0,1.0,1.0));
+	visAtt->SetVisibility(true);
 
-    G4SubtractionSolid* canCylinder = AluminumCanPiece();
+	G4SubtractionSolid* canCylinder = AluminumCanPiece();
 
-    // Define rotation and movement objects
-    G4ThreeVector direction 	= G4ThreeVector(0,0,1);
-    G4double zPosition		= 0.0*mm;
-    G4ThreeVector move 		= zPosition * direction;
+	// Define rotation and movement objects
+	G4ThreeVector direction 	= G4ThreeVector(0,0,1);
+	G4double zPosition		= 0.0*mm;
+	G4ThreeVector move 		= zPosition * direction;
 
-    G4RotationMatrix* rotate = new G4RotationMatrix;
+	G4RotationMatrix* rotate = new G4RotationMatrix;
 
-    //logical volume
-    if( fCanCylinderLog == NULL ) {
-        fCanCylinderLog = new G4LogicalVolume(canCylinder, material, "ancillaryCanCylinderLog", 0, 0, 0);
-        fCanCylinderLog->SetVisAttributes(visAtt);
-    }
+	//logical volume
+	if(fCanCylinderLog == nullptr) {
+		fCanCylinderLog = new G4LogicalVolume(canCylinder, material, "ancillaryCanCylinderLog", 0, 0, 0);
+		fCanCylinderLog->SetVisAttributes(visAtt);
+	}
 
-    fAssembly->AddPlacedVolume(fCanCylinderLog, move, rotate);
+	fAssembly->AddPlacedVolume(fCanCylinderLog, move, rotate);
 
-    return 1;
+	return 1;
 }
 
 G4int DetectionSystemAncillaryBGO::BuildAluminumCanBackCoverVolume() {
-    G4Material* material = G4Material::GetMaterial(fCanMaterial);
-    if( !material ) {
-        G4cout << " ----> Material " << fCanMaterial << " not found, cannot build the detector shell! " << G4endl;
-        return 0;
-    }
+	G4Material* material = G4Material::GetMaterial(fCanMaterial);
+	if(!material) {
+		G4cout<<" ----> Material "<<fCanMaterial<<" not found, cannot build the detector shell! "<<G4endl;
+		return 0;
+	}
 
-    // Set visualization attributes
-    G4VisAttributes* visAtt = new G4VisAttributes(G4Colour(1.0,1.0,1.0));
-    visAtt->SetVisibility(true);
+	// Set visualization attributes
+	G4VisAttributes* visAtt = new G4VisAttributes(G4Colour(1.0,1.0,1.0));
+	visAtt->SetVisibility(true);
 
-    G4Tubs* canCylinder = AluminumCanBackCover();
+	G4Tubs* canCylinder = AluminumCanBackCover();
 
-    // Define rotation and movement objects
-    G4ThreeVector direction 	= G4ThreeVector(0,0,1);
-    G4double zPosition		= (fCanLength - fCanThickness)/2.0;
-    G4ThreeVector move 		= zPosition * direction;
+	// Define rotation and movement objects
+	G4ThreeVector direction 	= G4ThreeVector(0,0,1);
+	G4double zPosition		= (fCanLength - fCanThickness)/2.0;
+	G4ThreeVector move 		= zPosition * direction;
 
-    G4RotationMatrix* rotate = new G4RotationMatrix;
+	G4RotationMatrix* rotate = new G4RotationMatrix;
 
-    //logical volume
-    if( fCanCylinderBackCoverLog == NULL ) {
-        fCanCylinderBackCoverLog = new G4LogicalVolume(canCylinder, material, "ancillaryCanCylinderBackCoverLog", 0, 0, 0);
-        fCanCylinderBackCoverLog->SetVisAttributes(visAtt);
-    }
+	//logical volume
+	if(fCanCylinderBackCoverLog == nullptr) {
+		fCanCylinderBackCoverLog = new G4LogicalVolume(canCylinder, material, "ancillaryCanCylinderBackCoverLog", 0, 0, 0);
+		fCanCylinderBackCoverLog->SetVisAttributes(visAtt);
+	}
 
-    fAssembly->AddPlacedVolume(fCanCylinderBackCoverLog, move, rotate);
+	fAssembly->AddPlacedVolume(fCanCylinderBackCoverLog, move, rotate);
 
-    return 1;
+	return 1;
 }
 
 G4int DetectionSystemAncillaryBGO::BuildHevimetPiece() {
-    G4Material* material = G4Material::GetMaterial(fHevimetMaterial);
-    if( !material ) {
-        G4cout << " ----> Material " << fHevimetMaterial << " not found, cannot build the detector shell! " << G4endl;
-        return 0;
-    }
+	G4Material* material = G4Material::GetMaterial(fHevimetMaterial);
+	if(!material) {
+		G4cout<<" ----> Material "<<fHevimetMaterial<<" not found, cannot build the detector shell! "<<G4endl;
+		return 0;
+	}
 
-    // Set visualization attributes
-    G4VisAttributes* visAtt = new G4VisAttributes(G4Colour(0.5,0.5,0.5));
-    visAtt->SetVisibility(true);
+	// Set visualization attributes
+	G4VisAttributes* visAtt = new G4VisAttributes(G4Colour(0.5,0.5,0.5));
+	visAtt->SetVisibility(true);
 
-    G4SubtractionSolid* canCylinder = HevimetPiece();
+	G4SubtractionSolid* canCylinder = HevimetPiece();
 
-    // Define rotation and movement objects
-    G4ThreeVector direction 	= G4ThreeVector(0,0,1);
-    G4double zPosition		= -1.0*(fHevimetThickness + fCanLength)/2.0;
-    G4ThreeVector move 		= zPosition * direction;
+	// Define rotation and movement objects
+	G4ThreeVector direction 	= G4ThreeVector(0,0,1);
+	G4double zPosition		= -1.0*(fHevimetThickness + fCanLength)/2.0;
+	G4ThreeVector move 		= zPosition * direction;
 
-    G4RotationMatrix* rotate = new G4RotationMatrix;
+	G4RotationMatrix* rotate = new G4RotationMatrix;
 
-    //logical volume
-    if( fHevimetBlockLog == NULL ) {
-        fHevimetBlockLog = new G4LogicalVolume(canCylinder, material, "ancillaryHevimetBlockLog", 0, 0, 0);
-        fHevimetBlockLog->SetVisAttributes(visAtt);
-    }
+	//logical volume
+	if(fHevimetBlockLog == nullptr) {
+		fHevimetBlockLog = new G4LogicalVolume(canCylinder, material, "ancillaryHevimetBlockLog", 0, 0, 0);
+		fHevimetBlockLog->SetVisAttributes(visAtt);
+	}
 
-    fAssemblyHevimet->AddPlacedVolume(fHevimetBlockLog, move, rotate);
+	fAssemblyHevimet->AddPlacedVolume(fHevimetBlockLog, move, rotate);
 
-    return 1;
+	return 1;
 }
 
 ///////////////////////////////////////////////////////////////////////
 // Methods used to build shapes
 ///////////////////////////////////////////////////////////////////////
 G4SubtractionSolid* DetectionSystemAncillaryBGO::BGOPiece() {
-    G4double startPhi = 0.0*deg;
-    G4double endPhi = 120.0*deg;
+	G4double startPhi = 0.0*deg;
+	G4double endPhi = 120.0*deg;
 
-    G4double innerRadius = fCanInnerRadius+fCanThickness+fGapThickness;
-    G4double outerRadius = innerRadius+fBgoThickness;
-    G4double halfLengthZ = fBgoLength/2.0;
+	G4double innerRadius = fCanInnerRadius+fCanThickness+fGapThickness;
+	G4double outerRadius = innerRadius+fBgoThickness;
+	G4double halfLengthZ = fBgoLength/2.0;
 
-    G4Tubs* bgoBlock = new G4Tubs("bgoBlock", innerRadius, outerRadius, halfLengthZ, startPhi, endPhi);
+	G4Tubs* bgoBlock = new G4Tubs("bgoBlock", innerRadius, outerRadius, halfLengthZ, startPhi, endPhi);
 
-    // turn the block to be symmetric about 0 degress so we can cut it.
-    bgoBlock->SetStartPhiAngle(-60.0*deg,true);
-    bgoBlock->SetDeltaPhiAngle(120.0*deg);
+	// turn the block to be symmetric about 0 degress so we can cut it.
+	bgoBlock->SetStartPhiAngle(-60.0*deg,true);
+	bgoBlock->SetDeltaPhiAngle(120.0*deg);
 
-    // grab the scissors, time to cut.
-    // make the cut surface unnecessarily large.
-    G4double cutHalfLengthZ = 2.0*fCanFaceToBuildOrigin;
-    G4double cutHalfLengthX = 2.0*fCanFaceToBuildOrigin;
-    G4double cutHalfLengthY = 2.0*fCanFaceToBuildOrigin;
+	// grab the scissors, time to cut.
+	// make the cut surface unnecessarily large.
+	G4double cutHalfLengthZ = 2.0*fCanFaceToBuildOrigin;
+	G4double cutHalfLengthX = 2.0*fCanFaceToBuildOrigin;
+	G4double cutHalfLengthY = 2.0*fCanFaceToBuildOrigin;
 
-    G4Box* cutPlate = new G4Box("cutPlate", cutHalfLengthX, cutHalfLengthY, cutHalfLengthZ);
+	G4Box* cutPlate = new G4Box("cutPlate", cutHalfLengthX, cutHalfLengthY, cutHalfLengthZ);
 
-    // move cutting box to the "build origin" (see technical drawings)
-    G4double moveCutZ = -1.0*(fCanFaceToBuildOrigin + fGapThickness + fCanThicknessFront + fBgoLength/2.0);
-    G4ThreeVector moveCut((cutHalfLengthX-fGapThickness-fCanThickness)/(cos(fChoppingOuterAngle)),0,moveCutZ);
+	// move cutting box to the "build origin" (see technical drawings)
+	G4double moveCutZ = -1.0*(fCanFaceToBuildOrigin + fGapThickness + fCanThicknessFront + fBgoLength/2.0);
+	G4ThreeVector moveCut((cutHalfLengthX-fGapThickness-fCanThickness)/(cos(fChoppingOuterAngle)),0,moveCutZ);
 
-    // rotate our cutting block to the "chopping" angle
-    G4RotationMatrix* rotateCut = new G4RotationMatrix;
-    rotateCut->rotateY(-1.0*fChoppingOuterAngle);
+	// rotate our cutting block to the "chopping" angle
+	G4RotationMatrix* rotateCut = new G4RotationMatrix;
+	rotateCut->rotateY(-1.0*fChoppingOuterAngle);
 
-    // snip snip
-    G4SubtractionSolid* bgoBlockCut = new G4SubtractionSolid("bgoBlockCut", bgoBlock, cutPlate, rotateCut, moveCut);
+	// snip snip
+	G4SubtractionSolid* bgoBlockCut = new G4SubtractionSolid("bgoBlockCut", bgoBlock, cutPlate, rotateCut, moveCut);
 
-    return bgoBlockCut;
+	return bgoBlockCut;
 }
 
 G4SubtractionSolid* DetectionSystemAncillaryBGO::VacuumPiece() {
-    G4double startPhi = 0.0*deg;
-    G4double endPhi = 120.0*deg;
+	G4double startPhi = 0.0*deg;
+	G4double endPhi = 120.0*deg;
 
-    G4double innerRadius = fCanInnerRadius+fCanThickness;
-    G4double outerRadius = innerRadius+fGapThickness+fBgoThickness+fGapThicknessOuter;
-    G4double halfLengthZ = (fBgoLength + fGapThickness)/2.0;
+	G4double innerRadius = fCanInnerRadius+fCanThickness;
+	G4double outerRadius = innerRadius+fGapThickness+fBgoThickness+fGapThicknessOuter;
+	G4double halfLengthZ = (fBgoLength + fGapThickness)/2.0;
 
-    G4Tubs* vacuumBlock = new G4Tubs("vacuumBlock", innerRadius, outerRadius, halfLengthZ, startPhi, endPhi);
+	G4Tubs* vacuumBlock = new G4Tubs("vacuumBlock", innerRadius, outerRadius, halfLengthZ, startPhi, endPhi);
 
-    // turn the block to be symmetric about 0 degress so we can cut it.
-    vacuumBlock->SetStartPhiAngle(-60.0*deg,true);
-    vacuumBlock->SetDeltaPhiAngle(120.0*deg);
+	// turn the block to be symmetric about 0 degress so we can cut it.
+	vacuumBlock->SetStartPhiAngle(-60.0*deg,true);
+	vacuumBlock->SetDeltaPhiAngle(120.0*deg);
 
-    // grab the scissors, time to cut.
-    // make the cut surface unnecessarily large.
-    G4double cutHalfLengthZ = 2.0*fCanFaceToBuildOrigin;
-    G4double cutHalfLengthX = 2.0*fCanFaceToBuildOrigin;
-    G4double cutHalfLengthY = 2.0*fCanFaceToBuildOrigin;
+	// grab the scissors, time to cut.
+	// make the cut surface unnecessarily large.
+	G4double cutHalfLengthZ = 2.0*fCanFaceToBuildOrigin;
+	G4double cutHalfLengthX = 2.0*fCanFaceToBuildOrigin;
+	G4double cutHalfLengthY = 2.0*fCanFaceToBuildOrigin;
 
-    G4Box* cutPlate = new G4Box("cutPlate", cutHalfLengthX, cutHalfLengthY, cutHalfLengthZ);
+	G4Box* cutPlate = new G4Box("cutPlate", cutHalfLengthX, cutHalfLengthY, cutHalfLengthZ);
 
-    // move cutting box to the "build origin" (see technical drawings)
-    G4double moveCutZ = -1.0*(fCanFaceToBuildOrigin + fGapThickness + fCanThicknessFront + fBgoLength/2.0);
-    G4ThreeVector moveCut((cutHalfLengthX-fCanThickness)/(cos(fChoppingOuterAngle)),0,moveCutZ);
+	// move cutting box to the "build origin" (see technical drawings)
+	G4double moveCutZ = -1.0*(fCanFaceToBuildOrigin + fGapThickness + fCanThicknessFront + fBgoLength/2.0);
+	G4ThreeVector moveCut((cutHalfLengthX-fCanThickness)/(cos(fChoppingOuterAngle)),0,moveCutZ);
 
-    // rotate our cutting block to the "chopping" angle
-    G4RotationMatrix* rotateCut = new G4RotationMatrix;
-    rotateCut->rotateY(-1.0*fChoppingOuterAngle);
+	// rotate our cutting block to the "chopping" angle
+	G4RotationMatrix* rotateCut = new G4RotationMatrix;
+	rotateCut->rotateY(-1.0*fChoppingOuterAngle);
 
-    // snip snip
-    G4SubtractionSolid* vacuumBlockCut = new G4SubtractionSolid("vacuumBlockCut", vacuumBlock, cutPlate, rotateCut, moveCut);
+	// snip snip
+	G4SubtractionSolid* vacuumBlockCut = new G4SubtractionSolid("vacuumBlockCut", vacuumBlock, cutPlate, rotateCut, moveCut);
 
-    // Now we have to do another cut on the vacuum.
-    // We need to remove the area where the BGO sits
-    // let's take this piece larger in phi to make sure we cut everything
-    startPhi = 0.0*deg;
-    endPhi = 140.0*deg;
+	// Now we have to do another cut on the vacuum.
+	// We need to remove the area where the BGO sits
+	// let's take this piece larger in phi to make sure we cut everything
+	startPhi = 0.0*deg;
+	endPhi = 140.0*deg;
 
-    innerRadius = fCanInnerRadius+fCanThickness+fGapThickness;
-    outerRadius = innerRadius+fBgoThickness;
-    halfLengthZ = (fBgoLength + fGapThickness)/2.0;
+	innerRadius = fCanInnerRadius+fCanThickness+fGapThickness;
+	outerRadius = innerRadius+fBgoThickness;
+	halfLengthZ = (fBgoLength + fGapThickness)/2.0;
 
-    G4Tubs* vacuumBlockCutBgo = new G4Tubs("vacuumBlockCutBgo", innerRadius, outerRadius, halfLengthZ, startPhi, endPhi);
+	G4Tubs* vacuumBlockCutBgo = new G4Tubs("vacuumBlockCutBgo", innerRadius, outerRadius, halfLengthZ, startPhi, endPhi);
 
-    // turn the block to be symmetric about 0 degress so we can cut it.
-    vacuumBlockCutBgo->SetStartPhiAngle(-70.0*deg,true);
-    vacuumBlockCutBgo->SetDeltaPhiAngle(140.0*deg);
+	// turn the block to be symmetric about 0 degress so we can cut it.
+	vacuumBlockCutBgo->SetStartPhiAngle(-70.0*deg,true);
+	vacuumBlockCutBgo->SetDeltaPhiAngle(140.0*deg);
 
-    // grab the scissors, time to cut.
-    // make the cut surface unnecessarily large.
-    cutHalfLengthZ = 2.0*fCanFaceToBuildOrigin;
-    cutHalfLengthX = 2.0*fCanFaceToBuildOrigin;
-    cutHalfLengthY = 2.0*fCanFaceToBuildOrigin;
+	// grab the scissors, time to cut.
+	// make the cut surface unnecessarily large.
+	cutHalfLengthZ = 2.0*fCanFaceToBuildOrigin;
+	cutHalfLengthX = 2.0*fCanFaceToBuildOrigin;
+	cutHalfLengthY = 2.0*fCanFaceToBuildOrigin;
 
-    G4Box* cutPlateForBgo = new G4Box("cutPlateForBgo", cutHalfLengthX, cutHalfLengthY, cutHalfLengthZ);
+	G4Box* cutPlateForBgo = new G4Box("cutPlateForBgo", cutHalfLengthX, cutHalfLengthY, cutHalfLengthZ);
 
-    // move cutting box to the "build origin" (see technical drawings)
-    moveCutZ = -1.0*(fCanFaceToBuildOrigin + fGapThickness + fCanThicknessFront + (fBgoLength + fGapThickness)/2.0);
-    G4ThreeVector moveCutForBgo((cutHalfLengthX-fCanThickness-fGapThickness)/(cos(fChoppingOuterAngle)),0,moveCutZ);
+	// move cutting box to the "build origin" (see technical drawings)
+	moveCutZ = -1.0*(fCanFaceToBuildOrigin + fGapThickness + fCanThicknessFront + (fBgoLength + fGapThickness)/2.0);
+	G4ThreeVector moveCutForBgo((cutHalfLengthX-fCanThickness-fGapThickness)/(cos(fChoppingOuterAngle)),0,moveCutZ);
 
-    // rotate our cutting block to the "chopping" angle
-    G4RotationMatrix* rotateCutForBgo = new G4RotationMatrix;
-    rotateCutForBgo->rotateY(-1.0*fChoppingOuterAngle);
+	// rotate our cutting block to the "chopping" angle
+	G4RotationMatrix* rotateCutForBgo = new G4RotationMatrix;
+	rotateCutForBgo->rotateY(-1.0*fChoppingOuterAngle);
 
-    // snip snip
-    G4SubtractionSolid* bgoBlockToBeCutOut = new G4SubtractionSolid("bgoBlockToBeCutOut", vacuumBlockCutBgo, cutPlateForBgo, rotateCutForBgo, moveCutForBgo);
+	// snip snip
+	G4SubtractionSolid* bgoBlockToBeCutOut = new G4SubtractionSolid("bgoBlockToBeCutOut", vacuumBlockCutBgo, cutPlateForBgo, rotateCutForBgo, moveCutForBgo);
 
-    // now we can remove the BGO area from inside the vacuum
-    // move cut just along z-axis by the amount of the gapThickness (both vacuum and bgo blacks are same size)
-    G4ThreeVector moveCutMe(0, 0, fGapThickness);
-    // no rotation
-    G4RotationMatrix* rotateCutMe = new G4RotationMatrix;
-    // final snip snip
-    G4SubtractionSolid* vacuumBlockWithBgoCutOut = new G4SubtractionSolid("vacuumBlockWithBgoCutOut", vacuumBlockCut, bgoBlockToBeCutOut, rotateCutMe, moveCutMe);
+	// now we can remove the BGO area from inside the vacuum
+	// move cut just along z-axis by the amount of the gapThickness (both vacuum and bgo blacks are same size)
+	G4ThreeVector moveCutMe(0, 0, fGapThickness);
+	// no rotation
+	G4RotationMatrix* rotateCutMe = new G4RotationMatrix;
+	// final snip snip
+	G4SubtractionSolid* vacuumBlockWithBgoCutOut = new G4SubtractionSolid("vacuumBlockWithBgoCutOut", vacuumBlockCut, bgoBlockToBeCutOut, rotateCutMe, moveCutMe);
 
-    return vacuumBlockWithBgoCutOut;
+	return vacuumBlockWithBgoCutOut;
 }
 
 G4SubtractionSolid* DetectionSystemAncillaryBGO::AluminumCanPiece() {
-    G4double startPhi = 0.0*deg;
-    G4double endPhi = 120.0*deg;
+	G4double startPhi = 0.0*deg;
+	G4double endPhi = 120.0*deg;
 
-    G4double innerRadius = fCanInnerRadius;
-    G4double outerRadius = innerRadius+fCanThickness+fGapThickness+fBgoThickness+fGapThicknessOuter+fCanThickness; //2*fCanThickness ???
-    G4double halfLengthZ = (fCanLength)/2.0;
+	G4double innerRadius = fCanInnerRadius;
+	G4double outerRadius = innerRadius+fCanThickness+fGapThickness+fBgoThickness+fGapThicknessOuter+fCanThickness; //2*fCanThickness ???
+	G4double halfLengthZ = (fCanLength)/2.0;
 
-    G4Tubs* canBlock = new G4Tubs("canBlock", innerRadius, outerRadius, halfLengthZ, startPhi, endPhi);
+	G4Tubs* canBlock = new G4Tubs("canBlock", innerRadius, outerRadius, halfLengthZ, startPhi, endPhi);
 
-    // turn the block to be symmetric about 0 degress so we can cut it.
-    canBlock->SetStartPhiAngle(-60.0*deg,true);
-    canBlock->SetDeltaPhiAngle(120.0*deg);
+	// turn the block to be symmetric about 0 degress so we can cut it.
+	canBlock->SetStartPhiAngle(-60.0*deg,true);
+	canBlock->SetDeltaPhiAngle(120.0*deg);
 
-    // grab the scissors, time to cut.
-    // make the cut surface unnecessarily large.
-    G4double cutHalfLengthZ = 2.0*fCanFaceToBuildOrigin;
-    G4double cutHalfLengthX = 2.0*fCanFaceToBuildOrigin;
-    G4double cutHalfLengthY = 2.0*fCanFaceToBuildOrigin;
+	// grab the scissors, time to cut.
+	// make the cut surface unnecessarily large.
+	G4double cutHalfLengthZ = 2.0*fCanFaceToBuildOrigin;
+	G4double cutHalfLengthX = 2.0*fCanFaceToBuildOrigin;
+	G4double cutHalfLengthY = 2.0*fCanFaceToBuildOrigin;
 
-    G4Box* cutPlate = new G4Box("cutPlate", cutHalfLengthX, cutHalfLengthY, cutHalfLengthZ);
+	G4Box* cutPlate = new G4Box("cutPlate", cutHalfLengthX, cutHalfLengthY, cutHalfLengthZ);
 
-    // move cutting box to the "build origin" (see technical drawings)
-    G4double moveCutZ = -1.0*(fCanFaceToBuildOrigin + fCanLength/2.0);
-    G4ThreeVector moveCut((cutHalfLengthX)/(cos(fChoppingOuterAngle)),0,moveCutZ);
+	// move cutting box to the "build origin" (see technical drawings)
+	G4double moveCutZ = -1.0*(fCanFaceToBuildOrigin + fCanLength/2.0);
+	G4ThreeVector moveCut((cutHalfLengthX)/(cos(fChoppingOuterAngle)),0,moveCutZ);
 
-    // rotate our cutting block to the "chopping" angle
-    G4RotationMatrix* rotateCut = new G4RotationMatrix;
-    rotateCut->rotateY(-1.0*fChoppingOuterAngle);
+	// rotate our cutting block to the "chopping" angle
+	G4RotationMatrix* rotateCut = new G4RotationMatrix;
+	rotateCut->rotateY(-1.0*fChoppingOuterAngle);
 
-    // snip snip
-    G4SubtractionSolid* canBlockCut = new G4SubtractionSolid("canBlockCut", canBlock, cutPlate, rotateCut, moveCut);
+	// snip snip
+	G4SubtractionSolid* canBlockCut = new G4SubtractionSolid("canBlockCut", canBlock, cutPlate, rotateCut, moveCut);
 
-    // Now we have to do another cut on the can.
-    // We need to remove the area where the vacuum and BGO sits
-    // let's take this piece larger in phi to make sure we cut everything
-    startPhi = 0.0*deg;
-    endPhi = 140.0*deg;
+	// Now we have to do another cut on the can.
+	// We need to remove the area where the vacuum and BGO sits
+	// let's take this piece larger in phi to make sure we cut everything
+	startPhi = 0.0*deg;
+	endPhi = 140.0*deg;
 
-    innerRadius = fCanInnerRadius+fCanThickness;
-    outerRadius = innerRadius+fGapThickness+fBgoThickness+fGapThicknessOuter;
-    halfLengthZ = (fCanLength)/2.0;
+	innerRadius = fCanInnerRadius+fCanThickness;
+	outerRadius = innerRadius+fGapThickness+fBgoThickness+fGapThicknessOuter;
+	halfLengthZ = (fCanLength)/2.0;
 
-    G4Tubs* canBlockCutVacuum = new G4Tubs("canBlockCutVacuum", innerRadius, outerRadius, halfLengthZ, startPhi, endPhi);
+	G4Tubs* canBlockCutVacuum = new G4Tubs("canBlockCutVacuum", innerRadius, outerRadius, halfLengthZ, startPhi, endPhi);
 
-    // turn the block to be symmetric about 0 degress so we can cut it.
-    canBlockCutVacuum->SetStartPhiAngle(-70.0*deg,true);
-    canBlockCutVacuum->SetDeltaPhiAngle(140.0*deg);
+	// turn the block to be symmetric about 0 degress so we can cut it.
+	canBlockCutVacuum->SetStartPhiAngle(-70.0*deg,true);
+	canBlockCutVacuum->SetDeltaPhiAngle(140.0*deg);
 
-    // grab the scissors, time to cut.
-    // make the cut surface unnecessarily large.
-    cutHalfLengthZ = 2.0*fCanFaceToBuildOrigin;
-    cutHalfLengthX = 2.0*fCanFaceToBuildOrigin;
-    cutHalfLengthY = 2.0*fCanFaceToBuildOrigin;
+	// grab the scissors, time to cut.
+	// make the cut surface unnecessarily large.
+	cutHalfLengthZ = 2.0*fCanFaceToBuildOrigin;
+	cutHalfLengthX = 2.0*fCanFaceToBuildOrigin;
+	cutHalfLengthY = 2.0*fCanFaceToBuildOrigin;
 
-    G4Box* cutPlate3 = new G4Box("cutPlate3", cutHalfLengthX, cutHalfLengthY, cutHalfLengthZ);
+	G4Box* cutPlate3 = new G4Box("cutPlate3", cutHalfLengthX, cutHalfLengthY, cutHalfLengthZ);
 
-    // move cutting box to the "build origin" (see technical drawings)
-    moveCutZ = -1.0*(fCanFaceToBuildOrigin + fCanThicknessFront + fCanLength/2.0);
-    G4ThreeVector moveCut3((cutHalfLengthX-fCanThickness)/(cos(fChoppingOuterAngle)),0,moveCutZ);
+	// move cutting box to the "build origin" (see technical drawings)
+	moveCutZ = -1.0*(fCanFaceToBuildOrigin + fCanThicknessFront + fCanLength/2.0);
+	G4ThreeVector moveCut3((cutHalfLengthX-fCanThickness)/(cos(fChoppingOuterAngle)),0,moveCutZ);
 
-    // rotate our cutting block to the "chopping" angle
-    G4RotationMatrix* rotateCut3 = new G4RotationMatrix;
-    rotateCut3->rotateY(-1.0*fChoppingOuterAngle);
+	// rotate our cutting block to the "chopping" angle
+	G4RotationMatrix* rotateCut3 = new G4RotationMatrix;
+	rotateCut3->rotateY(-1.0*fChoppingOuterAngle);
 
-    // snip snip
-    G4SubtractionSolid* vacuumBlockToBeCutOut = new G4SubtractionSolid("vacuumBlockToBeCutOut", canBlockCutVacuum, cutPlate3, rotateCut3, moveCut3);
+	// snip snip
+	G4SubtractionSolid* vacuumBlockToBeCutOut = new G4SubtractionSolid("vacuumBlockToBeCutOut", canBlockCutVacuum, cutPlate3, rotateCut3, moveCut3);
 
-    // now we can remove the vacuum/BGO area from inside the can
-    // move cut just along z-axis by the amount of the canThicknessFront (both vacuum and can blacks are same size)
-    G4ThreeVector moveCutMe(0,0,fCanThicknessFront);
-    // no rotation
-    G4RotationMatrix* rotateCutMe = new G4RotationMatrix;
-    // final snip snip
-    G4SubtractionSolid* canBlockWithVacuumCutOut = new G4SubtractionSolid("canBlockCut", canBlockCut, vacuumBlockToBeCutOut, rotateCutMe, moveCutMe);
+	// now we can remove the vacuum/BGO area from inside the can
+	// move cut just along z-axis by the amount of the canThicknessFront (both vacuum and can blacks are same size)
+	G4ThreeVector moveCutMe(0,0,fCanThicknessFront);
+	// no rotation
+	G4RotationMatrix* rotateCutMe = new G4RotationMatrix;
+	// final snip snip
+	G4SubtractionSolid* canBlockWithVacuumCutOut = new G4SubtractionSolid("canBlockCut", canBlockCut, vacuumBlockToBeCutOut, rotateCutMe, moveCutMe);
 
-    return canBlockWithVacuumCutOut;
+	return canBlockWithVacuumCutOut;
 }
 
 
 G4Tubs* DetectionSystemAncillaryBGO::AluminumCanBackCover() {
-    G4double startPhi = 0.0*deg;
-    G4double endPhi = 120.0*deg;
+	G4double startPhi = 0.0*deg;
+	G4double endPhi = 120.0*deg;
 
-    G4double innerRadius = fCanInnerRadius+fCanThickness;
-    G4double outerRadius = innerRadius+fCanThickness+fGapThickness+fBgoThickness+fGapThicknessOuter;
-    G4double halfLengthZ = (fCanThickness)/2.0;
+	G4double innerRadius = fCanInnerRadius+fCanThickness;
+	G4double outerRadius = innerRadius+fCanThickness+fGapThickness+fBgoThickness+fGapThicknessOuter;
+	G4double halfLengthZ = (fCanThickness)/2.0;
 
-    G4Tubs* canBlock = new G4Tubs("canBlock", innerRadius, outerRadius, halfLengthZ, startPhi, endPhi);
+	G4Tubs* canBlock = new G4Tubs("canBlock", innerRadius, outerRadius, halfLengthZ, startPhi, endPhi);
 
-    // turn the block to be symmetric about 0 degress
-    canBlock->SetStartPhiAngle(-60.0*deg,true);
-    canBlock->SetDeltaPhiAngle(120.0*deg);
+	// turn the block to be symmetric about 0 degress
+	canBlock->SetStartPhiAngle(-60.0*deg,true);
+	canBlock->SetDeltaPhiAngle(120.0*deg);
 
-    return canBlock;
+	return canBlock;
 }
 
 G4SubtractionSolid* DetectionSystemAncillaryBGO::HevimetPiece() {// this has been fix 
-    G4double startPhi = 0.0*deg;
-    G4double endPhi = 120.0*deg;
+	G4double startPhi = 0.0*deg;
+	G4double endPhi = 120.0*deg;
 
-    G4double innerRadius = 0.0*mm;
-    G4double outerRadius = fCanInnerRadius+fCanThickness+fGapThickness+fBgoThickness+fGapThicknessOuter+fCanThickness; //2*fCanThickness ???
-    G4double halfLengthZ = (fHevimetThickness)/2.0;
+	G4double innerRadius = 0.0*mm;
+	G4double outerRadius = fCanInnerRadius+fCanThickness+fGapThickness+fBgoThickness+fGapThicknessOuter+fCanThickness; //2*fCanThickness ???
+	G4double halfLengthZ = (fHevimetThickness)/2.0;
 
-    G4Tubs* hevimetBlock = new G4Tubs("hevimetBlock", innerRadius, outerRadius, halfLengthZ, startPhi, endPhi);
+	G4Tubs* hevimetBlock = new G4Tubs("hevimetBlock", innerRadius, outerRadius, halfLengthZ, startPhi, endPhi);
 
-    // turn the block to be symmetric about 0 degress so we can cut it.
-    hevimetBlock->SetStartPhiAngle(-60.0*deg,true);
-    hevimetBlock->SetDeltaPhiAngle(120.0*deg);
+	// turn the block to be symmetric about 0 degress so we can cut it.
+	hevimetBlock->SetStartPhiAngle(-60.0*deg,true);
+	hevimetBlock->SetDeltaPhiAngle(120.0*deg);
 
-    // grab the scissors, time to cut.
-    // make the cut surface unnecessarily large.
-    G4double cutHalfLengthZ = 2.0*fCanFaceToBuildOrigin;
-    G4double cutHalfLengthX = 2.0*fCanFaceToBuildOrigin;
-    G4double cutHalfLengthY = 2.0*fCanFaceToBuildOrigin;
+	// grab the scissors, time to cut.
+	// make the cut surface unnecessarily large.
+	G4double cutHalfLengthZ = 2.0*fCanFaceToBuildOrigin;
+	G4double cutHalfLengthX = 2.0*fCanFaceToBuildOrigin;
+	G4double cutHalfLengthY = 2.0*fCanFaceToBuildOrigin;
 
-    G4Box* cutPlate = new G4Box("cutPlate", cutHalfLengthX, cutHalfLengthY, cutHalfLengthZ);
+	G4Box* cutPlate = new G4Box("cutPlate", cutHalfLengthX, cutHalfLengthY, cutHalfLengthZ);
 
-    // move cutting box to the "build origin" (see technical drawings)
-    G4double moveCutZ = -1.0*(fCanFaceToBuildOrigin)+fHevimetThickness/2.0;
-    G4ThreeVector moveCut((cutHalfLengthX)/(cos(fChoppingOuterAngle)),0,moveCutZ);
+	// move cutting box to the "build origin" (see technical drawings)
+	G4double moveCutZ = -1.0*(fCanFaceToBuildOrigin)+fHevimetThickness/2.0;
+	G4ThreeVector moveCut((cutHalfLengthX)/(cos(fChoppingOuterAngle)),0,moveCutZ);
 
-    // rotate our cutting block to the "chopping" angle
-    G4RotationMatrix* rotateCut = new G4RotationMatrix;
-    rotateCut->rotateY(-1.0*fChoppingOuterAngle);
+	// rotate our cutting block to the "chopping" angle
+	G4RotationMatrix* rotateCut = new G4RotationMatrix;
+	rotateCut->rotateY(-1.0*fChoppingOuterAngle);
 
-    // snip snip
-    G4SubtractionSolid* hevimetBlockCut = new G4SubtractionSolid("hevimetBlockCut", hevimetBlock, cutPlate, rotateCut, moveCut);
-
-
-    // Now we need to cone in the middle.
-    G4double coneInnerRadius = 0.0*mm;
-    G4double coneLowerOuterRadius = 0.0*mm;
-    G4double coneUpperOuterRadius = tan(fChoppingInnerAngle)*(fCanFaceToBuildOrigin+fHevimetThickness);
-    G4double coneHalfLengthZ = (fCanFaceToBuildOrigin+fHevimetThickness)/2.0;
-
-    G4Cons* hevimetCutCone = new G4Cons("hevimetCutCone", coneInnerRadius, coneLowerOuterRadius, coneInnerRadius, coneUpperOuterRadius, coneHalfLengthZ, 0.0*deg, 360.0*deg);
-
-    // now we can remove the inner radius from the Hevimet
-    // move cut just along z-axis by the amount of the canThicknessFront (both vacuum and can blacks are same size)
-    G4ThreeVector moveCutMe(0,0,-1.0*(fCanFaceToBuildOrigin)/2.0+fHevimetThickness/2.0);
-    // no rotation
-    G4RotationMatrix* rotateCutMe = new G4RotationMatrix;
-    // final snip snip
-    G4SubtractionSolid* hevimetBlockCutWithConeCut = new G4SubtractionSolid("hevimetBlockCutWithConeCut", hevimetBlockCut, hevimetCutCone, rotateCutMe, moveCutMe);
+	// snip snip
+	G4SubtractionSolid* hevimetBlockCut = new G4SubtractionSolid("hevimetBlockCut", hevimetBlock, cutPlate, rotateCut, moveCut);
 
 
-    return hevimetBlockCutWithConeCut;
+	// Now we need to cone in the middle.
+	G4double coneInnerRadius = 0.0*mm;
+	G4double coneLowerOuterRadius = 0.0*mm;
+	G4double coneUpperOuterRadius = tan(fChoppingInnerAngle)*(fCanFaceToBuildOrigin+fHevimetThickness);
+	G4double coneHalfLengthZ = (fCanFaceToBuildOrigin+fHevimetThickness)/2.0;
+
+	G4Cons* hevimetCutCone = new G4Cons("hevimetCutCone", coneInnerRadius, coneLowerOuterRadius, coneInnerRadius, coneUpperOuterRadius, coneHalfLengthZ, 0.0*deg, 360.0*deg);
+
+	// now we can remove the inner radius from the Hevimet
+	// move cut just along z-axis by the amount of the canThicknessFront (both vacuum and can blacks are same size)
+	G4ThreeVector moveCutMe(0,0,-1.0*(fCanFaceToBuildOrigin)/2.0+fHevimetThickness/2.0);
+	// no rotation
+	G4RotationMatrix* rotateCutMe = new G4RotationMatrix;
+	// final snip snip
+	G4SubtractionSolid* hevimetBlockCutWithConeCut = new G4SubtractionSolid("hevimetBlockCutWithConeCut", hevimetBlockCut, hevimetCutCone, rotateCutMe, moveCutMe);
+
+
+	return hevimetBlockCutWithConeCut;
 }
 
 
 //Calculate a direction vector from spherical theta & phi components
 G4ThreeVector DetectionSystemAncillaryBGO::GetDirectionXYZ(G4double theta, G4double phi) {
-    G4double x,y,z;
-    x = sin(theta) * cos(phi);
-    y = sin(theta) * sin(phi);
-    z = cos(theta);
+	G4double x,y,z;
+	x = sin(theta) * cos(phi);
+	y = sin(theta) * sin(phi);
+	z = cos(theta);
 
-    G4ThreeVector direction = G4ThreeVector(x,y,z);
+	G4ThreeVector direction = G4ThreeVector(x,y,z);
 
-    return direction;
+	return direction;
 }//end ::GetDirection

--- a/src/DetectionSystemBox.cc
+++ b/src/DetectionSystemBox.cc
@@ -21,185 +21,184 @@
 #include "G4SystemOfUnits.hh" // new version geant4.10 requires units
 
 DetectionSystemBox::DetectionSystemBox(G4double xLengthIn, G4double yLengthIn, G4double zLengthIn, G4double thicknessIn, G4String boxMat, G4ThreeVector boxColour) :
-    // LogicalVolumes
-    fCellLog(0),
-    fSideNormXLog(0),
-    fSideNormYLog(0),
-    fSideNormZLog(0)
+	// LogicalVolumes
+	fCellLog(0),
+	fSideNormXLog(0),
+	fSideNormYLog(0),
+	fSideNormZLog(0)
 { 
 
-    fXLength = xLengthIn;
-    fYLength = yLengthIn;
-    fZLength = zLengthIn;
+	fXLength = xLengthIn;
+	fYLength = yLengthIn;
+	fZLength = zLengthIn;
 
-    fThickness = thicknessIn;
+	fThickness = thicknessIn;
 
-    fCellMaterial = boxMat;
+	fCellMaterial = boxMat;
 
-    fCellColour = boxColour;
+	fCellColour = boxColour;
 }
 
 DetectionSystemBox::~DetectionSystemBox()
 {
-    // LogicalVolumes
-    delete fCellLog;
-    delete fSideNormXLog;
-    delete fSideNormYLog;
-    delete fSideNormZLog;
+	// LogicalVolumes
+	delete fCellLog;
+	delete fSideNormXLog;
+	delete fSideNormYLog;
+	delete fSideNormZLog;
 
-    //    delete crystalBlockSD;
+	//    delete crystalBlockSD;
 }
 
 //G4int DetectionSystemBox::Build(G4SDManager* mySDman)
 G4int DetectionSystemBox::Build()
 { 
-    // Build assembly volume
-    fAssembly = new G4AssemblyVolume();
+	// Build assembly volume
+	fAssembly = new G4AssemblyVolume();
 
-    G4cout << "BuildXNormalVolumes" << G4endl;
-    BuildXNormalVolumes();
-    BuildYNormalVolumes();
-    BuildZNormalVolumes();
+	G4cout<<"BuildXNormalVolumes"<<G4endl;
+	BuildXNormalVolumes();
+	BuildYNormalVolumes();
+	BuildZNormalVolumes();
 
-    return 1;
+	return 1;
 }
 
 G4int DetectionSystemBox::PlaceDetector(G4LogicalVolume* expHallLog)
 {
-    G4int cellNumber = 1;
+	G4int cellNumber = 1;
 
-    G4ThreeVector position = G4ThreeVector(0.0*mm,0.0*mm,0.0*mm);
-    G4RotationMatrix* rotate  = new G4RotationMatrix;
+	G4ThreeVector position = G4ThreeVector(0.0*mm,0.0*mm,0.0*mm);
+	G4RotationMatrix* rotate  = new G4RotationMatrix;
 
-    fAssembly->MakeImprint(expHallLog, position, rotate, cellNumber);
+	fAssembly->MakeImprint(expHallLog, position, rotate, cellNumber);
 
-    return 1;
+	return 1;
 }
 
 G4int DetectionSystemBox::BuildXNormalVolumes()
 {
-    G4Material* material = G4Material::GetMaterial(fCellMaterial);
-    if( !material ) {
-        G4cout << " ----> Material " << fCellMaterial << " not found, cannot build the detector shell! " << G4endl;
-        return 0;
-    }
+	G4Material* material = G4Material::GetMaterial(fCellMaterial);
+	if(!material) {
+		G4cout<<" ----> Material "<<fCellMaterial<<" not found, cannot build the detector shell! "<<G4endl;
+		return 0;
+	}
 
-    // Set visualization attributes
-    G4VisAttributes* visAtt = new G4VisAttributes(G4Colour(fCellColour));
-    visAtt->SetVisibility(true);
+	// Set visualization attributes
+	G4VisAttributes* visAtt = new G4VisAttributes(G4Colour(fCellColour));
+	visAtt->SetVisibility(true);
 
 
-    G4Box* sideNormX = BuildXNormalSide();
+	G4Box* sideNormX = BuildXNormalSide();
 
-    // place first side
-    // Define rotation and movement objects
-    G4ThreeVector direction 	= G4ThreeVector(1,0,0);
-    G4double zPosition		= (fXLength+fThickness)/2.0;
-    G4ThreeVector move 		= zPosition * direction;
-    G4RotationMatrix* rotate  = new G4RotationMatrix;
+	// place first side
+	// Define rotation and movement objects
+	G4ThreeVector direction 	= G4ThreeVector(1,0,0);
+	G4double zPosition		= (fXLength+fThickness)/2.0;
+	G4ThreeVector move 		= zPosition * direction;
+	G4RotationMatrix* rotate  = new G4RotationMatrix;
 
-    //logical volume
-    if( fSideNormXLog == NULL )
-    {
-        fSideNormXLog = new G4LogicalVolume(sideNormX, material, "sideNormXLog", 0, 0, 0);
-        fSideNormXLog->SetVisAttributes(visAtt);
-    }
+	//logical volume
+	if(fSideNormXLog == nullptr)
+	{
+		fSideNormXLog = new G4LogicalVolume(sideNormX, material, "sideNormXLog", 0, 0, 0);
+		fSideNormXLog->SetVisAttributes(visAtt);
+	}
 
-    fAssembly->AddPlacedVolume(fSideNormXLog, move, rotate);
+	fAssembly->AddPlacedVolume(fSideNormXLog, move, rotate);
 
-    // place second side
-    // Define rotation and movement objects
-    direction     = G4ThreeVector(-1,0,0);
-    zPosition    = (fXLength+fThickness)/2.0;
-    move          = zPosition * direction;
+	// place second side
+	// Define rotation and movement objects
+	direction     = G4ThreeVector(-1,0,0);
+	zPosition    = (fXLength+fThickness)/2.0;
+	move          = zPosition * direction;
 
-    fAssembly->AddPlacedVolume(fSideNormXLog, move, rotate);
+	fAssembly->AddPlacedVolume(fSideNormXLog, move, rotate);
 
-    return 1;
+	return 1;
 }
 
 G4int DetectionSystemBox::BuildYNormalVolumes()
 {
-    G4Material* material = G4Material::GetMaterial(fCellMaterial);
-    if( !material ) {
-        G4cout << " ----> Material " << fCellMaterial << " not found, cannot build the detector shell! " << G4endl;
-        return 0;
-    }
+	G4Material* material = G4Material::GetMaterial(fCellMaterial);
+	if(!material) {
+		G4cout<<" ----> Material "<<fCellMaterial<<" not found, cannot build the detector shell! "<<G4endl;
+		return 0;
+	}
 
-    // Set visualization attributes
-    G4VisAttributes* visAtt = new G4VisAttributes(G4Colour(fCellColour));
-    visAtt->SetVisibility(true);
+	// Set visualization attributes
+	G4VisAttributes* visAtt = new G4VisAttributes(G4Colour(fCellColour));
+	visAtt->SetVisibility(true);
 
 
-    G4Box* sideNormY = BuildYNormalSide();
+	G4Box* sideNormY = BuildYNormalSide();
 
-    // place first side
-    // Define rotation and movement objects
-    G4ThreeVector direction 	= G4ThreeVector(0,1,0);
-    G4double zPosition		= (fYLength+fThickness)/2.0;
-    G4ThreeVector move 		= zPosition * direction;
-    G4RotationMatrix* rotate  = new G4RotationMatrix;
+	// place first side
+	// Define rotation and movement objects
+	G4ThreeVector direction 	= G4ThreeVector(0,1,0);
+	G4double zPosition		= (fYLength+fThickness)/2.0;
+	G4ThreeVector move 		= zPosition * direction;
+	G4RotationMatrix* rotate  = new G4RotationMatrix;
 
-    //logical volume
-    if( fSideNormYLog == NULL )
-    {
-        fSideNormYLog = new G4LogicalVolume(sideNormY, material, "sideNormYLog", 0, 0, 0);
-        fSideNormYLog->SetVisAttributes(visAtt);
-    }
+	//logical volume
+	if(fSideNormYLog == nullptr)
+	{
+		fSideNormYLog = new G4LogicalVolume(sideNormY, material, "sideNormYLog", 0, 0, 0);
+		fSideNormYLog->SetVisAttributes(visAtt);
+	}
 
-    fAssembly->AddPlacedVolume(fSideNormYLog, move, rotate);
+	fAssembly->AddPlacedVolume(fSideNormYLog, move, rotate);
 
-    // place second side
-    // Define rotation and movement objects
-    direction     = G4ThreeVector(0,-1,0);
-    zPosition    = (fYLength+fThickness)/2.0;
-    move          = zPosition * direction;
+	// place second side
+	// Define rotation and movement objects
+	direction     = G4ThreeVector(0,-1,0);
+	zPosition    = (fYLength+fThickness)/2.0;
+	move          = zPosition * direction;
 
-    fAssembly->AddPlacedVolume(fSideNormYLog, move, rotate);
+	fAssembly->AddPlacedVolume(fSideNormYLog, move, rotate);
 
-    return 1;
+	return 1;
 }
 
 G4int DetectionSystemBox::BuildZNormalVolumes()
 {
-    G4Material* material = G4Material::GetMaterial(fCellMaterial);
-    if( !material ) {
-        G4cout << " ----> Material " << fCellMaterial << " not found, cannot build the detector shell! " << G4endl;
-        return 0;
-    }
+	G4Material* material = G4Material::GetMaterial(fCellMaterial);
+	if(!material) {
+		G4cout<<" ----> Material "<<fCellMaterial<<" not found, cannot build the detector shell! "<<G4endl;
+		return 0;
+	}
 
-    // Set visualization attributes
-    G4VisAttributes* visAtt = new G4VisAttributes(G4Colour(fCellColour));
-    visAtt->SetVisibility(true);
+	// Set visualization attributes
+	G4VisAttributes* visAtt = new G4VisAttributes(G4Colour(fCellColour));
+	visAtt->SetVisibility(true);
 
 
-    G4Box* sideNormZ = BuildZNormalSide();
+	G4Box* sideNormZ = BuildZNormalSide();
 
-    // place first side
-    // Define rotation and movement objects
-    G4ThreeVector direction 	= G4ThreeVector(0,0,1);
-    G4double zPosition		= (fZLength+fThickness)/2.0;
-    G4ThreeVector move 		= zPosition * direction;
-    G4RotationMatrix* rotate  = new G4RotationMatrix;
+	// place first side
+	// Define rotation and movement objects
+	G4ThreeVector direction 	= G4ThreeVector(0,0,1);
+	G4double zPosition		= (fZLength+fThickness)/2.0;
+	G4ThreeVector move 		= zPosition * direction;
+	G4RotationMatrix* rotate  = new G4RotationMatrix;
 
-    //logical volume
-    if( fSideNormZLog == NULL )
-    {
-        fSideNormZLog = new G4LogicalVolume(sideNormZ, material, "sideNormZLog", 0, 0, 0);
-        fSideNormZLog->SetVisAttributes(visAtt);
-    }
+	//logical volume
+	if(fSideNormZLog == nullptr) {
+		fSideNormZLog = new G4LogicalVolume(sideNormZ, material, "sideNormZLog", 0, 0, 0);
+		fSideNormZLog->SetVisAttributes(visAtt);
+	}
 
-    fAssembly->AddPlacedVolume(fSideNormZLog, move, rotate);
+	fAssembly->AddPlacedVolume(fSideNormZLog, move, rotate);
 
-    // place second side
-    // Define rotation and movement objects
-    direction    = G4ThreeVector(0,0,-1);
-    zPosition    = (fZLength+fThickness)/2.0;
-    move         = zPosition * direction;
+	// place second side
+	// Define rotation and movement objects
+	direction    = G4ThreeVector(0,0,-1);
+	zPosition    = (fZLength+fThickness)/2.0;
+	move         = zPosition * direction;
 
-    fAssembly->AddPlacedVolume(fSideNormZLog, move, rotate);
+	fAssembly->AddPlacedVolume(fSideNormZLog, move, rotate);
 
-    return 1;
+	return 1;
 }
 
 ///////////////////////////////////////////////////////////////////////
@@ -207,33 +206,33 @@ G4int DetectionSystemBox::BuildZNormalVolumes()
 ///////////////////////////////////////////////////////////////////////
 G4Box* DetectionSystemBox::BuildXNormalSide()
 {
-    G4double halfLengthX = fThickness/2.0;
-    G4double halfLengthY = (fYLength+(2.0*fThickness))/2.0;
-    G4double halfLengthZ = (fZLength+(2.0*fThickness))/2.0;
+	G4double halfLengthX = fThickness/2.0;
+	G4double halfLengthY = (fYLength+(2.0*fThickness))/2.0;
+	G4double halfLengthZ = (fZLength+(2.0*fThickness))/2.0;
 
-    G4Box* cellX = new G4Box("cellX", halfLengthX, halfLengthY, halfLengthZ);
+	G4Box* cellX = new G4Box("cellX", halfLengthX, halfLengthY, halfLengthZ);
 
-    return cellX;
+	return cellX;
 }//end ::BuildXNormalSide
 
 G4Box* DetectionSystemBox::BuildYNormalSide()
 {
-    G4double halfLengthX = (fXLength)/2.0;
-    G4double halfLengthY = fThickness/2.0;
-    G4double halfLengthZ = (fZLength+(2.0*fThickness))/2.0;
+	G4double halfLengthX = (fXLength)/2.0;
+	G4double halfLengthY = fThickness/2.0;
+	G4double halfLengthZ = (fZLength+(2.0*fThickness))/2.0;
 
-    G4Box* cellY = new G4Box("cellY", halfLengthX, halfLengthY, halfLengthZ);
+	G4Box* cellY = new G4Box("cellY", halfLengthX, halfLengthY, halfLengthZ);
 
-    return cellY;
+	return cellY;
 }//end ::BuildXNormalSide
 
 G4Box* DetectionSystemBox::BuildZNormalSide()
 {
-    G4double halfLengthX = (fXLength)/2.0;
-    G4double halfLengthY = (fYLength)/2.0;
-    G4double halfLengthZ = fThickness/2.0;
+	G4double halfLengthX = (fXLength)/2.0;
+	G4double halfLengthY = (fYLength)/2.0;
+	G4double halfLengthZ = fThickness/2.0;
 
-    G4Box* cellZ = new G4Box("cellZ", halfLengthX, halfLengthY, halfLengthZ);
+	G4Box* cellZ = new G4Box("cellZ", halfLengthX, halfLengthY, halfLengthZ);
 
-    return cellZ;
+	return cellZ;
 }//end ::BuildXNormalSide

--- a/src/DetectionSystemDescant.cc
+++ b/src/DetectionSystemDescant.cc
@@ -29,1068 +29,1068 @@
 #include <string>
 
 DetectionSystemDescant::DetectionSystemDescant(G4bool leadShield) :
-    // LogicalVolumes
-    fBlueVolumeLog(0),
-    fGreenVolumeLog(0),
-    fRedVolumeLog(0),
-    fWhiteVolumeLog(0),
-    fYellowVolumeLog(0),
-    fBlueScintillatorVolumeLog(0),
-    fGreenScintillatorVolumeLog(0),
-    fRedScintillatorVolumeLog(0),
-    fWhiteScintillatorVolumeLog(0),
-    fYellowScintillatorVolumeLog(0),
-    fBlueLeadVolumeLog(0),
-    fGreenLeadVolumeLog(0),
-    fRedLeadVolumeLog(0),
-    fWhiteLeadVolumeLog(0),
-    fYellowLeadVolumeLog(0),
-    fQuartzWindow5inchLog(0),
-    fQuartzWindow3inchLog(0)
+	// LogicalVolumes
+	fBlueVolumeLog(0),
+	fGreenVolumeLog(0),
+	fRedVolumeLog(0),
+	fWhiteVolumeLog(0),
+	fYellowVolumeLog(0),
+	fBlueScintillatorVolumeLog(0),
+	fGreenScintillatorVolumeLog(0),
+	fRedScintillatorVolumeLog(0),
+	fWhiteScintillatorVolumeLog(0),
+	fYellowScintillatorVolumeLog(0),
+	fBlueLeadVolumeLog(0),
+	fGreenLeadVolumeLog(0),
+	fRedLeadVolumeLog(0),
+	fWhiteLeadVolumeLog(0),
+	fYellowLeadVolumeLog(0),
+	fQuartzWindow5inchLog(0),
+	fQuartzWindow3inchLog(0)
 {
-    // can properties
-    fCanLength              = 150.0*mm;
-    fCanThickness           = 1.5*mm;
-    fCanMaterial            = "G4_Al";
-    fLiquidMaterial         = "Deuterated Scintillator";
-    fLeadMaterial           = "G4_Pb";
-    fLeadShieldThickness   = 6.35*mm;
-    fCanBackThickness      = 12.7*mm;   
-   
-    // set DESCANT lead shield on/off (set by run macro)
-    fIncludeLead = leadShield;
+	// can properties
+	fCanLength              = 150.0*mm;
+	fCanThickness           = 1.5*mm;
+	fCanMaterial            = "G4_Al";
+	fLiquidMaterial         = "Deuterated Scintillator";
+	fLeadMaterial           = "G4_Pb";
+	fLeadShieldThickness   = 6.35*mm;
+	fCanBackThickness      = 12.7*mm;   
 
-    // for cutting the PMT port on the detectors
-    fInnerRadiusWindow       = 0.0*mm;     
-    fOuterRadiusWindow5inch  = (127.0*mm)/2.0; 
-    fOuterRadiusWindow3inch  = (76.0*mm)/2.0;  
-    fHalfLengthZWindowCut    = 100.0*mm;
-    fStartPhi                = 0.0*deg;
-    fEndPhi                  = 360.0*deg;
+	// set DESCANT lead shield on/off (set by run macro)
+	fIncludeLead = leadShield;
 
-    fWhitePMTOffsetY         = 4.0*mm;
-    fBluePMTOffsetX          = 3.0*mm;
-    fRedPMTOffsetX           = 12.7*mm;
-    fYellowGreenPMTOffsetX   = 10.0*mm; 
-    fYellowGreenPMTOffsetY   = 5.0*mm;
+	// for cutting the PMT port on the detectors
+	fInnerRadiusWindow       = 0.0*mm;     
+	fOuterRadiusWindow5inch  = (127.0*mm)/2.0; 
+	fOuterRadiusWindow3inch  = (76.0*mm)/2.0;  
+	fHalfLengthZWindowCut    = 100.0*mm;
+	fStartPhi                = 0.0*deg;
+	fEndPhi                  = 360.0*deg;
 
-    fQuartzMaterial                 = "G4_SILICON_DIOXIDE";
-    fOpticalWindowHalfThickness   = (9.0*mm)/2.0;
+	fWhitePMTOffsetY         = 4.0*mm;
+	fBluePMTOffsetX          = 3.0*mm;
+	fRedPMTOffsetX           = 12.7*mm;
+	fYellowGreenPMTOffsetX   = 10.0*mm; 
+	fYellowGreenPMTOffsetY   = 5.0*mm;
 
-    // The face of the detector is 50 cm from the origin, this does NOT include the lead shield.
-    fRadialDistance         = 50*cm;
-    
-    // Check surfaces to determine any problematic overlaps. Turn this on to have Geant4 check the surfaces.
-    // Do not leave this on, it will slow the DetectorConstruction process!
-    // This was last check on May 29th, 2015. - GOOD!, but...
-    // The green, yellow and blue detectors had small overlaps, this is probably due to taking the pure mathematical model
-    // of DESCANT, and then Saint Gobain rounding the result to generate the data files (below).
-    fSurfCheck               = false;
+	fQuartzMaterial                 = "G4_SILICON_DIOXIDE";
+	fOpticalWindowHalfThickness   = (9.0*mm)/2.0;
 
-    // Geometry overlaps were found for green, yellow and blue detectors.               
-    // We need to squeeze the green and yellow detectors along the y direction,                
-    // and we need to squeeze the blue detectors on one x edge of the blue detector.           
-    fTrimGreenY    = 10.0*um;         
-    fTrimYellowY   = 10.0*um;         
-    fTrimBlueX     = 2.2*um;
+	// The face of the detector is 50 cm from the origin, this does NOT include the lead shield.
+	fRadialDistance         = 50*cm;
 
-    // Saint Gobain data files, 6 points around the front face of the can, and 6 on the back
-    // from Dan Brennan
+	// Check surfaces to determine any problematic overlaps. Turn this on to have Geant4 check the surfaces.
+	// Do not leave this on, it will slow the DetectorConstruction process!
+	// This was last check on May 29th, 2015. - GOOD!, but...
+	// The green, yellow and blue detectors had small overlaps, this is probably due to taking the pure mathematical model
+	// of DESCANT, and then Saint Gobain rounding the result to generate the data files (below).
+	fSurfCheck               = false;
 
-    G4double blue[12][3] = {
-        { 40.60*mm,  61.10*mm,    0.00*mm},
-        {-34.70*mm,  61.10*mm,    0.00*mm},
-        {-75.10*mm,   0.00*mm,    0.00*mm},
-        {-34.70*mm, -61.10*mm,    0.00*mm},
-        { 40.60*mm, -61.10*mm,    0.00*mm},
-        { 76.30*mm-fTrimBlueX,   0.00*mm,    0.00*mm},
-        { 52.80*mm,  79.40*mm, -150.00*mm},
-        {-45.10*mm,  79.40*mm, -150.00*mm},
-        {-97.60*mm,   0.00*mm, -150.00*mm},
-        {-45.10*mm, -79.40*mm, -150.00*mm},
-        { 52.80*mm, -79.40*mm, -150.00*mm},
-        { 99.20*mm-fTrimBlueX,   0.00*mm, -150.00*mm}
-    };
+	// Geometry overlaps were found for green, yellow and blue detectors.               
+	// We need to squeeze the green and yellow detectors along the y direction,                
+	// and we need to squeeze the blue detectors on one x edge of the blue detector.           
+	fTrimGreenY    = 10.0*um;         
+	fTrimYellowY   = 10.0*um;         
+	fTrimBlueX     = 2.2*um;
 
-    G4double green[12][3] = {
-        { 31.90*mm,  61.20*mm-fTrimGreenY,    0.00*mm},
-        {-31.90*mm,  61.20*mm-fTrimGreenY,    0.00*mm},
-        {-71.50*mm,   0.00*mm,    0.00*mm},
-        {-31.90*mm, -55.30*mm+fTrimGreenY,    0.00*mm},
-        { 31.90*mm, -55.30*mm+fTrimGreenY,    0.00*mm},
-        { 47.90*mm,  36.60*mm,    0.00*mm},
-        { 41.50*mm,  79.60*mm-fTrimGreenY, -150.00*mm},
-        {-41.50*mm,  79.60*mm-fTrimGreenY, -150.00*mm},
-        {-93.00*mm,   0.00*mm, -150.00*mm},
-        {-41.50*mm, -71.90*mm+fTrimGreenY, -150.00*mm},
-        { 41.50*mm, -71.90*mm+fTrimGreenY, -150.00*mm},
-        { 62.30*mm,  47.60*mm, -150.00*mm}
-    };
+	// Saint Gobain data files, 6 points around the front face of the can, and 6 on the back
+	// from Dan Brennan
 
-    G4double red[12][3] = {
-        { 28.80*mm,  67.00*mm,    0.00*mm},
-        {-39.70*mm,  64.10*mm,    0.00*mm},
-        {-78.30*mm,   0.00*mm,    0.00*mm},
-        {-39.70*mm, -64.10*mm,    0.00*mm},
-        { 28.80*mm, -67.00*mm,    0.00*mm},
-        { 56.20*mm,   0.00*mm,    0.00*mm},
-        { 37.40*mm,  87.10*mm, -150.00*mm},
-        {-51.60*mm,  83.30*mm, -150.00*mm},
-        {-101.80*mm,  0.00*mm, -150.00*mm},
-        {-51.60*mm, -83.30*mm, -150.00*mm},
-        { 37.40*mm, -87.10*mm, -150.00*mm},
-        { 73.10*mm,   0.00*mm, -150.00*mm}
-    };
+	G4double blue[12][3] = {
+		{ 40.60*mm,  61.10*mm,    0.00*mm},
+		{-34.70*mm,  61.10*mm,    0.00*mm},
+		{-75.10*mm,   0.00*mm,    0.00*mm},
+		{-34.70*mm, -61.10*mm,    0.00*mm},
+		{ 40.60*mm, -61.10*mm,    0.00*mm},
+		{ 76.30*mm-fTrimBlueX,   0.00*mm,    0.00*mm},
+		{ 52.80*mm,  79.40*mm, -150.00*mm},
+		{-45.10*mm,  79.40*mm, -150.00*mm},
+		{-97.60*mm,   0.00*mm, -150.00*mm},
+		{-45.10*mm, -79.40*mm, -150.00*mm},
+		{ 52.80*mm, -79.40*mm, -150.00*mm},
+		{ 99.20*mm-fTrimBlueX,   0.00*mm, -150.00*mm}
+	};
 
-    G4double white[12][3] = {
-        { 31.90*mm,  61.20*mm,    0.00*mm},
-        {-31.90*mm,  61.20*mm,    0.00*mm},
-        {-71.50*mm,   0.00*mm,    0.00*mm},
-        {-31.90*mm, -55.30*mm,    0.00*mm},
-        { 31.90*mm, -55.30*mm,    0.00*mm},
-        { 71.50*mm,   0.00*mm,    0.00*mm},
-        { 41.50*mm,  79.60*mm, -150.00*mm},
-        {-41.50*mm,  79.60*mm, -150.00*mm},
-        {-93.00*mm,   0.00*mm, -150.00*mm},
-        {-41.50*mm, -71.90*mm, -150.00*mm},
-        { 41.50*mm, -71.90*mm, -150.00*mm},
-        { 93.00*mm,   0.00*mm, -150.00*mm}
-    };
+	G4double green[12][3] = {
+		{ 31.90*mm,  61.20*mm-fTrimGreenY,    0.00*mm},
+		{-31.90*mm,  61.20*mm-fTrimGreenY,    0.00*mm},
+		{-71.50*mm,   0.00*mm,    0.00*mm},
+		{-31.90*mm, -55.30*mm+fTrimGreenY,    0.00*mm},
+		{ 31.90*mm, -55.30*mm+fTrimGreenY,    0.00*mm},
+		{ 47.90*mm,  36.60*mm,    0.00*mm},
+		{ 41.50*mm,  79.60*mm-fTrimGreenY, -150.00*mm},
+		{-41.50*mm,  79.60*mm-fTrimGreenY, -150.00*mm},
+		{-93.00*mm,   0.00*mm, -150.00*mm},
+		{-41.50*mm, -71.90*mm+fTrimGreenY, -150.00*mm},
+		{ 41.50*mm, -71.90*mm+fTrimGreenY, -150.00*mm},
+		{ 62.30*mm,  47.60*mm, -150.00*mm}
+	};
 
-    G4double yellow[12][3] = {
-        { 31.90*mm,   61.20*mm-fTrimYellowY,    0.00*mm},
-        {-31.90*mm,   61.20*mm-fTrimYellowY,    0.00*mm},
-        {-47.90*mm,   36.60*mm,    0.00*mm},
-        {-31.90*mm,  -55.30*mm+fTrimYellowY,    0.00*mm},
-        { 31.90*mm,  -55.30*mm+fTrimYellowY,    0.00*mm},
-        { 71.50*mm,    0.00*mm,    0.00*mm},
-        { 41.50*mm,   79.60*mm-fTrimYellowY, -150.00*mm},
-        {-41.50*mm,   79.60*mm-fTrimYellowY, -150.00*mm},
-        {-62.30*mm,   47.60*mm, -150.00*mm},
-        {-41.50*mm,  -71.90*mm+fTrimYellowY, -150.00*mm},
-        { 41.50*mm,  -71.90*mm+fTrimYellowY, -150.00*mm},
-        { 93.00*mm,    0.00*mm, -150.00*mm}
-    };
+	G4double red[12][3] = {
+		{ 28.80*mm,  67.00*mm,    0.00*mm},
+		{-39.70*mm,  64.10*mm,    0.00*mm},
+		{-78.30*mm,   0.00*mm,    0.00*mm},
+		{-39.70*mm, -64.10*mm,    0.00*mm},
+		{ 28.80*mm, -67.00*mm,    0.00*mm},
+		{ 56.20*mm,   0.00*mm,    0.00*mm},
+		{ 37.40*mm,  87.10*mm, -150.00*mm},
+		{-51.60*mm,  83.30*mm, -150.00*mm},
+		{-101.80*mm,  0.00*mm, -150.00*mm},
+		{-51.60*mm, -83.30*mm, -150.00*mm},
+		{ 37.40*mm, -87.10*mm, -150.00*mm},
+		{ 73.10*mm,   0.00*mm, -150.00*mm}
+	};
+
+	G4double white[12][3] = {
+		{ 31.90*mm,  61.20*mm,    0.00*mm},
+		{-31.90*mm,  61.20*mm,    0.00*mm},
+		{-71.50*mm,   0.00*mm,    0.00*mm},
+		{-31.90*mm, -55.30*mm,    0.00*mm},
+		{ 31.90*mm, -55.30*mm,    0.00*mm},
+		{ 71.50*mm,   0.00*mm,    0.00*mm},
+		{ 41.50*mm,  79.60*mm, -150.00*mm},
+		{-41.50*mm,  79.60*mm, -150.00*mm},
+		{-93.00*mm,   0.00*mm, -150.00*mm},
+		{-41.50*mm, -71.90*mm, -150.00*mm},
+		{ 41.50*mm, -71.90*mm, -150.00*mm},
+		{ 93.00*mm,   0.00*mm, -150.00*mm}
+	};
+
+	G4double yellow[12][3] = {
+		{ 31.90*mm,   61.20*mm-fTrimYellowY,    0.00*mm},
+		{-31.90*mm,   61.20*mm-fTrimYellowY,    0.00*mm},
+		{-47.90*mm,   36.60*mm,    0.00*mm},
+		{-31.90*mm,  -55.30*mm+fTrimYellowY,    0.00*mm},
+		{ 31.90*mm,  -55.30*mm+fTrimYellowY,    0.00*mm},
+		{ 71.50*mm,    0.00*mm,    0.00*mm},
+		{ 41.50*mm,   79.60*mm-fTrimYellowY, -150.00*mm},
+		{-41.50*mm,   79.60*mm-fTrimYellowY, -150.00*mm},
+		{-62.30*mm,   47.60*mm, -150.00*mm},
+		{-41.50*mm,  -71.90*mm+fTrimYellowY, -150.00*mm},
+		{ 41.50*mm,  -71.90*mm+fTrimYellowY, -150.00*mm},
+		{ 93.00*mm,    0.00*mm, -150.00*mm}
+	};
 
 
-    memcpy(fBlueDetector,   blue,   sizeof(fBlueDetector));
-    memcpy(fGreenDetector,  green,  sizeof(fGreenDetector));
-    memcpy(fRedDetector,    red,    sizeof(fRedDetector));
-    memcpy(fWhiteDetector,  white,  sizeof(fWhiteDetector));
-    memcpy(fYellowDetector, yellow, sizeof(fYellowDetector));
+	memcpy(fBlueDetector,   blue,   sizeof(fBlueDetector));
+	memcpy(fGreenDetector,  green,  sizeof(fGreenDetector));
+	memcpy(fRedDetector,    red,    sizeof(fRedDetector));
+	memcpy(fWhiteDetector,  white,  sizeof(fWhiteDetector));
+	memcpy(fYellowDetector, yellow, sizeof(fYellowDetector));
 
-    // These are the angles of the cuts for each of the 6 sides of the detectors
-    // These were worked out by hand.
-    G4double bluePhiArray[6] = {
-        (90.0*deg),
-        (180.0*deg-(33.4731*deg)),
-        -1.0*(180.0*deg-(33.4731*deg)),
-        -1.0*(90.0*deg),
-        -1.0*(30.2972*deg),
-        (30.2972*deg)
-    };
+	// These are the angles of the cuts for each of the 6 sides of the detectors
+	// These were worked out by hand.
+	G4double bluePhiArray[6] = {
+		(90.0*deg),
+		(180.0*deg-(33.4731*deg)),
+		-1.0*(180.0*deg-(33.4731*deg)),
+		-1.0*(90.0*deg),
+		-1.0*(30.2972*deg),
+		(30.2972*deg)
+	};
 
-    G4double greenPhiArray[6] = {
-        (90.0*deg),
-        (180.0*deg-(32.9052*deg)),
-        -1.0*(180.0*deg-(35.6062*deg)),
-        -1.0*(90.0*deg),
-        -1.0*(9.8763*deg),
-        (33.0402*deg)
-    };
+	G4double greenPhiArray[6] = {
+		(90.0*deg),
+		(180.0*deg-(32.9052*deg)),
+		-1.0*(180.0*deg-(35.6062*deg)),
+		-1.0*(90.0*deg),
+		-1.0*(9.8763*deg),
+		(33.0402*deg)
+	};
 
-    G4double redPhiArray[6] = {
-        (90.0*deg + 2.4242*deg),
-        (180.0*deg-(31.0557*deg)),
-        -1.0*(180.0*deg-(31.0557*deg)),
-        -1.0*(90.0*deg + 2.4242*deg),
-        -1.0*(22.2424*deg),
-        (22.2424*deg)
-    };
+	G4double redPhiArray[6] = {
+		(90.0*deg + 2.4242*deg),
+		(180.0*deg-(31.0557*deg)),
+		-1.0*(180.0*deg-(31.0557*deg)),
+		-1.0*(90.0*deg + 2.4242*deg),
+		-1.0*(22.2424*deg),
+		(22.2424*deg)
+	};
 
-    G4double whitePhiArray[6] = {
-        (90.0*deg),
-        (180.0*deg-(32.9052*deg)),
-        -1.0*(180.0*deg-(35.6062*deg)),
-        -1.0*(90.0*deg),
-        -1.0*(35.6062*deg),
-        (32.9052*deg)
-    };
+	G4double whitePhiArray[6] = {
+		(90.0*deg),
+		(180.0*deg-(32.9052*deg)),
+		-1.0*(180.0*deg-(35.6062*deg)),
+		-1.0*(90.0*deg),
+		-1.0*(35.6062*deg),
+		(32.9052*deg)
+	};
 
-    G4double yellowPhiArray[6] = {
-        (90.0*deg),
-        (180.0*deg-(33.0402*deg)),
-        -1.0*(180.0*deg-(9.8763*deg)),
-        -1.0*(90.0*deg),
-        -1.0*(35.6062*deg),
-        1.0*(32.9052*deg)
-    };
+	G4double yellowPhiArray[6] = {
+		(90.0*deg),
+		(180.0*deg-(33.0402*deg)),
+		-1.0*(180.0*deg-(9.8763*deg)),
+		-1.0*(90.0*deg),
+		-1.0*(35.6062*deg),
+		1.0*(32.9052*deg)
+	};
 
-    memcpy(fBluePhi,    bluePhiArray,     sizeof(fBluePhi));
-    memcpy(fGreenPhi,   greenPhiArray,    sizeof(fGreenPhi));
-    memcpy(fRedPhi,     redPhiArray,      sizeof(fRedPhi));
-    memcpy(fWhitePhi,   whitePhiArray,    sizeof(fWhitePhi));
-    memcpy(fYellowPhi,  yellowPhiArray,   sizeof(fYellowPhi));
+	memcpy(fBluePhi,    bluePhiArray,     sizeof(fBluePhi));
+	memcpy(fGreenPhi,   greenPhiArray,    sizeof(fGreenPhi));
+	memcpy(fRedPhi,     redPhiArray,      sizeof(fRedPhi));
+	memcpy(fWhitePhi,   whitePhiArray,    sizeof(fWhitePhi));
+	memcpy(fYellowPhi,  yellowPhiArray,   sizeof(fYellowPhi));
 
-    // The Euler angles from James' MSc thesis which gives us the detector positions
-    // Some of the angles for the green and yellow detectors are wrong in James' thesis,
-    // note the +180 on a few angles.
-    G4double blueAlphaBetaGammaArray[15][3] = {
-        {	-22.39*deg,	-33.76*deg,	-71.19*deg},
-        {	-49.61*deg,	-33.76*deg,	71.19*deg},
-        {	-36.00*deg,	-46.06*deg,	180.00*deg},
-        {	85.61*deg,	33.76*deg,	108.81*deg},
-        {	58.39*deg,	33.76*deg,	251.19*deg},
-        {	72.00*deg,	46.06*deg,	360.00*deg},
-        {	13.61*deg,	33.76*deg,	108.81*deg},
-        {	-13.61*deg,	33.76*deg,	251.19*deg},
-        {	0.00*deg,	46.06*deg,	360.00*deg},
-        {	-58.39*deg,	33.76*deg,	108.81*deg},
-        {	-85.61*deg,	33.76*deg,	251.19*deg},
-        {	-72.00*deg,	46.06*deg,	360.00*deg},
-        {	49.61*deg,	-33.76*deg,	-71.19*deg},
-        {	22.39*deg,	-33.76*deg,	71.19*deg},
-        {	36.00*deg,	-46.06*deg,	180.00*deg}
-    };
+	// The Euler angles from James' MSc thesis which gives us the detector positions
+	// Some of the angles for the green and yellow detectors are wrong in James' thesis,
+	// note the +180 on a few angles.
+	G4double blueAlphaBetaGammaArray[15][3] = {
+		{	-22.39*deg,	-33.76*deg,	-71.19*deg},
+		{	-49.61*deg,	-33.76*deg,	71.19*deg},
+		{	-36.00*deg,	-46.06*deg,	180.00*deg},
+		{	85.61*deg,	33.76*deg,	108.81*deg},
+		{	58.39*deg,	33.76*deg,	251.19*deg},
+		{	72.00*deg,	46.06*deg,	360.00*deg},
+		{	13.61*deg,	33.76*deg,	108.81*deg},
+		{	-13.61*deg,	33.76*deg,	251.19*deg},
+		{	0.00*deg,	46.06*deg,	360.00*deg},
+		{	-58.39*deg,	33.76*deg,	108.81*deg},
+		{	-85.61*deg,	33.76*deg,	251.19*deg},
+		{	-72.00*deg,	46.06*deg,	360.00*deg},
+		{	49.61*deg,	-33.76*deg,	-71.19*deg},
+		{	22.39*deg,	-33.76*deg,	71.19*deg},
+		{	36.00*deg,	-46.06*deg,	180.00*deg}
+	};
 
-    G4double greenAlphaBetaGammaArray[10][3] = {
-        {	-12.45*deg,	-60.47*deg,	-12.45*deg},
-        {	-27.73*deg,	-58.55*deg,	-4.54*deg},
-        {	-84.45*deg,	-60.47*deg,	-12.45*deg},
-        {	80.27*deg,	58.55*deg,	(-4.54+180)*deg},
-        {	23.55*deg,	60.47*deg,	167.55*deg},
-        {	8.27*deg,	58.55*deg,	175.46*deg},
-        {	-48.45*deg,	60.47*deg,	167.55*deg},
-        {	-63.73*deg,	58.55*deg,	175.46*deg},
-        {	59.55*deg,	-60.47*deg,	-12.45*deg},
-        {	44.27*deg,	-58.55*deg,	-4.54*deg}
-    };
+	G4double greenAlphaBetaGammaArray[10][3] = {
+		{	-12.45*deg,	-60.47*deg,	-12.45*deg},
+		{	-27.73*deg,	-58.55*deg,	-4.54*deg},
+		{	-84.45*deg,	-60.47*deg,	-12.45*deg},
+		{	80.27*deg,	58.55*deg,	(-4.54+180)*deg},
+		{	23.55*deg,	60.47*deg,	167.55*deg},
+		{	8.27*deg,	58.55*deg,	175.46*deg},
+		{	-48.45*deg,	60.47*deg,	167.55*deg},
+		{	-63.73*deg,	58.55*deg,	175.46*deg},
+		{	59.55*deg,	-60.47*deg,	-12.45*deg},
+		{	44.27*deg,	-58.55*deg,	-4.54*deg}
+	};
 
-    G4double redAlphaBetaGammaArray[15][3] = {
-        {	-36.00*deg,	-20.39*deg,	180.00*deg},
-        {	-16.04*deg,	-47.84*deg,	45.10*deg},
-        {	-55.96*deg,	-47.84*deg,	314.90*deg},
-        {	72.00*deg,	20.39*deg,	0.00*deg},
-        {	-88.04*deg,	-47.84*deg,	45.10*deg},
-        {	52.04*deg,	47.84*deg,	134.90*deg},
-        {	0.00*deg,	20.39*deg,	0.00*deg},
-        {	19.96*deg,	47.84*deg,	225.10*deg},
-        {	-19.96*deg,	47.84*deg,	134.90*deg},
-        {	-72.00*deg,	20.39*deg,	0.00*deg},
-        {	-52.04*deg,	47.84*deg,	225.10*deg},
-        {	88.04*deg,	-47.84*deg,	314.90*deg},
-        {	36.00*deg,	-20.39*deg,	180.00*deg},
-        {	55.96*deg,	-47.84*deg,	45.10*deg},
-        {	16.04*deg,	-47.84*deg,	314.90*deg}
-    };
+	G4double redAlphaBetaGammaArray[15][3] = {
+		{	-36.00*deg,	-20.39*deg,	180.00*deg},
+		{	-16.04*deg,	-47.84*deg,	45.10*deg},
+		{	-55.96*deg,	-47.84*deg,	314.90*deg},
+		{	72.00*deg,	20.39*deg,	0.00*deg},
+		{	-88.04*deg,	-47.84*deg,	45.10*deg},
+		{	52.04*deg,	47.84*deg,	134.90*deg},
+		{	0.00*deg,	20.39*deg,	0.00*deg},
+		{	19.96*deg,	47.84*deg,	225.10*deg},
+		{	-19.96*deg,	47.84*deg,	134.90*deg},
+		{	-72.00*deg,	20.39*deg,	0.00*deg},
+		{	-52.04*deg,	47.84*deg,	225.10*deg},
+		{	88.04*deg,	-47.84*deg,	314.90*deg},
+		{	36.00*deg,	-20.39*deg,	180.00*deg},
+		{	55.96*deg,	-47.84*deg,	45.10*deg},
+		{	16.04*deg,	-47.84*deg,	314.90*deg}
+	};
 
-    G4double whiteAlphaBetaGammaArray[20][3] = {
-        {	0.00*deg,	-11.37*deg,	90.00*deg},
-        {	0.00*deg,	-24.67*deg,	90.00*deg},
-        {	0.00*deg,	-38.76*deg,	-90.00*deg},
-        {	0.00*deg,	-52.06*deg,	-90.00*deg},
-        {	-72.00*deg,	-11.37*deg,	90.00*deg},
-        {	-72.00*deg,	-24.67*deg,	90.00*deg},
-        {	-72.00*deg,	-38.76*deg,	-90.00*deg},
-        {	-72.00*deg,	-52.06*deg,	-90.00*deg},
-        {	36.00*deg,	11.37*deg,	270.00*deg},
-        {	36.00*deg,	24.67*deg,	270.00*deg},
-        {	36.00*deg,	38.76*deg,	90.00*deg},
-        {	36.00*deg,	52.06*deg,	90.00*deg},
-        {	-36.00*deg,	11.37*deg,	270.00*deg},
-        {	-36.00*deg,	24.67*deg,	270.00*deg},
-        {	-36.00*deg,	38.76*deg,	90.00*deg},
-        {	-36.00*deg,	52.06*deg,	90.00*deg},
-        {	72.00*deg,	-11.37*deg,	90.00*deg},
-        {	72.00*deg,	-24.67*deg,	90.00*deg},
-        {	72.00*deg,	-38.76*deg,	-90.00*deg},
-        {	72.00*deg,	-52.06*deg,	-90.00*deg}
-    };
+	G4double whiteAlphaBetaGammaArray[20][3] = {
+		{	0.00*deg,	-11.37*deg,	90.00*deg},
+		{	0.00*deg,	-24.67*deg,	90.00*deg},
+		{	0.00*deg,	-38.76*deg,	-90.00*deg},
+		{	0.00*deg,	-52.06*deg,	-90.00*deg},
+		{	-72.00*deg,	-11.37*deg,	90.00*deg},
+		{	-72.00*deg,	-24.67*deg,	90.00*deg},
+		{	-72.00*deg,	-38.76*deg,	-90.00*deg},
+		{	-72.00*deg,	-52.06*deg,	-90.00*deg},
+		{	36.00*deg,	11.37*deg,	270.00*deg},
+		{	36.00*deg,	24.67*deg,	270.00*deg},
+		{	36.00*deg,	38.76*deg,	90.00*deg},
+		{	36.00*deg,	52.06*deg,	90.00*deg},
+		{	-36.00*deg,	11.37*deg,	270.00*deg},
+		{	-36.00*deg,	24.67*deg,	270.00*deg},
+		{	-36.00*deg,	38.76*deg,	90.00*deg},
+		{	-36.00*deg,	52.06*deg,	90.00*deg},
+		{	72.00*deg,	-11.37*deg,	90.00*deg},
+		{	72.00*deg,	-24.67*deg,	90.00*deg},
+		{	72.00*deg,	-38.76*deg,	-90.00*deg},
+		{	72.00*deg,	-52.06*deg,	-90.00*deg}
+	};
 
-    G4double yellowAlphaBetaGammaArray[10][3] = {
-        {	-44.27*deg,	-58.55*deg,	(4.54+180)*deg},
-        {	-59.55*deg,	-60.47*deg,	192.45*deg},
-        {	63.73*deg,	58.55*deg,	4.54*deg},
-        {	48.45*deg,	60.47*deg,	(192.45+180)*deg},
-        {	-8.27*deg,	58.55*deg,	(184.54+180)*deg},
-        {	-23.55*deg,	60.47*deg,	372.45*deg},
-        {	-80.27*deg,	58.55*deg,	(184.54+180)*deg},
-        {	84.45*deg,	-60.47*deg,	(372.45+180)*deg},
-        {	27.73*deg,	-58.55*deg,	(4.54+180)*deg},
-        {	12.45*deg,	-60.47*deg,	192.45*deg}
-    };
+	G4double yellowAlphaBetaGammaArray[10][3] = {
+		{	-44.27*deg,	-58.55*deg,	(4.54+180)*deg},
+		{	-59.55*deg,	-60.47*deg,	192.45*deg},
+		{	63.73*deg,	58.55*deg,	4.54*deg},
+		{	48.45*deg,	60.47*deg,	(192.45+180)*deg},
+		{	-8.27*deg,	58.55*deg,	(184.54+180)*deg},
+		{	-23.55*deg,	60.47*deg,	372.45*deg},
+		{	-80.27*deg,	58.55*deg,	(184.54+180)*deg},
+		{	84.45*deg,	-60.47*deg,	(372.45+180)*deg},
+		{	27.73*deg,	-58.55*deg,	(4.54+180)*deg},
+		{	12.45*deg,	-60.47*deg,	192.45*deg}
+	};
 
-    memcpy(fBlueAlphaBetaGamma,   blueAlphaBetaGammaArray,   sizeof(fBlueAlphaBetaGamma));
-    memcpy(fGreenAlphaBetaGamma,  greenAlphaBetaGammaArray,  sizeof(fGreenAlphaBetaGamma));
-    memcpy(fRedAlphaBetaGamma,    redAlphaBetaGammaArray,    sizeof(fRedAlphaBetaGamma));
-    memcpy(fWhiteAlphaBetaGamma,  whiteAlphaBetaGammaArray,  sizeof(fWhiteAlphaBetaGamma));
-    memcpy(fYellowAlphaBetaGamma, yellowAlphaBetaGammaArray, sizeof(fYellowAlphaBetaGamma));
+	memcpy(fBlueAlphaBetaGamma,   blueAlphaBetaGammaArray,   sizeof(fBlueAlphaBetaGamma));
+	memcpy(fGreenAlphaBetaGamma,  greenAlphaBetaGammaArray,  sizeof(fGreenAlphaBetaGamma));
+	memcpy(fRedAlphaBetaGamma,    redAlphaBetaGammaArray,    sizeof(fRedAlphaBetaGamma));
+	memcpy(fWhiteAlphaBetaGamma,  whiteAlphaBetaGammaArray,  sizeof(fWhiteAlphaBetaGamma));
+	memcpy(fYellowAlphaBetaGamma, yellowAlphaBetaGammaArray, sizeof(fYellowAlphaBetaGamma));
 
-    fBlueColour     = G4Colour(0.0/255.0,0.0/255.0,255.0/255.0);
-    fGreenColour    = G4Colour(0.0/255.0,255.0/255.0,0.0/255.0);
-    fRedColour      = G4Colour(255.0/255.0,0.0/255.0,0.0/255.0);
-    fWhiteColour    = G4Colour(255.0/255.0,255.0/255.0,255.0/255.0);
-    fYellowColour   = G4Colour(255.0/255.0,255.0/255.0,0.0/255.0);
-    fLiquidColour   = G4Colour(0.0/255.0,255.0/255.0,225.0/255.0);
-    fGreyColour     = G4Colour(0.5, 0.5, 0.5); 
-    fMagentaColour  = G4Colour(1.0, 0.0, 1.0); 
-    fBlackColour    = G4Colour(0.0, 0.0, 0.0);
+	fBlueColour     = G4Colour(0.0/255.0,0.0/255.0,255.0/255.0);
+	fGreenColour    = G4Colour(0.0/255.0,255.0/255.0,0.0/255.0);
+	fRedColour      = G4Colour(255.0/255.0,0.0/255.0,0.0/255.0);
+	fWhiteColour    = G4Colour(255.0/255.0,255.0/255.0,255.0/255.0);
+	fYellowColour   = G4Colour(255.0/255.0,255.0/255.0,0.0/255.0);
+	fLiquidColour   = G4Colour(0.0/255.0,255.0/255.0,225.0/255.0);
+	fGreyColour     = G4Colour(0.5, 0.5, 0.5); 
+	fMagentaColour  = G4Colour(1.0, 0.0, 1.0); 
+	fBlackColour    = G4Colour(0.0, 0.0, 0.0);
 
-    // for lanthanum bromide locations
-	 //G4double triangleThetaAngle = (180/M_PI)*(atan((1/sqrt(3))/sqrt((11/12) + (1/sqrt(2))))+atan((sqrt(2))/(1+sqrt(2))))*deg;
-	 G4double triangleThetaAngle = 54.735610317245360*deg;
-		  
-	 // theta
-	 fDetectorAngles[0][0] 	= triangleThetaAngle;
-	 fDetectorAngles[1][0] 	= triangleThetaAngle;
-	 fDetectorAngles[2][0] 	= triangleThetaAngle;
-	 fDetectorAngles[3][0] 	= triangleThetaAngle;
-	 fDetectorAngles[4][0] 	= 180.0*deg - triangleThetaAngle;
-	 fDetectorAngles[5][0] 	= 180.0*deg - triangleThetaAngle;
-	 fDetectorAngles[6][0] 	= 180.0*deg - triangleThetaAngle;
-	 fDetectorAngles[7][0] 	= 180.0*deg - triangleThetaAngle;
-	 // phi
-	 fDetectorAngles[0][1] 	= 22.5*deg;
-	 fDetectorAngles[1][1] 	= 112.5*deg;
-	 fDetectorAngles[2][1] 	= 202.5*deg;
-	 fDetectorAngles[3][1] 	= 292.5*deg;
-	 fDetectorAngles[4][1] 	= 22.5*deg;
-	 fDetectorAngles[5][1] 	= 112.5*deg;
-	 fDetectorAngles[6][1] 	= 202.5*deg;
-	 fDetectorAngles[7][1] 	= 292.5*deg;
-	 // yaw (alpha)
-	 fDetectorAngles[0][2] 	= 0.0*deg;
-	 fDetectorAngles[1][2] 	= 0.0*deg;
-	 fDetectorAngles[2][2] 	= 0.0*deg;
-	 fDetectorAngles[3][2] 	= 0.0*deg;
-	 fDetectorAngles[4][2] 	= 0.0*deg;
-	 fDetectorAngles[5][2] 	= 0.0*deg;
-	 fDetectorAngles[6][2] 	= 0.0*deg;
-	 fDetectorAngles[7][2] 	= 0.0*deg;
-	 // pitch (beta)
-	 fDetectorAngles[0][3] 	= triangleThetaAngle;
-	 fDetectorAngles[1][3] 	= triangleThetaAngle;
-	 fDetectorAngles[2][3] 	= triangleThetaAngle;
-	 fDetectorAngles[3][3] 	= triangleThetaAngle;
-	 fDetectorAngles[4][3] 	= 180.0*deg - triangleThetaAngle;
-	 fDetectorAngles[5][3] 	= 180.0*deg - triangleThetaAngle;
-	 fDetectorAngles[6][3] 	= 180.0*deg - triangleThetaAngle;
-	 fDetectorAngles[7][3] 	= 180.0*deg - triangleThetaAngle;
-	 // roll (gamma)
-	 fDetectorAngles[0][4] 	= 22.5*deg;
-	 fDetectorAngles[1][4] 	= 112.5*deg;
-	 fDetectorAngles[2][4] 	= 202.5*deg;
-	 fDetectorAngles[3][4] 	= 292.5*deg;
-	 fDetectorAngles[4][4] 	= 22.5*deg;
-	 fDetectorAngles[5][4] 	= 112.5*deg;
-	 fDetectorAngles[6][4] 	= 202.5*deg;
-	 fDetectorAngles[7][4] 	= 292.5*deg;
+	// for lanthanum bromide locations
+	//G4double triangleThetaAngle = (180/M_PI)*(atan((1/sqrt(3))/sqrt((11/12) + (1/sqrt(2))))+atan((sqrt(2))/(1+sqrt(2))))*deg;
+	G4double triangleThetaAngle = 54.735610317245360*deg;
+
+	// theta
+	fDetectorAngles[0][0] 	= triangleThetaAngle;
+	fDetectorAngles[1][0] 	= triangleThetaAngle;
+	fDetectorAngles[2][0] 	= triangleThetaAngle;
+	fDetectorAngles[3][0] 	= triangleThetaAngle;
+	fDetectorAngles[4][0] 	= 180.0*deg - triangleThetaAngle;
+	fDetectorAngles[5][0] 	= 180.0*deg - triangleThetaAngle;
+	fDetectorAngles[6][0] 	= 180.0*deg - triangleThetaAngle;
+	fDetectorAngles[7][0] 	= 180.0*deg - triangleThetaAngle;
+	// phi
+	fDetectorAngles[0][1] 	= 22.5*deg;
+	fDetectorAngles[1][1] 	= 112.5*deg;
+	fDetectorAngles[2][1] 	= 202.5*deg;
+	fDetectorAngles[3][1] 	= 292.5*deg;
+	fDetectorAngles[4][1] 	= 22.5*deg;
+	fDetectorAngles[5][1] 	= 112.5*deg;
+	fDetectorAngles[6][1] 	= 202.5*deg;
+	fDetectorAngles[7][1] 	= 292.5*deg;
+	// yaw (alpha)
+	fDetectorAngles[0][2] 	= 0.0*deg;
+	fDetectorAngles[1][2] 	= 0.0*deg;
+	fDetectorAngles[2][2] 	= 0.0*deg;
+	fDetectorAngles[3][2] 	= 0.0*deg;
+	fDetectorAngles[4][2] 	= 0.0*deg;
+	fDetectorAngles[5][2] 	= 0.0*deg;
+	fDetectorAngles[6][2] 	= 0.0*deg;
+	fDetectorAngles[7][2] 	= 0.0*deg;
+	// pitch (beta)
+	fDetectorAngles[0][3] 	= triangleThetaAngle;
+	fDetectorAngles[1][3] 	= triangleThetaAngle;
+	fDetectorAngles[2][3] 	= triangleThetaAngle;
+	fDetectorAngles[3][3] 	= triangleThetaAngle;
+	fDetectorAngles[4][3] 	= 180.0*deg - triangleThetaAngle;
+	fDetectorAngles[5][3] 	= 180.0*deg - triangleThetaAngle;
+	fDetectorAngles[6][3] 	= 180.0*deg - triangleThetaAngle;
+	fDetectorAngles[7][3] 	= 180.0*deg - triangleThetaAngle;
+	// roll (gamma)
+	fDetectorAngles[0][4] 	= 22.5*deg;
+	fDetectorAngles[1][4] 	= 112.5*deg;
+	fDetectorAngles[2][4] 	= 202.5*deg;
+	fDetectorAngles[3][4] 	= 292.5*deg;
+	fDetectorAngles[4][4] 	= 22.5*deg;
+	fDetectorAngles[5][4] 	= 112.5*deg;
+	fDetectorAngles[6][4] 	= 202.5*deg;
+	fDetectorAngles[7][4] 	= 292.5*deg;
 }
 
 
 DetectionSystemDescant::~DetectionSystemDescant() {
-    // LogicalVolumes
-    delete fBlueVolumeLog;
-    delete fGreenVolumeLog;
-    delete fRedVolumeLog;
-    delete fWhiteVolumeLog;
-    delete fYellowVolumeLog;
-    delete fBlueScintillatorVolumeLog;
-    delete fGreenScintillatorVolumeLog;
-    delete fRedScintillatorVolumeLog;
-    delete fWhiteScintillatorVolumeLog;
-    delete fYellowScintillatorVolumeLog;
-    delete fBlueLeadVolumeLog;
-    delete fGreenLeadVolumeLog;
-    delete fRedLeadVolumeLog;
-    delete fWhiteLeadVolumeLog;
-    delete fYellowLeadVolumeLog;
-    delete fQuartzWindow5inchLog;
-    delete fQuartzWindow3inchLog;
+	// LogicalVolumes
+	delete fBlueVolumeLog;
+	delete fGreenVolumeLog;
+	delete fRedVolumeLog;
+	delete fWhiteVolumeLog;
+	delete fYellowVolumeLog;
+	delete fBlueScintillatorVolumeLog;
+	delete fGreenScintillatorVolumeLog;
+	delete fRedScintillatorVolumeLog;
+	delete fWhiteScintillatorVolumeLog;
+	delete fYellowScintillatorVolumeLog;
+	delete fBlueLeadVolumeLog;
+	delete fGreenLeadVolumeLog;
+	delete fRedLeadVolumeLog;
+	delete fWhiteLeadVolumeLog;
+	delete fYellowLeadVolumeLog;
+	delete fQuartzWindow5inchLog;
+	delete fQuartzWindow3inchLog;
 }
 
 
 G4int DetectionSystemDescant::Build() {
-    // Build assembly volumes
-    // assemblyBlue contains non-sensitive volumes of the blue detector
-    // assemblyBlueScintillator contains only sensitive volumes of the blue detector
-    G4AssemblyVolume* myAssemblyBlue = new G4AssemblyVolume();
-    fAssemblyBlue = myAssemblyBlue;
-    G4AssemblyVolume* myAssemblyBlueScintillator = new G4AssemblyVolume();
-    fAssemblyBlueScintillator = myAssemblyBlueScintillator;
+	// Build assembly volumes
+	// assemblyBlue contains non-sensitive volumes of the blue detector
+	// assemblyBlueScintillator contains only sensitive volumes of the blue detector
+	G4AssemblyVolume* myAssemblyBlue = new G4AssemblyVolume();
+	fAssemblyBlue = myAssemblyBlue;
+	G4AssemblyVolume* myAssemblyBlueScintillator = new G4AssemblyVolume();
+	fAssemblyBlueScintillator = myAssemblyBlueScintillator;
 
-    G4AssemblyVolume* myAssemblyGreen = new G4AssemblyVolume();
-    fAssemblyGreen = myAssemblyGreen;
-    G4AssemblyVolume* myAssemblyGreenScintillator = new G4AssemblyVolume();
-    fAssemblyGreenScintillator = myAssemblyGreenScintillator;
+	G4AssemblyVolume* myAssemblyGreen = new G4AssemblyVolume();
+	fAssemblyGreen = myAssemblyGreen;
+	G4AssemblyVolume* myAssemblyGreenScintillator = new G4AssemblyVolume();
+	fAssemblyGreenScintillator = myAssemblyGreenScintillator;
 
-    G4AssemblyVolume* myAssemblyRed = new G4AssemblyVolume();
-    fAssemblyRed = myAssemblyRed;
-    G4AssemblyVolume* myAssemblyRedScintillator = new G4AssemblyVolume();
-    fAssemblyRedScintillator = myAssemblyRedScintillator;
+	G4AssemblyVolume* myAssemblyRed = new G4AssemblyVolume();
+	fAssemblyRed = myAssemblyRed;
+	G4AssemblyVolume* myAssemblyRedScintillator = new G4AssemblyVolume();
+	fAssemblyRedScintillator = myAssemblyRedScintillator;
 
-    G4AssemblyVolume* myAssemblyWhite = new G4AssemblyVolume();
-    fAssemblyWhite = myAssemblyWhite;
-    G4AssemblyVolume* myAssemblyWhiteScintillator = new G4AssemblyVolume();
-    fAssemblyWhiteScintillator = myAssemblyWhiteScintillator;
+	G4AssemblyVolume* myAssemblyWhite = new G4AssemblyVolume();
+	fAssemblyWhite = myAssemblyWhite;
+	G4AssemblyVolume* myAssemblyWhiteScintillator = new G4AssemblyVolume();
+	fAssemblyWhiteScintillator = myAssemblyWhiteScintillator;
 
-    G4AssemblyVolume* myAssemblyYellow = new G4AssemblyVolume();
-    fAssemblyYellow = myAssemblyYellow;
-    G4AssemblyVolume* myAssemblyYellowScintillator = new G4AssemblyVolume();
-    fAssemblyYellowScintillator = myAssemblyYellowScintillator;
+	G4AssemblyVolume* myAssemblyYellow = new G4AssemblyVolume();
+	fAssemblyYellow = myAssemblyYellow;
+	G4AssemblyVolume* myAssemblyYellowScintillator = new G4AssemblyVolume();
+	fAssemblyYellowScintillator = myAssemblyYellowScintillator;
 
-    G4cout << "Building DESCANT..." << G4endl;
+	G4cout<<"Building DESCANT..."<<G4endl;
 
-    G4cout << "BuildCanVolume" << G4endl;
-    BuildCanVolume();
+	G4cout<<"BuildCanVolume"<<G4endl;
+	BuildCanVolume();
 
-    G4cout << "BuildDetectorVolume" << G4endl;
-    BuildDetectorVolume();
+	G4cout<<"BuildDetectorVolume"<<G4endl;
+	BuildDetectorVolume();
 
-    return 1;
+	return 1;
 }
 
 G4int DetectionSystemDescant::PlaceDetector(G4LogicalVolume* expHallLog, G4int detectorNumber) {
-    G4double position = fRadialDistance;
+	G4double position = fRadialDistance;
 
-    G4int idx;
-    G4double x = 0;
-    G4double y = 0;
-    G4double z = position;
+	G4int idx;
+	G4double x = 0;
+	G4double y = 0;
+	G4double z = position;
 
-    G4ThreeVector move;
-    G4RotationMatrix* rotate;
+	G4ThreeVector move;
+	G4RotationMatrix* rotate;
 
-    // Place Blue Detector
-    for(G4int i=0; i<(detectorNumber-55); i++) {
-        move = G4ThreeVector(x,y,z);
-        idx = i;
-        move.rotateZ(fBlueAlphaBetaGamma[idx][2]);
-        move.rotateY(fBlueAlphaBetaGamma[idx][1]);
-        move.rotateZ(fBlueAlphaBetaGamma[idx][0]);
-        rotate = new G4RotationMatrix;
-        rotate->rotateY(M_PI); // flip the detector so that the face is pointing upstream.
-        rotate->rotateZ(fBlueAlphaBetaGamma[idx][2]);
-        rotate->rotateY(fBlueAlphaBetaGamma[idx][1]);
-        rotate->rotateZ(fBlueAlphaBetaGamma[idx][0]);
-        fAssemblyBlue->MakeImprint(expHallLog, move, rotate, i, fSurfCheck);
-        fAssemblyBlueScintillator->MakeImprint(expHallLog, move, rotate, i, fSurfCheck);
+	// Place Blue Detector
+	for(G4int i=0; i<(detectorNumber-55); i++) {
+		move = G4ThreeVector(x,y,z);
+		idx = i;
+		move.rotateZ(fBlueAlphaBetaGamma[idx][2]);
+		move.rotateY(fBlueAlphaBetaGamma[idx][1]);
+		move.rotateZ(fBlueAlphaBetaGamma[idx][0]);
+		rotate = new G4RotationMatrix;
+		rotate->rotateY(M_PI); // flip the detector so that the face is pointing upstream.
+		rotate->rotateZ(fBlueAlphaBetaGamma[idx][2]);
+		rotate->rotateY(fBlueAlphaBetaGamma[idx][1]);
+		rotate->rotateZ(fBlueAlphaBetaGamma[idx][0]);
+		fAssemblyBlue->MakeImprint(expHallLog, move, rotate, i, fSurfCheck);
+		fAssemblyBlueScintillator->MakeImprint(expHallLog, move, rotate, i, fSurfCheck);
 
-    }
-    // Place Green Detector
-    for(G4int i=15; i<(detectorNumber-45); i++) {
-        idx = i-15;
-        move = G4ThreeVector(x,y,z);
-        move.rotateZ(fGreenAlphaBetaGamma[idx][2]);
-        move.rotateY(fGreenAlphaBetaGamma[idx][1]);
-        move.rotateZ(fGreenAlphaBetaGamma[idx][0]);
-        rotate = new G4RotationMatrix;
-        rotate->rotateY(M_PI); // flip the detector so that the face is pointing upstream.
-        rotate->rotateZ(fGreenAlphaBetaGamma[idx][2]);
-        rotate->rotateY(fGreenAlphaBetaGamma[idx][1]);
-        rotate->rotateZ(fGreenAlphaBetaGamma[idx][0]);
-        fAssemblyGreen->MakeImprint(expHallLog, move, rotate, i, fSurfCheck);
-        fAssemblyGreenScintillator->MakeImprint(expHallLog, move, rotate, i, fSurfCheck);
-    }
-    // Place Red Detector
-    for(G4int i=25; i<(detectorNumber-30); i++) {
-        idx = i-25;
-        move = G4ThreeVector(x,y,z);
-        move.rotateZ(fRedAlphaBetaGamma[idx][2]);
-        move.rotateY(fRedAlphaBetaGamma[idx][1]);
-        move.rotateZ(fRedAlphaBetaGamma[idx][0]);
-        rotate = new G4RotationMatrix;
-        rotate->rotateY(M_PI); // flip the detector so that the face is pointing upstream.
-        rotate->rotateZ(fRedAlphaBetaGamma[idx][2]);
-        rotate->rotateY(fRedAlphaBetaGamma[idx][1]);
-        rotate->rotateZ(fRedAlphaBetaGamma[idx][0]);
-        fAssemblyRed->MakeImprint(expHallLog, move, rotate, i, fSurfCheck);
-        fAssemblyRedScintillator->MakeImprint(expHallLog, move, rotate, i, fSurfCheck);
-    }
-    // Place White Detector
-    for(G4int i=40; i<(detectorNumber-10); i++) {
-        idx = i-40;
-        move = G4ThreeVector(x,y,z);
-        move.rotateZ(fWhiteAlphaBetaGamma[idx][2]);
-        move.rotateY(fWhiteAlphaBetaGamma[idx][1]);
-        move.rotateZ(fWhiteAlphaBetaGamma[idx][0]);
-        rotate = new G4RotationMatrix;
-        rotate->rotateY(M_PI); // flip the detector so that the face is pointing upstream.
-        rotate->rotateZ(fWhiteAlphaBetaGamma[idx][2]);
-        rotate->rotateY(fWhiteAlphaBetaGamma[idx][1]);
-        rotate->rotateZ(fWhiteAlphaBetaGamma[idx][0]);
-        fAssemblyWhite->MakeImprint(expHallLog, move, rotate, i, fSurfCheck);
-        fAssemblyWhiteScintillator->MakeImprint(expHallLog, move, rotate, i, fSurfCheck);
-    }
-    // Place Yellow Detector
-    for(G4int i=60; i<(detectorNumber); i++) {
-        idx = i-60;
-        move = G4ThreeVector(x,y,z);
-        move.rotateZ(fYellowAlphaBetaGamma[idx][2]);
-        move.rotateY(fYellowAlphaBetaGamma[idx][1]);
-        move.rotateZ(fYellowAlphaBetaGamma[idx][0]);
-        rotate = new G4RotationMatrix;
-        rotate->rotateY(M_PI); // flip the detector so that the face is pointing upstream.
-        rotate->rotateZ(fYellowAlphaBetaGamma[idx][2]);
-        rotate->rotateY(fYellowAlphaBetaGamma[idx][1]);
-        rotate->rotateZ(fYellowAlphaBetaGamma[idx][0]);
-        fAssemblyYellow->MakeImprint(expHallLog, move, rotate, i, fSurfCheck);
-        fAssemblyYellowScintillator->MakeImprint(expHallLog, move, rotate, i, fSurfCheck);
-    }
+	}
+	// Place Green Detector
+	for(G4int i=15; i<(detectorNumber-45); i++) {
+		idx = i-15;
+		move = G4ThreeVector(x,y,z);
+		move.rotateZ(fGreenAlphaBetaGamma[idx][2]);
+		move.rotateY(fGreenAlphaBetaGamma[idx][1]);
+		move.rotateZ(fGreenAlphaBetaGamma[idx][0]);
+		rotate = new G4RotationMatrix;
+		rotate->rotateY(M_PI); // flip the detector so that the face is pointing upstream.
+		rotate->rotateZ(fGreenAlphaBetaGamma[idx][2]);
+		rotate->rotateY(fGreenAlphaBetaGamma[idx][1]);
+		rotate->rotateZ(fGreenAlphaBetaGamma[idx][0]);
+		fAssemblyGreen->MakeImprint(expHallLog, move, rotate, i, fSurfCheck);
+		fAssemblyGreenScintillator->MakeImprint(expHallLog, move, rotate, i, fSurfCheck);
+	}
+	// Place Red Detector
+	for(G4int i=25; i<(detectorNumber-30); i++) {
+		idx = i-25;
+		move = G4ThreeVector(x,y,z);
+		move.rotateZ(fRedAlphaBetaGamma[idx][2]);
+		move.rotateY(fRedAlphaBetaGamma[idx][1]);
+		move.rotateZ(fRedAlphaBetaGamma[idx][0]);
+		rotate = new G4RotationMatrix;
+		rotate->rotateY(M_PI); // flip the detector so that the face is pointing upstream.
+		rotate->rotateZ(fRedAlphaBetaGamma[idx][2]);
+		rotate->rotateY(fRedAlphaBetaGamma[idx][1]);
+		rotate->rotateZ(fRedAlphaBetaGamma[idx][0]);
+		fAssemblyRed->MakeImprint(expHallLog, move, rotate, i, fSurfCheck);
+		fAssemblyRedScintillator->MakeImprint(expHallLog, move, rotate, i, fSurfCheck);
+	}
+	// Place White Detector
+	for(G4int i=40; i<(detectorNumber-10); i++) {
+		idx = i-40;
+		move = G4ThreeVector(x,y,z);
+		move.rotateZ(fWhiteAlphaBetaGamma[idx][2]);
+		move.rotateY(fWhiteAlphaBetaGamma[idx][1]);
+		move.rotateZ(fWhiteAlphaBetaGamma[idx][0]);
+		rotate = new G4RotationMatrix;
+		rotate->rotateY(M_PI); // flip the detector so that the face is pointing upstream.
+		rotate->rotateZ(fWhiteAlphaBetaGamma[idx][2]);
+		rotate->rotateY(fWhiteAlphaBetaGamma[idx][1]);
+		rotate->rotateZ(fWhiteAlphaBetaGamma[idx][0]);
+		fAssemblyWhite->MakeImprint(expHallLog, move, rotate, i, fSurfCheck);
+		fAssemblyWhiteScintillator->MakeImprint(expHallLog, move, rotate, i, fSurfCheck);
+	}
+	// Place Yellow Detector
+	for(G4int i=60; i<(detectorNumber); i++) {
+		idx = i-60;
+		move = G4ThreeVector(x,y,z);
+		move.rotateZ(fYellowAlphaBetaGamma[idx][2]);
+		move.rotateY(fYellowAlphaBetaGamma[idx][1]);
+		move.rotateZ(fYellowAlphaBetaGamma[idx][0]);
+		rotate = new G4RotationMatrix;
+		rotate->rotateY(M_PI); // flip the detector so that the face is pointing upstream.
+		rotate->rotateZ(fYellowAlphaBetaGamma[idx][2]);
+		rotate->rotateY(fYellowAlphaBetaGamma[idx][1]);
+		rotate->rotateZ(fYellowAlphaBetaGamma[idx][0]);
+		fAssemblyYellow->MakeImprint(expHallLog, move, rotate, i, fSurfCheck);
+		fAssemblyYellowScintillator->MakeImprint(expHallLog, move, rotate, i, fSurfCheck);
+	}
 
-    return 1;
+	return 1;
 }
 
 
 G4int DetectionSystemDescant::PlaceDetector(G4LogicalVolume* expHallLog, G4String color, G4ThreeVector pos, G4ThreeVector rot) {
-    G4RotationMatrix* rotate;
+	G4RotationMatrix* rotate;
 
-	 G4double alpha = rot.x();
-	 G4double beta  = rot.y();
-	 G4double gamma = rot.z();
+	G4double alpha = rot.x();
+	G4double beta  = rot.y();
+	G4double gamma = rot.z();
 
-    // Place Detector
-	 rotate = new G4RotationMatrix;
-	 rotate->rotateY(M_PI); // flip the detector so that the face is pointing upstream.
-	 rotate->rotateZ(gamma);
-	 rotate->rotateY(beta);
-	 rotate->rotateZ(alpha);
+	// Place Detector
+	rotate = new G4RotationMatrix;
+	rotate->rotateY(M_PI); // flip the detector so that the face is pointing upstream.
+	rotate->rotateZ(gamma);
+	rotate->rotateY(beta);
+	rotate->rotateZ(alpha);
 
-	 if(color.compareTo("blue", G4String::ignoreCase) == 0) {
+	if(color.compareTo("blue", G4String::ignoreCase) == 0) {
 		fAssemblyBlue->MakeImprint(expHallLog, pos, rotate, 1);
 		fAssemblyBlueScintillator->MakeImprint(expHallLog, pos, rotate, 1);
-	 } else if(color.compareTo("red", G4String::ignoreCase) == 0) {
+	} else if(color.compareTo("red", G4String::ignoreCase) == 0) {
 		fAssemblyRed->MakeImprint(expHallLog, pos, rotate, 1);
 		fAssemblyRedScintillator->MakeImprint(expHallLog, pos, rotate, 1);
-	 } else if(color.compareTo("white", G4String::ignoreCase) == 0) {
+	} else if(color.compareTo("white", G4String::ignoreCase) == 0) {
 		fAssemblyWhite->MakeImprint(expHallLog, pos, rotate, 1);
 		fAssemblyWhiteScintillator->MakeImprint(expHallLog, pos, rotate, 1);
-	 } else if(color.compareTo("green", G4String::ignoreCase) == 0) {
+	} else if(color.compareTo("green", G4String::ignoreCase) == 0) {
 		fAssemblyGreen->MakeImprint(expHallLog, pos, rotate, 1);
 		fAssemblyGreenScintillator->MakeImprint(expHallLog, pos, rotate, 1);
-	 } else if(color.compareTo("yellow", G4String::ignoreCase) == 0) {
+	} else if(color.compareTo("yellow", G4String::ignoreCase) == 0) {
 		fAssemblyYellow->MakeImprint(expHallLog, pos, rotate, 1);
 		fAssemblyYellowScintillator->MakeImprint(expHallLog, pos, rotate, 1);
-	 }
+	}
 
-    return 1;
+	return 1;
 }
 
 G4int DetectionSystemDescant::PlaceDetectorAuxPorts(G4LogicalVolume* expHallLog, G4int detectorNumber, G4double radialpos) {
-    G4int detectorCopyID = 0;
+	G4int detectorCopyID = 0;
 
-    G4cout << "Descant Detector Number = " << detectorNumber << G4endl;
+	G4cout<<"Descant Detector Number = "<<detectorNumber<<G4endl;
 
-    G4int copyNumber = detectorCopyID + detectorNumber;
+	G4int copyNumber = detectorCopyID + detectorNumber;
 
-    G4double position = radialpos + fCanThicknessFront +(fCanLength / 2.0) ;
-    fSetRadialPos = radialpos;
+	G4double position = radialpos + fCanThicknessFront +(fCanLength / 2.0) ;
+	fSetRadialPos = radialpos;
 
-    G4double theta  = fDetectorAngles[detectorNumber][0];
-    G4double phi    = fDetectorAngles[detectorNumber][1];
-    //G4double alpha  = fDetectorAngles[detectorNumber][2]; // yaw
-    G4double beta   = fDetectorAngles[detectorNumber][3]; // pitch
-    G4double gamma  = fDetectorAngles[detectorNumber][4]; // roll
+	G4double theta  = fDetectorAngles[detectorNumber][0];
+	G4double phi    = fDetectorAngles[detectorNumber][1];
+	//G4double alpha  = fDetectorAngles[detectorNumber][2]; // yaw
+	G4double beta   = fDetectorAngles[detectorNumber][3]; // pitch
+	G4double gamma  = fDetectorAngles[detectorNumber][4]; // roll
 
-    G4double x = 0;
-    G4double y = 0;
-    G4double z = position;
+	G4double x = 0;
+	G4double y = 0;
+	G4double z = position;
 
-    G4RotationMatrix* rotate = new G4RotationMatrix;    // rotation matrix corresponding to direction vector
-    //rotate->rotateY(M_PI);
-    rotate->rotateZ(90.0*deg);
-    rotate->rotateY(M_PI+beta);
-    rotate->rotateZ(gamma);
+	G4RotationMatrix* rotate = new G4RotationMatrix;    // rotation matrix corresponding to direction vector
+	//rotate->rotateY(M_PI);
+	rotate->rotateZ(90.0*deg);
+	rotate->rotateY(M_PI+beta);
+	rotate->rotateZ(gamma);
 
-    G4ThreeVector move(TransX(x,y,z,theta,phi), TransY(x,y,z,theta,phi), TransZ(x,y,z,theta));
+	G4ThreeVector move(TransX(x,y,z,theta,phi), TransY(x,y,z,theta,phi), TransZ(x,y,z,theta));
 
-    fAssemblyWhite->MakeImprint(expHallLog, move, rotate, copyNumber);
-    fAssemblyWhiteScintillator->MakeImprint(expHallLog, move, rotate, copyNumber);
+	fAssemblyWhite->MakeImprint(expHallLog, move, rotate, copyNumber);
+	fAssemblyWhiteScintillator->MakeImprint(expHallLog, move, rotate, copyNumber);
 
-    return 1;
+	return 1;
 }
 
 
 G4int DetectionSystemDescant::BuildCanVolume() {
-    G4ThreeVector moveCut, move, direction;
-    G4RotationMatrix* rotateCut;
-    G4RotationMatrix* rotate;
-    G4double zPosition, moveExtra;
+	G4ThreeVector moveCut, move, direction;
+	G4RotationMatrix* rotateCut;
+	G4RotationMatrix* rotate;
+	G4double zPosition, moveExtra;
 
-    G4Material* canG4material = G4Material::GetMaterial(fCanMaterial);
-    if(!canG4material) {
-        G4cout << " ----> Material " << fCanMaterial << " not found, cannot build! " << G4endl;
-        return 0;
-    }
+	G4Material* canG4material = G4Material::GetMaterial(fCanMaterial);
+	if(!canG4material) {
+		G4cout<<" ----> Material "<<fCanMaterial<<" not found, cannot build! "<<G4endl;
+		return 0;
+	}
 
-    G4Material* leadG4material = G4Material::GetMaterial(fLeadMaterial);
-    if(!leadG4material) {
-        G4cout << " ----> Material " << fLeadMaterial << " not found, cannot build! " << G4endl;
-        return 0;
-    }
+	G4Material* leadG4material = G4Material::GetMaterial(fLeadMaterial);
+	if(!leadG4material) {
+		G4cout<<" ----> Material "<<fLeadMaterial<<" not found, cannot build! "<<G4endl;
+		return 0;
+	}
 
-    G4Material* quartzG4material = G4Material::GetMaterial(fQuartzMaterial);
-    if(!quartzG4material) {
-        G4cout << " ----> Material " << fQuartzMaterial << " not found, cannot build! " << G4endl;
-        return 0;
-    }
+	G4Material* quartzG4material = G4Material::GetMaterial(fQuartzMaterial);
+	if(!quartzG4material) {
+		G4cout<<" ----> Material "<<fQuartzMaterial<<" not found, cannot build! "<<G4endl;
+		return 0;
+	}
 
-    // for cutting PMT window
-    G4Tubs * windowCut5inch = new G4Tubs("windowCut5inch", fInnerRadiusWindow, fOuterRadiusWindow5inch, fHalfLengthZWindowCut, fStartPhi, fEndPhi);
-    G4Tubs * windowCut3inch = new G4Tubs("windowCut3inch", fInnerRadiusWindow, fOuterRadiusWindow3inch, fHalfLengthZWindowCut, fStartPhi, fEndPhi);
+	// for cutting PMT window
+	G4Tubs * windowCut5inch = new G4Tubs("windowCut5inch", fInnerRadiusWindow, fOuterRadiusWindow5inch, fHalfLengthZWindowCut, fStartPhi, fEndPhi);
+	G4Tubs * windowCut3inch = new G4Tubs("windowCut3inch", fInnerRadiusWindow, fOuterRadiusWindow3inch, fHalfLengthZWindowCut, fStartPhi, fEndPhi);
 
-    // quartz windows
-    //G4VisAttributes* quartzVisAtt = new G4VisAttributes(fMagentaColour);
-    G4VisAttributes* quartzVisAtt = new G4VisAttributes(fBlackColour);
-    quartzVisAtt->SetForceWireframe(true);
-    quartzVisAtt->SetVisibility(true);
+	// quartz windows
+	//G4VisAttributes* quartzVisAtt = new G4VisAttributes(fMagentaColour);
+	G4VisAttributes* quartzVisAtt = new G4VisAttributes(fBlackColour);
+	quartzVisAtt->SetForceWireframe(true);
+	quartzVisAtt->SetVisibility(true);
 
-    G4Tubs * quartzWindow5inch = new G4Tubs("window5inch", fInnerRadiusWindow, fOuterRadiusWindow5inch, fOpticalWindowHalfThickness, fStartPhi, fEndPhi);
-    G4Tubs * quartzWindow3inch = new G4Tubs("window3inch", fInnerRadiusWindow, fOuterRadiusWindow3inch, fOpticalWindowHalfThickness, fStartPhi, fEndPhi);
+	G4Tubs * quartzWindow5inch = new G4Tubs("window5inch", fInnerRadiusWindow, fOuterRadiusWindow5inch, fOpticalWindowHalfThickness, fStartPhi, fEndPhi);
+	G4Tubs * quartzWindow3inch = new G4Tubs("window3inch", fInnerRadiusWindow, fOuterRadiusWindow3inch, fOpticalWindowHalfThickness, fStartPhi, fEndPhi);
 
-    if(fQuartzWindow5inchLog == NULL) {
-        fQuartzWindow5inchLog = new G4LogicalVolume(quartzWindow5inch, quartzG4material, "quartzWindow5inchLog", 0, 0, 0);
-        fQuartzWindow5inchLog->SetVisAttributes(quartzVisAtt);
-    }
-    if(fQuartzWindow3inchLog == NULL) {
-        fQuartzWindow3inchLog = new G4LogicalVolume(quartzWindow3inch, quartzG4material, "quartzWindow3inchLog", 0, 0, 0);
-        fQuartzWindow3inchLog->SetVisAttributes(quartzVisAtt);
-    }
+	if(fQuartzWindow5inchLog == nullptr) {
+		fQuartzWindow5inchLog = new G4LogicalVolume(quartzWindow5inch, quartzG4material, "quartzWindow5inchLog", 0, 0, 0);
+		fQuartzWindow5inchLog->SetVisAttributes(quartzVisAtt);
+	}
+	if(fQuartzWindow3inchLog == nullptr) {
+		fQuartzWindow3inchLog = new G4LogicalVolume(quartzWindow3inch, quartzG4material, "quartzWindow3inchLog", 0, 0, 0);
+		fQuartzWindow3inchLog->SetVisAttributes(quartzVisAtt);
+	}
 
 
-    // BLUE
-    // Set visualization attributes
-    G4VisAttributes* blueVisAtt = new G4VisAttributes(fBlueColour);
-    blueVisAtt->SetVisibility(true);
+	// BLUE
+	// Set visualization attributes
+	G4VisAttributes* blueVisAtt = new G4VisAttributes(fBlueColour);
+	blueVisAtt->SetVisibility(true);
 
-    G4SubtractionSolid* blueVolume1      = CanVolume(false, fCanLength + fCanBackThickness, fBlueDetector, fBluePhi);
-    G4SubtractionSolid* blueVolume1_cut  = CanVolume(true, fCanLength - fCanThickness, fBlueDetector, fBluePhi);
+	G4SubtractionSolid* blueVolume1      = CanVolume(false, fCanLength + fCanBackThickness, fBlueDetector, fBluePhi);
+	G4SubtractionSolid* blueVolume1_cut  = CanVolume(true, fCanLength - fCanThickness, fBlueDetector, fBluePhi);
 
-    moveCut = G4ThreeVector(0.0*mm,0.0*mm, (fCanBackThickness)/2.0 - (fCanThickness)/2.0);
-    rotateCut = new G4RotationMatrix;
-    G4SubtractionSolid* blueVolume2 = new G4SubtractionSolid("blueVolume2", blueVolume1, blueVolume1_cut, rotateCut, moveCut);
+	moveCut = G4ThreeVector(0.0*mm,0.0*mm, (fCanBackThickness)/2.0 - (fCanThickness)/2.0);
+	rotateCut = new G4RotationMatrix;
+	G4SubtractionSolid* blueVolume2 = new G4SubtractionSolid("blueVolume2", blueVolume1, blueVolume1_cut, rotateCut, moveCut);
 
-    moveCut = G4ThreeVector(fBluePMTOffsetX, 0.0 , -1.0*(fCanLength));
-    rotateCut = new G4RotationMatrix;  
-    G4SubtractionSolid * blueVolume3 = new G4SubtractionSolid("blueVolume3", blueVolume2, windowCut5inch, rotateCut, moveCut);
-    
-    // Define rotation and movement objects
-    direction   = G4ThreeVector(0,0,1);
-    zPosition    = -1.0*(fCanLength + fCanBackThickness)/2.0 ;
-    move          = zPosition * direction;
-    rotate = new G4RotationMatrix;
+	moveCut = G4ThreeVector(fBluePMTOffsetX, 0.0 , -1.0*(fCanLength));
+	rotateCut = new G4RotationMatrix;  
+	G4SubtractionSolid * blueVolume3 = new G4SubtractionSolid("blueVolume3", blueVolume2, windowCut5inch, rotateCut, moveCut);
 
-    // logical volume blue
-    if(fBlueVolumeLog == NULL) {
-        fBlueVolumeLog = new G4LogicalVolume(blueVolume3, canG4material, "descantBlueVolumeLog", 0, 0, 0);
-        fBlueVolumeLog->SetVisAttributes(blueVisAtt);
-    }
-    fAssemblyBlue->AddPlacedVolume(fBlueVolumeLog, move, rotate);
-    
-    // quartz window blue
-    moveExtra = 2.0*(1.85*mm);
-    move = G4ThreeVector(fBluePMTOffsetX, 0.0, -1.0*(fCanLength + (fCanBackThickness)/2.0 + moveExtra));
-    rotate = new G4RotationMatrix;
-    fAssemblyBlue->AddPlacedVolume(fQuartzWindow5inchLog, move, rotate);
+	// Define rotation and movement objects
+	direction   = G4ThreeVector(0,0,1);
+	zPosition    = -1.0*(fCanLength + fCanBackThickness)/2.0 ;
+	move          = zPosition * direction;
+	rotate = new G4RotationMatrix;
 
-    // BLUE LEAD
-    // Set visualization attributes
-    G4VisAttributes* blueLeadVisAtt = new G4VisAttributes(fBlueColour);
-    blueLeadVisAtt->SetVisibility(true);
+	// logical volume blue
+	if(fBlueVolumeLog == nullptr) {
+		fBlueVolumeLog = new G4LogicalVolume(blueVolume3, canG4material, "descantBlueVolumeLog", 0, 0, 0);
+		fBlueVolumeLog->SetVisAttributes(blueVisAtt);
+	}
+	fAssemblyBlue->AddPlacedVolume(fBlueVolumeLog, move, rotate);
 
-    G4SubtractionSolid* blueLeadVolume1 = CanVolume(false, fLeadShieldThickness, fBlueDetector, fBluePhi);
+	// quartz window blue
+	moveExtra = 2.0*(1.85*mm);
+	move = G4ThreeVector(fBluePMTOffsetX, 0.0, -1.0*(fCanLength + (fCanBackThickness)/2.0 + moveExtra));
+	rotate = new G4RotationMatrix;
+	fAssemblyBlue->AddPlacedVolume(fQuartzWindow5inchLog, move, rotate);
 
-    // Define rotation and movement objects
-    direction 	= G4ThreeVector(0,0,1);
-    zPosition    = fLeadShieldThickness/2.0 ;
-    move          = zPosition * direction;
+	// BLUE LEAD
+	// Set visualization attributes
+	G4VisAttributes* blueLeadVisAtt = new G4VisAttributes(fBlueColour);
+	blueLeadVisAtt->SetVisibility(true);
 
-    rotate = new G4RotationMatrix;
+	G4SubtractionSolid* blueLeadVolume1 = CanVolume(false, fLeadShieldThickness, fBlueDetector, fBluePhi);
 
-    //logical volume
-    if(fBlueLeadVolumeLog == NULL) {
-        fBlueLeadVolumeLog = new G4LogicalVolume(blueLeadVolume1, leadG4material, "descantBlueLeadVolumeLog", 0, 0, 0);
-        fBlueLeadVolumeLog->SetVisAttributes(blueLeadVisAtt);
-    }
+	// Define rotation and movement objects
+	direction 	= G4ThreeVector(0,0,1);
+	zPosition    = fLeadShieldThickness/2.0 ;
+	move          = zPosition * direction;
 
-    if(fIncludeLead)
-        fAssemblyBlue->AddPlacedVolume(fBlueLeadVolumeLog, move, rotate);
+	rotate = new G4RotationMatrix;
 
-    // GREEN
-    // Set visualization attributes
-    G4VisAttributes* greenVisAtt = new G4VisAttributes(fGreenColour);
-    greenVisAtt->SetVisibility(true);
+	//logical volume
+	if(fBlueLeadVolumeLog == nullptr) {
+		fBlueLeadVolumeLog = new G4LogicalVolume(blueLeadVolume1, leadG4material, "descantBlueLeadVolumeLog", 0, 0, 0);
+		fBlueLeadVolumeLog->SetVisAttributes(blueLeadVisAtt);
+	}
 
-    G4SubtractionSolid* greenVolume1      = CanVolume(false, fCanLength + fCanBackThickness, fGreenDetector, fGreenPhi);
-    G4SubtractionSolid* greenVolume1_cut  = CanVolume(true, fCanLength -  fCanThickness, fGreenDetector, fGreenPhi);
+	if(fIncludeLead)
+		fAssemblyBlue->AddPlacedVolume(fBlueLeadVolumeLog, move, rotate);
 
-    moveCut = G4ThreeVector(0.0*mm,0.0*mm, (fCanBackThickness)/2.0 - (fCanThickness)/2.0);
-    rotateCut = new G4RotationMatrix;
+	// GREEN
+	// Set visualization attributes
+	G4VisAttributes* greenVisAtt = new G4VisAttributes(fGreenColour);
+	greenVisAtt->SetVisibility(true);
 
-    G4SubtractionSolid* greenVolume2 = new G4SubtractionSolid("greenVolume2", greenVolume1, greenVolume1_cut, rotateCut, moveCut);
+	G4SubtractionSolid* greenVolume1      = CanVolume(false, fCanLength + fCanBackThickness, fGreenDetector, fGreenPhi);
+	G4SubtractionSolid* greenVolume1_cut  = CanVolume(true, fCanLength -  fCanThickness, fGreenDetector, fGreenPhi);
 
-    moveCut = G4ThreeVector(-1.0*fYellowGreenPMTOffsetX, fYellowGreenPMTOffsetY , -1.0*(fCanLength));
-    rotateCut = new G4RotationMatrix;
+	moveCut = G4ThreeVector(0.0*mm,0.0*mm, (fCanBackThickness)/2.0 - (fCanThickness)/2.0);
+	rotateCut = new G4RotationMatrix;
 
-    G4SubtractionSolid * greenVolume3 = new G4SubtractionSolid("greenVolume3", greenVolume2, windowCut3inch, rotateCut, moveCut);
+	G4SubtractionSolid* greenVolume2 = new G4SubtractionSolid("greenVolume2", greenVolume1, greenVolume1_cut, rotateCut, moveCut);
 
-    // Define rotation and movement objects
-    direction   = G4ThreeVector(0,0,1);
-    zPosition    = -1.0*(fCanLength + fCanBackThickness)/2.0 ;
-    move          = zPosition * direction;
+	moveCut = G4ThreeVector(-1.0*fYellowGreenPMTOffsetX, fYellowGreenPMTOffsetY , -1.0*(fCanLength));
+	rotateCut = new G4RotationMatrix;
 
-    rotate = new G4RotationMatrix;
+	G4SubtractionSolid * greenVolume3 = new G4SubtractionSolid("greenVolume3", greenVolume2, windowCut3inch, rotateCut, moveCut);
 
-    //logical volume
-    if(fGreenVolumeLog == NULL) {
-        fGreenVolumeLog = new G4LogicalVolume(greenVolume3, canG4material, "descantGreenVolumeLog", 0, 0, 0);
-        fGreenVolumeLog->SetVisAttributes(greenVisAtt);
-    }
-    fAssemblyGreen->AddPlacedVolume(fGreenVolumeLog, move, rotate);
+	// Define rotation and movement objects
+	direction   = G4ThreeVector(0,0,1);
+	zPosition    = -1.0*(fCanLength + fCanBackThickness)/2.0 ;
+	move          = zPosition * direction;
 
-    // quartz window green
-    moveExtra = 2.0*(1.85*mm);
-    move = G4ThreeVector(-1.0*fYellowGreenPMTOffsetX, fYellowGreenPMTOffsetY, -1.0*(fCanLength + (fCanBackThickness)/2.0 + moveExtra));
-    rotate = new G4RotationMatrix;
-    fAssemblyGreen->AddPlacedVolume(fQuartzWindow3inchLog, move, rotate);
+	rotate = new G4RotationMatrix;
 
-    // GREEN LEAD
-    // Set visualization attributes
-    G4VisAttributes* greenLeadVisAtt = new G4VisAttributes(fGreenColour);
-    greenLeadVisAtt->SetVisibility(true);
+	//logical volume
+	if(fGreenVolumeLog == nullptr) {
+		fGreenVolumeLog = new G4LogicalVolume(greenVolume3, canG4material, "descantGreenVolumeLog", 0, 0, 0);
+		fGreenVolumeLog->SetVisAttributes(greenVisAtt);
+	}
+	fAssemblyGreen->AddPlacedVolume(fGreenVolumeLog, move, rotate);
 
-    G4SubtractionSolid* greenLeadVolume1 = CanVolume(false, fLeadShieldThickness, fGreenDetector, fGreenPhi);
+	// quartz window green
+	moveExtra = 2.0*(1.85*mm);
+	move = G4ThreeVector(-1.0*fYellowGreenPMTOffsetX, fYellowGreenPMTOffsetY, -1.0*(fCanLength + (fCanBackThickness)/2.0 + moveExtra));
+	rotate = new G4RotationMatrix;
+	fAssemblyGreen->AddPlacedVolume(fQuartzWindow3inchLog, move, rotate);
 
-    // Define rotation and movement objects
-    direction 	= G4ThreeVector(0,0,1);
-    zPosition    = fLeadShieldThickness/2.0 ;
-    move          = zPosition * direction;
+	// GREEN LEAD
+	// Set visualization attributes
+	G4VisAttributes* greenLeadVisAtt = new G4VisAttributes(fGreenColour);
+	greenLeadVisAtt->SetVisibility(true);
 
-    rotate = new G4RotationMatrix;
+	G4SubtractionSolid* greenLeadVolume1 = CanVolume(false, fLeadShieldThickness, fGreenDetector, fGreenPhi);
 
-    //logical volume
-    if(fGreenLeadVolumeLog == NULL) {
-        fGreenLeadVolumeLog = new G4LogicalVolume(greenLeadVolume1, leadG4material, "descantGreenLeadVolumeLog", 0, 0, 0);
-        fGreenLeadVolumeLog->SetVisAttributes(greenLeadVisAtt);
-    }
+	// Define rotation and movement objects
+	direction 	= G4ThreeVector(0,0,1);
+	zPosition    = fLeadShieldThickness/2.0 ;
+	move          = zPosition * direction;
 
-    if(fIncludeLead)
-        fAssemblyGreen->AddPlacedVolume(fGreenLeadVolumeLog, move, rotate);
+	rotate = new G4RotationMatrix;
 
-    // RED
-    // Set visualization attributes
-    G4VisAttributes* redVisAtt = new G4VisAttributes(fRedColour);
-    redVisAtt->SetVisibility(true);
-    
-    G4SubtractionSolid* redVolume1      = CanVolume(false, fCanLength + fCanBackThickness, fRedDetector, fRedPhi);
-    G4SubtractionSolid* redVolume1_cut  = CanVolume(true, fCanLength -  fCanThickness, fRedDetector, fRedPhi);
-    
-    moveCut = G4ThreeVector(0.0*mm,0.0*mm, (fCanBackThickness)/2.0 - (fCanThickness)/2.0);
-    rotateCut = new G4RotationMatrix;
-    
-    G4SubtractionSolid* redVolume2 = new G4SubtractionSolid("redVolume2", redVolume1, redVolume1_cut, rotateCut, moveCut);
-    
-    moveCut = G4ThreeVector(-1.0*fRedPMTOffsetX , 0.0 , -1.0*(fCanLength));
-    rotateCut = new G4RotationMatrix;
-    
-    G4SubtractionSolid * redVolume3 = new G4SubtractionSolid("redVolume3", redVolume2, windowCut5inch, rotateCut, moveCut);
-    
-    // Define rotation and movement objects
-    direction 	= G4ThreeVector(0,0,1);
-    zPosition    = -1.0*(fCanLength + fCanBackThickness)/2.0 ;
-    move          = zPosition * direction;
-    
-    rotate = new G4RotationMatrix;
-    
-    //logical volume
-    if(fRedVolumeLog == NULL) {
-        fRedVolumeLog = new G4LogicalVolume(redVolume3, canG4material, "descantRedVolumeLog", 0, 0, 0);
-        fRedVolumeLog->SetVisAttributes(redVisAtt);
-    }
-    fAssemblyRed->AddPlacedVolume(fRedVolumeLog, move, rotate);
-    
-    moveExtra = 2.0*(1.85*mm);
-    move = G4ThreeVector(-1.0*fRedPMTOffsetX, 0.0, -1.0*(fCanLength + (fCanBackThickness)/2.0 + moveExtra));
-    rotate = new G4RotationMatrix;
-    fAssemblyRed->AddPlacedVolume(fQuartzWindow5inchLog, move, rotate);
-    
-    // RED LEAD
-    // Set visualization attributes
-    G4VisAttributes* redLeadVisAtt = new G4VisAttributes(fRedColour);
-    redLeadVisAtt->SetVisibility(true);
-    
-    G4SubtractionSolid* redLeadVolume1 = CanVolume(false, fLeadShieldThickness, fRedDetector, fRedPhi);
-    
-    // Define rotation and movement objects
-    direction 	= G4ThreeVector(0,0,1);
-    zPosition    = fLeadShieldThickness/2.0 ;
-    move          = zPosition * direction;
-    
-    rotate = new G4RotationMatrix;
-    
-    //logical volume
-    if(fRedLeadVolumeLog == NULL) {
-        fRedLeadVolumeLog = new G4LogicalVolume(redLeadVolume1, leadG4material, "descantRedLeadVolumeLog", 0, 0, 0);
-        fRedLeadVolumeLog->SetVisAttributes(redLeadVisAtt);
-    }
-    
-    if(fIncludeLead)
-        fAssemblyRed->AddPlacedVolume(fRedLeadVolumeLog, move, rotate);
-    
-    // WHITE
-    // Set visualization attributes
-    G4VisAttributes* whiteVisAtt = new G4VisAttributes(fWhiteColour);
-    whiteVisAtt->SetVisibility(true);
-    
-    G4SubtractionSolid* whiteVolume1      = CanVolume(false, fCanLength + fCanBackThickness, fWhiteDetector, fWhitePhi);
-    G4SubtractionSolid* whiteVolume1_cut  = CanVolume(true, fCanLength - fCanThickness, fWhiteDetector, fWhitePhi);
-    
-    moveCut = G4ThreeVector(0.0*mm,0.0*mm, (fCanBackThickness)/2.0 - (fCanThickness)/2.0);
-    rotateCut = new G4RotationMatrix;
-    
-    G4SubtractionSolid* whiteVolume2 = new G4SubtractionSolid("whiteVolume2", whiteVolume1, whiteVolume1_cut, rotateCut, moveCut);
-    
-    moveCut = G4ThreeVector(0.0, fWhitePMTOffsetY, -1.0*(fCanLength));
-    rotateCut = new G4RotationMatrix;
-    
-    G4SubtractionSolid * whiteVolume3 = new G4SubtractionSolid("whiteVolume3", whiteVolume2, windowCut5inch, rotateCut, moveCut);
-    
-    // Define rotation and movement objects
-    direction 	= G4ThreeVector(0,0,1);
-    zPosition    = -1.0*(fCanLength + fCanBackThickness)/2.0 ;
-    move          = zPosition * direction;
-    
-    rotate = new G4RotationMatrix;
-    
-    //logical volume
-    if(fWhiteVolumeLog == NULL) {
-        fWhiteVolumeLog = new G4LogicalVolume(whiteVolume3, canG4material, "descantWhiteVolumeLog", 0, 0, 0);
-        fWhiteVolumeLog->SetVisAttributes(whiteVisAtt);
-        
-    }
-    fAssemblyWhite->AddPlacedVolume(fWhiteVolumeLog, move, rotate);
-    
-    // QUARTZ WINDOW
-    moveExtra = 2.0*(1.85*mm);
-    move = G4ThreeVector(0.0, fWhitePMTOffsetY, -1.0*(fCanLength + (fCanBackThickness)/2.0 + moveExtra));
-    rotate = new G4RotationMatrix;
-    fAssemblyWhite->AddPlacedVolume(fQuartzWindow5inchLog, move, rotate);
-    
-    // WHITE LEAD
-    // Set visualization attributes
-    G4VisAttributes* whiteLeadVisAtt = new G4VisAttributes(fWhiteColour);
-    whiteLeadVisAtt->SetVisibility(true);
-    
-    G4SubtractionSolid* whiteLeadVolume1 = CanVolume(false, fLeadShieldThickness, fWhiteDetector, fWhitePhi);
-    
-    // Define rotation and movement objects
-    direction 	= G4ThreeVector(0,0,1);
-    zPosition    = fLeadShieldThickness/2.0 ;
-    move          = zPosition * direction;
-    
-    rotate = new G4RotationMatrix;
-    
-    //logical volume
-    if(fWhiteLeadVolumeLog == NULL) {
-        fWhiteLeadVolumeLog = new G4LogicalVolume(whiteLeadVolume1, leadG4material, "descantWhiteLeadVolumeLog", 0, 0, 0);
-        fWhiteLeadVolumeLog->SetVisAttributes(whiteLeadVisAtt);
-    }
-    
-    if(fIncludeLead)
-        fAssemblyWhite->AddPlacedVolume(fWhiteLeadVolumeLog, move, rotate);
-    
-    // YELLOW
-    // Set visualization attributes
-    G4VisAttributes* yellowVisAtt = new G4VisAttributes(fYellowColour);
-    yellowVisAtt->SetVisibility(true);
-    
-    G4SubtractionSolid* yellowVolume1      = CanVolume(false, fCanLength + fCanBackThickness, fYellowDetector, fYellowPhi);
-    G4SubtractionSolid* yellowVolume1_cut  = CanVolume(true, fCanLength -  fCanThickness, fYellowDetector, fYellowPhi);
-    
-    moveCut = G4ThreeVector(0.0*mm,0.0*mm, (fCanBackThickness)/2.0 - (fCanThickness)/2.0);
-    rotateCut = new G4RotationMatrix;
-    
-    G4SubtractionSolid* yellowVolume2 = new G4SubtractionSolid("yellowVolume2", yellowVolume1, yellowVolume1_cut, rotateCut, moveCut);
-    
-    moveCut = G4ThreeVector(1.0*fYellowGreenPMTOffsetX, fYellowGreenPMTOffsetY , -1.0*(fCanLength));
-    rotateCut = new G4RotationMatrix;
-    
-    G4SubtractionSolid * yellowVolume3 = new G4SubtractionSolid("yellowVolume3", yellowVolume2, windowCut3inch, rotateCut, moveCut);
-    
-    // Define rotation and movement objects
-    direction   = G4ThreeVector(0,0,1);
-    zPosition    = -1.0*(fCanLength + fCanBackThickness)/2.0 ;
-    move          = zPosition * direction;
-    
-    rotate = new G4RotationMatrix;
-    
-    //logical volume
-    if(fYellowVolumeLog == NULL) {
-        fYellowVolumeLog = new G4LogicalVolume(yellowVolume3, canG4material, "descantYellowVolumeLog", 0, 0, 0);
-        fYellowVolumeLog->SetVisAttributes(yellowVisAtt);
-    }
-    fAssemblyYellow->AddPlacedVolume(fYellowVolumeLog, move, rotate);
-    
-    // QUARTZ WINDOW
-    moveExtra = 2.0*(1.85*mm);
-    move = G4ThreeVector(1.0*fYellowGreenPMTOffsetX, fYellowGreenPMTOffsetY, -1.0*(fCanLength + (fCanBackThickness)/2.0 + moveExtra));
-    rotate = new G4RotationMatrix;
-    fAssemblyYellow->AddPlacedVolume(fQuartzWindow3inchLog, move, rotate);
-    
-    // YELLOW LEAD
-    // Set visualization attributes
-    G4VisAttributes* yellowLeadVisAtt = new G4VisAttributes(fYellowColour);
-    yellowLeadVisAtt->SetVisibility(true);
-    
-    G4SubtractionSolid* yellowLeadVolume1 = CanVolume(false, fLeadShieldThickness, fYellowDetector, fYellowPhi);
-    
-    // Define rotation and movement objects
-    direction 	= G4ThreeVector(0,0,1);
-    zPosition    = fLeadShieldThickness/2.0 ;
-    move          = zPosition * direction;
-    
-    rotate = new G4RotationMatrix;
-    
-    //logical volume
-    if(fYellowLeadVolumeLog == NULL) {
-        fYellowLeadVolumeLog = new G4LogicalVolume(yellowLeadVolume1, leadG4material, "descantYellowLeadVolumeLog", 0, 0, 0);
-        fYellowLeadVolumeLog->SetVisAttributes(yellowLeadVisAtt);
-    }
-    
-    if(fIncludeLead)
-        fAssemblyYellow->AddPlacedVolume(fYellowLeadVolumeLog, move, rotate);
-    
-    return 1;
+	//logical volume
+	if(fGreenLeadVolumeLog == nullptr) {
+		fGreenLeadVolumeLog = new G4LogicalVolume(greenLeadVolume1, leadG4material, "descantGreenLeadVolumeLog", 0, 0, 0);
+		fGreenLeadVolumeLog->SetVisAttributes(greenLeadVisAtt);
+	}
+
+	if(fIncludeLead)
+		fAssemblyGreen->AddPlacedVolume(fGreenLeadVolumeLog, move, rotate);
+
+	// RED
+	// Set visualization attributes
+	G4VisAttributes* redVisAtt = new G4VisAttributes(fRedColour);
+	redVisAtt->SetVisibility(true);
+
+	G4SubtractionSolid* redVolume1      = CanVolume(false, fCanLength + fCanBackThickness, fRedDetector, fRedPhi);
+	G4SubtractionSolid* redVolume1_cut  = CanVolume(true, fCanLength -  fCanThickness, fRedDetector, fRedPhi);
+
+	moveCut = G4ThreeVector(0.0*mm,0.0*mm, (fCanBackThickness)/2.0 - (fCanThickness)/2.0);
+	rotateCut = new G4RotationMatrix;
+
+	G4SubtractionSolid* redVolume2 = new G4SubtractionSolid("redVolume2", redVolume1, redVolume1_cut, rotateCut, moveCut);
+
+	moveCut = G4ThreeVector(-1.0*fRedPMTOffsetX , 0.0 , -1.0*(fCanLength));
+	rotateCut = new G4RotationMatrix;
+
+	G4SubtractionSolid * redVolume3 = new G4SubtractionSolid("redVolume3", redVolume2, windowCut5inch, rotateCut, moveCut);
+
+	// Define rotation and movement objects
+	direction 	= G4ThreeVector(0,0,1);
+	zPosition    = -1.0*(fCanLength + fCanBackThickness)/2.0 ;
+	move          = zPosition * direction;
+
+	rotate = new G4RotationMatrix;
+
+	//logical volume
+	if(fRedVolumeLog == nullptr) {
+		fRedVolumeLog = new G4LogicalVolume(redVolume3, canG4material, "descantRedVolumeLog", 0, 0, 0);
+		fRedVolumeLog->SetVisAttributes(redVisAtt);
+	}
+	fAssemblyRed->AddPlacedVolume(fRedVolumeLog, move, rotate);
+
+	moveExtra = 2.0*(1.85*mm);
+	move = G4ThreeVector(-1.0*fRedPMTOffsetX, 0.0, -1.0*(fCanLength + (fCanBackThickness)/2.0 + moveExtra));
+	rotate = new G4RotationMatrix;
+	fAssemblyRed->AddPlacedVolume(fQuartzWindow5inchLog, move, rotate);
+
+	// RED LEAD
+	// Set visualization attributes
+	G4VisAttributes* redLeadVisAtt = new G4VisAttributes(fRedColour);
+	redLeadVisAtt->SetVisibility(true);
+
+	G4SubtractionSolid* redLeadVolume1 = CanVolume(false, fLeadShieldThickness, fRedDetector, fRedPhi);
+
+	// Define rotation and movement objects
+	direction 	= G4ThreeVector(0,0,1);
+	zPosition    = fLeadShieldThickness/2.0 ;
+	move          = zPosition * direction;
+
+	rotate = new G4RotationMatrix;
+
+	//logical volume
+	if(fRedLeadVolumeLog == nullptr) {
+		fRedLeadVolumeLog = new G4LogicalVolume(redLeadVolume1, leadG4material, "descantRedLeadVolumeLog", 0, 0, 0);
+		fRedLeadVolumeLog->SetVisAttributes(redLeadVisAtt);
+	}
+
+	if(fIncludeLead)
+		fAssemblyRed->AddPlacedVolume(fRedLeadVolumeLog, move, rotate);
+
+	// WHITE
+	// Set visualization attributes
+	G4VisAttributes* whiteVisAtt = new G4VisAttributes(fWhiteColour);
+	whiteVisAtt->SetVisibility(true);
+
+	G4SubtractionSolid* whiteVolume1      = CanVolume(false, fCanLength + fCanBackThickness, fWhiteDetector, fWhitePhi);
+	G4SubtractionSolid* whiteVolume1_cut  = CanVolume(true, fCanLength - fCanThickness, fWhiteDetector, fWhitePhi);
+
+	moveCut = G4ThreeVector(0.0*mm,0.0*mm, (fCanBackThickness)/2.0 - (fCanThickness)/2.0);
+	rotateCut = new G4RotationMatrix;
+
+	G4SubtractionSolid* whiteVolume2 = new G4SubtractionSolid("whiteVolume2", whiteVolume1, whiteVolume1_cut, rotateCut, moveCut);
+
+	moveCut = G4ThreeVector(0.0, fWhitePMTOffsetY, -1.0*(fCanLength));
+	rotateCut = new G4RotationMatrix;
+
+	G4SubtractionSolid * whiteVolume3 = new G4SubtractionSolid("whiteVolume3", whiteVolume2, windowCut5inch, rotateCut, moveCut);
+
+	// Define rotation and movement objects
+	direction 	= G4ThreeVector(0,0,1);
+	zPosition    = -1.0*(fCanLength + fCanBackThickness)/2.0 ;
+	move          = zPosition * direction;
+
+	rotate = new G4RotationMatrix;
+
+	//logical volume
+	if(fWhiteVolumeLog == nullptr) {
+		fWhiteVolumeLog = new G4LogicalVolume(whiteVolume3, canG4material, "descantWhiteVolumeLog", 0, 0, 0);
+		fWhiteVolumeLog->SetVisAttributes(whiteVisAtt);
+
+	}
+	fAssemblyWhite->AddPlacedVolume(fWhiteVolumeLog, move, rotate);
+
+	// QUARTZ WINDOW
+	moveExtra = 2.0*(1.85*mm);
+	move = G4ThreeVector(0.0, fWhitePMTOffsetY, -1.0*(fCanLength + (fCanBackThickness)/2.0 + moveExtra));
+	rotate = new G4RotationMatrix;
+	fAssemblyWhite->AddPlacedVolume(fQuartzWindow5inchLog, move, rotate);
+
+	// WHITE LEAD
+	// Set visualization attributes
+	G4VisAttributes* whiteLeadVisAtt = new G4VisAttributes(fWhiteColour);
+	whiteLeadVisAtt->SetVisibility(true);
+
+	G4SubtractionSolid* whiteLeadVolume1 = CanVolume(false, fLeadShieldThickness, fWhiteDetector, fWhitePhi);
+
+	// Define rotation and movement objects
+	direction 	= G4ThreeVector(0,0,1);
+	zPosition    = fLeadShieldThickness/2.0 ;
+	move          = zPosition * direction;
+
+	rotate = new G4RotationMatrix;
+
+	//logical volume
+	if(fWhiteLeadVolumeLog == nullptr) {
+		fWhiteLeadVolumeLog = new G4LogicalVolume(whiteLeadVolume1, leadG4material, "descantWhiteLeadVolumeLog", 0, 0, 0);
+		fWhiteLeadVolumeLog->SetVisAttributes(whiteLeadVisAtt);
+	}
+
+	if(fIncludeLead)
+		fAssemblyWhite->AddPlacedVolume(fWhiteLeadVolumeLog, move, rotate);
+
+	// YELLOW
+	// Set visualization attributes
+	G4VisAttributes* yellowVisAtt = new G4VisAttributes(fYellowColour);
+	yellowVisAtt->SetVisibility(true);
+
+	G4SubtractionSolid* yellowVolume1      = CanVolume(false, fCanLength + fCanBackThickness, fYellowDetector, fYellowPhi);
+	G4SubtractionSolid* yellowVolume1_cut  = CanVolume(true, fCanLength -  fCanThickness, fYellowDetector, fYellowPhi);
+
+	moveCut = G4ThreeVector(0.0*mm,0.0*mm, (fCanBackThickness)/2.0 - (fCanThickness)/2.0);
+	rotateCut = new G4RotationMatrix;
+
+	G4SubtractionSolid* yellowVolume2 = new G4SubtractionSolid("yellowVolume2", yellowVolume1, yellowVolume1_cut, rotateCut, moveCut);
+
+	moveCut = G4ThreeVector(1.0*fYellowGreenPMTOffsetX, fYellowGreenPMTOffsetY , -1.0*(fCanLength));
+	rotateCut = new G4RotationMatrix;
+
+	G4SubtractionSolid * yellowVolume3 = new G4SubtractionSolid("yellowVolume3", yellowVolume2, windowCut3inch, rotateCut, moveCut);
+
+	// Define rotation and movement objects
+	direction   = G4ThreeVector(0,0,1);
+	zPosition    = -1.0*(fCanLength + fCanBackThickness)/2.0 ;
+	move          = zPosition * direction;
+
+	rotate = new G4RotationMatrix;
+
+	//logical volume
+	if(fYellowVolumeLog == nullptr) {
+		fYellowVolumeLog = new G4LogicalVolume(yellowVolume3, canG4material, "descantYellowVolumeLog", 0, 0, 0);
+		fYellowVolumeLog->SetVisAttributes(yellowVisAtt);
+	}
+	fAssemblyYellow->AddPlacedVolume(fYellowVolumeLog, move, rotate);
+
+	// QUARTZ WINDOW
+	moveExtra = 2.0*(1.85*mm);
+	move = G4ThreeVector(1.0*fYellowGreenPMTOffsetX, fYellowGreenPMTOffsetY, -1.0*(fCanLength + (fCanBackThickness)/2.0 + moveExtra));
+	rotate = new G4RotationMatrix;
+	fAssemblyYellow->AddPlacedVolume(fQuartzWindow3inchLog, move, rotate);
+
+	// YELLOW LEAD
+	// Set visualization attributes
+	G4VisAttributes* yellowLeadVisAtt = new G4VisAttributes(fYellowColour);
+	yellowLeadVisAtt->SetVisibility(true);
+
+	G4SubtractionSolid* yellowLeadVolume1 = CanVolume(false, fLeadShieldThickness, fYellowDetector, fYellowPhi);
+
+	// Define rotation and movement objects
+	direction 	= G4ThreeVector(0,0,1);
+	zPosition    = fLeadShieldThickness/2.0 ;
+	move          = zPosition * direction;
+
+	rotate = new G4RotationMatrix;
+
+	//logical volume
+	if(fYellowLeadVolumeLog == nullptr) {
+		fYellowLeadVolumeLog = new G4LogicalVolume(yellowLeadVolume1, leadG4material, "descantYellowLeadVolumeLog", 0, 0, 0);
+		fYellowLeadVolumeLog->SetVisAttributes(yellowLeadVisAtt);
+	}
+
+	if(fIncludeLead)
+		fAssemblyYellow->AddPlacedVolume(fYellowLeadVolumeLog, move, rotate);
+
+	return 1;
 }
 
 G4int DetectionSystemDescant::BuildDetectorVolume()
 {
-    G4ThreeVector move, direction;
-    G4RotationMatrix* rotate;
-    G4double zPosition;
+	G4ThreeVector move, direction;
+	G4RotationMatrix* rotate;
+	G4double zPosition;
 
-    G4Material* material = G4Material::GetMaterial(fLiquidMaterial);
-    if(!material) {
-        G4cout << " ----> Material " << fLiquidMaterial << " not found, cannot build the detector shell! " << G4endl;
-        return 0;
-    }
+	G4Material* material = G4Material::GetMaterial(fLiquidMaterial);
+	if(!material) {
+		G4cout<<" ----> Material "<<fLiquidMaterial<<" not found, cannot build the detector shell! "<<G4endl;
+		return 0;
+	}
 
-    // BLUE
-    // Set visualization attributes
-    G4VisAttributes* blueVisAtt = new G4VisAttributes(fLiquidColour);
-    blueVisAtt->SetVisibility(true);
+	// BLUE
+	// Set visualization attributes
+	G4VisAttributes* blueVisAtt = new G4VisAttributes(fLiquidColour);
+	blueVisAtt->SetVisibility(true);
 
-    G4SubtractionSolid* blueVolume1_cut  = CanVolume(true, fCanLength-fCanThickness, fBlueDetector, fBluePhi);
+	G4SubtractionSolid* blueVolume1_cut  = CanVolume(true, fCanLength-fCanThickness, fBlueDetector, fBluePhi);
 
-    // Define rotation and movement objects
-    direction 	= G4ThreeVector(0,0,1);
-    zPosition    = -1.0*(fCanLength+fCanThickness)/2.0 ;
-    move          = zPosition * direction;
+	// Define rotation and movement objects
+	direction 	= G4ThreeVector(0,0,1);
+	zPosition    = -1.0*(fCanLength+fCanThickness)/2.0 ;
+	move          = zPosition * direction;
 
-    rotate = new G4RotationMatrix;
+	rotate = new G4RotationMatrix;
 
-    //logical volume
-    if(fBlueScintillatorVolumeLog == NULL)
-    {
-        fBlueScintillatorVolumeLog = new G4LogicalVolume(blueVolume1_cut, material, "blueScintillatorVolumeLog", 0, 0, 0);
-        fBlueScintillatorVolumeLog->SetVisAttributes(blueVisAtt);
-    }
+	//logical volume
+	if(fBlueScintillatorVolumeLog == nullptr)
+	{
+		fBlueScintillatorVolumeLog = new G4LogicalVolume(blueVolume1_cut, material, "blueScintillatorVolumeLog", 0, 0, 0);
+		fBlueScintillatorVolumeLog->SetVisAttributes(blueVisAtt);
+	}
 
-    fAssemblyBlueScintillator->AddPlacedVolume(fBlueScintillatorVolumeLog, move, rotate);
+	fAssemblyBlueScintillator->AddPlacedVolume(fBlueScintillatorVolumeLog, move, rotate);
 
-    //GREEN
-    // Set visualization attributes
-    G4VisAttributes* greenVisAtt = new G4VisAttributes(fLiquidColour);
-    greenVisAtt->SetVisibility(true);
+	//GREEN
+	// Set visualization attributes
+	G4VisAttributes* greenVisAtt = new G4VisAttributes(fLiquidColour);
+	greenVisAtt->SetVisibility(true);
 
-    G4SubtractionSolid* greenVolume1_cut  = CanVolume(true, fCanLength-fCanThickness, fGreenDetector, fGreenPhi);
+	G4SubtractionSolid* greenVolume1_cut  = CanVolume(true, fCanLength-fCanThickness, fGreenDetector, fGreenPhi);
 
-    // Define rotation and movement objects
-    direction 	= G4ThreeVector(0,0,1);
-    zPosition    = -1.0*(fCanLength+fCanThickness)/2.0 ;
-    move          = zPosition * direction;
+	// Define rotation and movement objects
+	direction 	= G4ThreeVector(0,0,1);
+	zPosition    = -1.0*(fCanLength+fCanThickness)/2.0 ;
+	move          = zPosition * direction;
 
-    rotate = new G4RotationMatrix;
+	rotate = new G4RotationMatrix;
 
-    //logical volume
-    if(fGreenScintillatorVolumeLog == NULL)
-    {
-        fGreenScintillatorVolumeLog = new G4LogicalVolume(greenVolume1_cut, material, "greenScintillatorVolumeLog", 0, 0, 0);
-        fGreenScintillatorVolumeLog->SetVisAttributes(greenVisAtt);
-    }
+	//logical volume
+	if(fGreenScintillatorVolumeLog == nullptr)
+	{
+		fGreenScintillatorVolumeLog = new G4LogicalVolume(greenVolume1_cut, material, "greenScintillatorVolumeLog", 0, 0, 0);
+		fGreenScintillatorVolumeLog->SetVisAttributes(greenVisAtt);
+	}
 
-    fAssemblyGreenScintillator->AddPlacedVolume(fGreenScintillatorVolumeLog, move, rotate);
+	fAssemblyGreenScintillator->AddPlacedVolume(fGreenScintillatorVolumeLog, move, rotate);
 
-    // RED
-    // Set visualization attributes
-    G4VisAttributes* redVisAtt = new G4VisAttributes(fLiquidColour);
-    redVisAtt->SetVisibility(true);
+	// RED
+	// Set visualization attributes
+	G4VisAttributes* redVisAtt = new G4VisAttributes(fLiquidColour);
+	redVisAtt->SetVisibility(true);
 
-    G4SubtractionSolid* redVolume1_cut  = CanVolume(true, fCanLength-fCanThickness, fRedDetector, fRedPhi);
+	G4SubtractionSolid* redVolume1_cut  = CanVolume(true, fCanLength-fCanThickness, fRedDetector, fRedPhi);
 
-    // Define rotation and movement objects
-    direction 	= G4ThreeVector(0,0,1);
-    zPosition    = -1.0*(fCanLength+fCanThickness)/2.0 ;
-    move          = zPosition * direction;
+	// Define rotation and movement objects
+	direction 	= G4ThreeVector(0,0,1);
+	zPosition    = -1.0*(fCanLength+fCanThickness)/2.0 ;
+	move          = zPosition * direction;
 
-    rotate = new G4RotationMatrix;
+	rotate = new G4RotationMatrix;
 
-    //logical volume
-    if(fRedScintillatorVolumeLog == NULL)
-    {
-        fRedScintillatorVolumeLog = new G4LogicalVolume(redVolume1_cut, material, "redScintillatorVolumeLog", 0, 0, 0);
-        fRedScintillatorVolumeLog->SetVisAttributes(redVisAtt);
-    }
+	//logical volume
+	if(fRedScintillatorVolumeLog == nullptr)
+	{
+		fRedScintillatorVolumeLog = new G4LogicalVolume(redVolume1_cut, material, "redScintillatorVolumeLog", 0, 0, 0);
+		fRedScintillatorVolumeLog->SetVisAttributes(redVisAtt);
+	}
 
-    fAssemblyRedScintillator->AddPlacedVolume(fRedScintillatorVolumeLog, move, rotate);
+	fAssemblyRedScintillator->AddPlacedVolume(fRedScintillatorVolumeLog, move, rotate);
 
-    // WHITE
-    // Set visualization attributes
-    G4VisAttributes* whiteVisAtt = new G4VisAttributes(fLiquidColour);
-    whiteVisAtt->SetVisibility(true);
+	// WHITE
+	// Set visualization attributes
+	G4VisAttributes* whiteVisAtt = new G4VisAttributes(fLiquidColour);
+	whiteVisAtt->SetVisibility(true);
 
-    G4SubtractionSolid* whiteVolume1_cut  = CanVolume(true, fCanLength-fCanThickness, fWhiteDetector, fWhitePhi);
+	G4SubtractionSolid* whiteVolume1_cut  = CanVolume(true, fCanLength-fCanThickness, fWhiteDetector, fWhitePhi);
 
-    // Define rotation and movement objects
-    direction 	= G4ThreeVector(0,0,1);
-    zPosition    = -1.0*(fCanLength+fCanThickness)/2.0 ;
-    move          = zPosition * direction;
+	// Define rotation and movement objects
+	direction 	= G4ThreeVector(0,0,1);
+	zPosition    = -1.0*(fCanLength+fCanThickness)/2.0 ;
+	move          = zPosition * direction;
 
-    rotate = new G4RotationMatrix;
+	rotate = new G4RotationMatrix;
 
-    //logical volume
-    if(fWhiteScintillatorVolumeLog == NULL)
-    {
-        fWhiteScintillatorVolumeLog = new G4LogicalVolume(whiteVolume1_cut, material, "whiteScintillatorVolumeLog", 0, 0, 0);
-        fWhiteScintillatorVolumeLog->SetVisAttributes(whiteVisAtt);
-    }
+	//logical volume
+	if(fWhiteScintillatorVolumeLog == nullptr)
+	{
+		fWhiteScintillatorVolumeLog = new G4LogicalVolume(whiteVolume1_cut, material, "whiteScintillatorVolumeLog", 0, 0, 0);
+		fWhiteScintillatorVolumeLog->SetVisAttributes(whiteVisAtt);
+	}
 
-    fAssemblyWhiteScintillator->AddPlacedVolume(fWhiteScintillatorVolumeLog, move, rotate);
+	fAssemblyWhiteScintillator->AddPlacedVolume(fWhiteScintillatorVolumeLog, move, rotate);
 
-    // YELLOW
-    // Set visualization attributes
-    G4VisAttributes* yellowVisAtt = new G4VisAttributes(fLiquidColour);
-    yellowVisAtt->SetVisibility(true);
+	// YELLOW
+	// Set visualization attributes
+	G4VisAttributes* yellowVisAtt = new G4VisAttributes(fLiquidColour);
+	yellowVisAtt->SetVisibility(true);
 
-    G4SubtractionSolid* yellowVolume1_cut  = CanVolume(true, fCanLength-fCanThickness, fYellowDetector, fYellowPhi);
+	G4SubtractionSolid* yellowVolume1_cut  = CanVolume(true, fCanLength-fCanThickness, fYellowDetector, fYellowPhi);
 
-    // Define rotation and movement objects
-    direction 	= G4ThreeVector(0,0,1);
-    zPosition    = -1.0*(fCanLength+fCanThickness)/2.0 ;
-    move          = zPosition * direction;
+	// Define rotation and movement objects
+	direction 	= G4ThreeVector(0,0,1);
+	zPosition    = -1.0*(fCanLength+fCanThickness)/2.0 ;
+	move          = zPosition * direction;
 
-    rotate = new G4RotationMatrix;
+	rotate = new G4RotationMatrix;
 
-    //logical volume
-    if(fYellowScintillatorVolumeLog == NULL)
-    {
-        fYellowScintillatorVolumeLog = new G4LogicalVolume(yellowVolume1_cut, material, "yellowScintillatorVolumeLog", 0, 0, 0);
-        fYellowScintillatorVolumeLog->SetVisAttributes(yellowVisAtt);
-    }
+	//logical volume
+	if(fYellowScintillatorVolumeLog == nullptr)
+	{
+		fYellowScintillatorVolumeLog = new G4LogicalVolume(yellowVolume1_cut, material, "yellowScintillatorVolumeLog", 0, 0, 0);
+		fYellowScintillatorVolumeLog->SetVisAttributes(yellowVisAtt);
+	}
 
-    fAssemblyYellowScintillator->AddPlacedVolume(fYellowScintillatorVolumeLog, move, rotate);
+	fAssemblyYellowScintillator->AddPlacedVolume(fYellowScintillatorVolumeLog, move, rotate);
 
-    return 1;
+	return 1;
 }
 
 ///////////////////////////////////////////////////////////////////////
@@ -1099,178 +1099,178 @@ G4int DetectionSystemDescant::BuildDetectorVolume()
 // This function constructs a generic 6 sided shape defined by 12 input points, and the cut phi angles.
 G4SubtractionSolid* DetectionSystemDescant::CanVolume(G4bool insideVol, G4double volumeLength, G4double detector[12][3], G4double detectorPhi[6])
 {
-    G4int idx1;
-    G4int idx2;
+	G4int idx1;
+	G4int idx2;
 
-    G4ThreeVector frontP1;
-    G4ThreeVector frontP2;
+	G4ThreeVector frontP1;
+	G4ThreeVector frontP2;
 
-    G4double startPhi      = 0.0*deg;
-    G4double endPhi        = 360.0*deg;
-    G4double innerRadius;
-    G4double outerRadius;
-    G4double halfLengthZ;
+	G4double startPhi      = 0.0*deg;
+	G4double endPhi        = 360.0*deg;
+	G4double innerRadius;
+	G4double outerRadius;
+	G4double halfLengthZ;
 
-    innerRadius = 0.0*mm;
-    outerRadius = 200.0*mm;
-    halfLengthZ = volumeLength/2.0;
+	innerRadius = 0.0*mm;
+	outerRadius = 200.0*mm;
+	halfLengthZ = volumeLength/2.0;
 
-    G4Tubs* canVolume = new G4Tubs("canVolume", innerRadius, outerRadius, halfLengthZ, startPhi, endPhi);
+	G4Tubs* canVolume = new G4Tubs("canVolume", innerRadius, outerRadius, halfLengthZ, startPhi, endPhi);
 
-    // Cut out a small cube out of the front of the detector to get a G4SubtractionSolid,
-    // needed for CutVolumeOnFourPoints methods
-    G4double cutHalfLengthX = 5.0*mm;
-    G4double cutHalfLengthY = 5.0*mm;
-    G4double cutHalfLengthZ = 5.0*mm;
+	// Cut out a small cube out of the front of the detector to get a G4SubtractionSolid,
+	// needed for CutVolumeOnFourPoints methods
+	G4double cutHalfLengthX = 5.0*mm;
+	G4double cutHalfLengthY = 5.0*mm;
+	G4double cutHalfLengthZ = 5.0*mm;
 
-    G4Box* cutPlate = new G4Box("cutPlate", cutHalfLengthX, cutHalfLengthY, cutHalfLengthZ);
+	G4Box* cutPlate = new G4Box("cutPlate", cutHalfLengthX, cutHalfLengthY, cutHalfLengthZ);
 
-    G4ThreeVector moveCut = G4ThreeVector(0,outerRadius,1.0*volumeLength/2.0);
-    G4RotationMatrix* rotateCut = new G4RotationMatrix;
+	G4ThreeVector moveCut = G4ThreeVector(0,outerRadius,1.0*volumeLength/2.0);
+	G4RotationMatrix* rotateCut = new G4RotationMatrix;
 
-    // snip snip
-    G4SubtractionSolid* canVolumeCut1 = new G4SubtractionSolid("canVolumeCut1", canVolume, cutPlate, rotateCut, moveCut);
+	// snip snip
+	G4SubtractionSolid* canVolumeCut1 = new G4SubtractionSolid("canVolumeCut1", canVolume, cutPlate, rotateCut, moveCut);
 
-    // first set of points
-    idx1 = 0;
-    idx2 = idx1+1;
+	// first set of points
+	idx1 = 0;
+	idx2 = idx1+1;
 
-    frontP1    = G4ThreeVector(detector[0+idx1][0],detector[0+idx1][1],detector[0+idx1][2]);
-    frontP2    = G4ThreeVector(detector[0+idx2][0],detector[0+idx2][1],detector[0+idx2][2]);
+	frontP1    = G4ThreeVector(detector[0+idx1][0],detector[0+idx1][1],detector[0+idx1][2]);
+	frontP2    = G4ThreeVector(detector[0+idx2][0],detector[0+idx2][1],detector[0+idx2][2]);
 
-    G4SubtractionSolid* canVolumeCut2 = CutVolumeOnFourPoints(idx1, insideVol, volumeLength, detectorPhi, canVolumeCut1, frontP1, frontP2);
+	G4SubtractionSolid* canVolumeCut2 = CutVolumeOnFourPoints(idx1, insideVol, volumeLength, detectorPhi, canVolumeCut1, frontP1, frontP2);
 
-    // next set of points
-    idx1 = 1;
-    idx2 = idx1+1;
+	// next set of points
+	idx1 = 1;
+	idx2 = idx1+1;
 
-    frontP1    = G4ThreeVector(detector[0+idx1][0],detector[0+idx1][1],detector[0+idx1][2]);
-    frontP2    = G4ThreeVector(detector[0+idx2][0],detector[0+idx2][1],detector[0+idx2][2]);
+	frontP1    = G4ThreeVector(detector[0+idx1][0],detector[0+idx1][1],detector[0+idx1][2]);
+	frontP2    = G4ThreeVector(detector[0+idx2][0],detector[0+idx2][1],detector[0+idx2][2]);
 
-    G4SubtractionSolid* canVolumeCut3 = CutVolumeOnFourPoints(idx1, insideVol, volumeLength, detectorPhi, canVolumeCut2, frontP1, frontP2);
+	G4SubtractionSolid* canVolumeCut3 = CutVolumeOnFourPoints(idx1, insideVol, volumeLength, detectorPhi, canVolumeCut2, frontP1, frontP2);
 
-    idx1 = 2;
-    idx2 = idx1+1;
+	idx1 = 2;
+	idx2 = idx1+1;
 
-    frontP1    = G4ThreeVector(detector[0+idx1][0],detector[0+idx1][1],detector[0+idx1][2]);
-    frontP2    = G4ThreeVector(detector[0+idx2][0],detector[0+idx2][1],detector[0+idx2][2]);
+	frontP1    = G4ThreeVector(detector[0+idx1][0],detector[0+idx1][1],detector[0+idx1][2]);
+	frontP2    = G4ThreeVector(detector[0+idx2][0],detector[0+idx2][1],detector[0+idx2][2]);
 
-    G4SubtractionSolid* canVolumeCut4 = CutVolumeOnFourPoints(idx1, insideVol, volumeLength, detectorPhi, canVolumeCut3, frontP1, frontP2);
+	G4SubtractionSolid* canVolumeCut4 = CutVolumeOnFourPoints(idx1, insideVol, volumeLength, detectorPhi, canVolumeCut3, frontP1, frontP2);
 
-    idx1 = 3;
-    idx2 = idx1+1;
+	idx1 = 3;
+	idx2 = idx1+1;
 
-    frontP1    = G4ThreeVector(detector[0+idx1][0],detector[0+idx1][1],detector[0+idx1][2]);
-    frontP2    = G4ThreeVector(detector[0+idx2][0],detector[0+idx2][1],detector[0+idx2][2]);
+	frontP1    = G4ThreeVector(detector[0+idx1][0],detector[0+idx1][1],detector[0+idx1][2]);
+	frontP2    = G4ThreeVector(detector[0+idx2][0],detector[0+idx2][1],detector[0+idx2][2]);
 
-    G4SubtractionSolid* canVolumeCut5 = CutVolumeOnFourPoints(idx1, insideVol, volumeLength, detectorPhi, canVolumeCut4, frontP1, frontP2);
+	G4SubtractionSolid* canVolumeCut5 = CutVolumeOnFourPoints(idx1, insideVol, volumeLength, detectorPhi, canVolumeCut4, frontP1, frontP2);
 
-    idx1 = 4;
-    idx2 = idx1+1;
+	idx1 = 4;
+	idx2 = idx1+1;
 
-    frontP1    = G4ThreeVector(detector[0+idx1][0],detector[0+idx1][1],detector[0+idx1][2]);
-    frontP2    = G4ThreeVector(detector[0+idx2][0],detector[0+idx2][1],detector[0+idx2][2]);
+	frontP1    = G4ThreeVector(detector[0+idx1][0],detector[0+idx1][1],detector[0+idx1][2]);
+	frontP2    = G4ThreeVector(detector[0+idx2][0],detector[0+idx2][1],detector[0+idx2][2]);
 
-    G4SubtractionSolid* canVolumeCut6 = CutVolumeOnFourPoints(idx1, insideVol, volumeLength, detectorPhi, canVolumeCut5, frontP1, frontP2);
+	G4SubtractionSolid* canVolumeCut6 = CutVolumeOnFourPoints(idx1, insideVol, volumeLength, detectorPhi, canVolumeCut5, frontP1, frontP2);
 
-    idx1 = 5;
-    idx2 = 0;
+	idx1 = 5;
+	idx2 = 0;
 
-    frontP1    = G4ThreeVector(detector[0+idx1][0],detector[0+idx1][1],detector[0+idx1][2]);
-    frontP2    = G4ThreeVector(detector[0+idx2][0],detector[0+idx2][1],detector[0+idx2][2]);
+	frontP1    = G4ThreeVector(detector[0+idx1][0],detector[0+idx1][1],detector[0+idx1][2]);
+	frontP2    = G4ThreeVector(detector[0+idx2][0],detector[0+idx2][1],detector[0+idx2][2]);
 
-    G4SubtractionSolid* canVolumeCut7 = CutVolumeOnFourPoints(idx1, insideVol, volumeLength, detectorPhi, canVolumeCut6, frontP1, frontP2);
+	G4SubtractionSolid* canVolumeCut7 = CutVolumeOnFourPoints(idx1, insideVol, volumeLength, detectorPhi, canVolumeCut6, frontP1, frontP2);
 
-    return canVolumeCut7;
+	return canVolumeCut7;
 }
 
 // This method does the actual cutting of the surface.
 G4SubtractionSolid* DetectionSystemDescant::CutVolumeOnFourPoints(G4int idx, G4bool insideVol, G4double volumeLength, G4double detectorPhi[6], G4SubtractionSolid* volume, G4ThreeVector frontP1, G4ThreeVector frontP2)
 {
-    G4double maxZ = 500.0*mm;
-    G4double theta = 0;
-    G4double phi = 0;
-    G4double moveZCut = 0;
+	G4double maxZ = 500.0*mm;
+	G4double theta = 0;
+	G4double phi = 0;
+	G4double moveZCut = 0;
 
-    // make the cuts excessively large.
-    G4double cutHalfLengthX = 1.0*maxZ;
-    G4double cutHalfLengthY = 1.0*maxZ;
-    G4double cutHalfLengthZ = 2.0*maxZ;
+	// make the cuts excessively large.
+	G4double cutHalfLengthX = 1.0*maxZ;
+	G4double cutHalfLengthY = 1.0*maxZ;
+	G4double cutHalfLengthZ = 2.0*maxZ;
 
-    G4ThreeVector moveCut;
-    G4RotationMatrix* rotateCut;
+	G4ThreeVector moveCut;
+	G4RotationMatrix* rotateCut;
 
-    // find the equation of the line defined by the two front face points.
-    // then using a circle of radius r, solve for the minimum r to get the minimum theta angle to that plane!
-    G4double slope  = (frontP2.y() - frontP1.y())/(frontP2.x() - frontP1.x());
-    G4double intcp  = (frontP1.y()) - (slope*frontP1.x());
-    G4double minx   = (-1.0*slope*intcp)/(1+slope*slope);
-    G4double miny   = slope*minx + intcp;
+	// find the equation of the line defined by the two front face points.
+	// then using a circle of radius r, solve for the minimum r to get the minimum theta angle to that plane!
+	G4double slope  = (frontP2.y() - frontP1.y())/(frontP2.x() - frontP1.x());
+	G4double intcp  = (frontP1.y()) - (slope*frontP1.x());
+	G4double minx   = (-1.0*slope*intcp)/(1+slope*slope);
+	G4double miny   = slope*minx + intcp;
 
-    // make vectors, and get angle between vectors
-    G4ThreeVector newV1 = G4ThreeVector(minx,miny,500.0*mm);
-    G4ThreeVector newV2 = G4ThreeVector(0.0*mm,0.0*mm,500.0*mm);
+	// make vectors, and get angle between vectors
+	G4ThreeVector newV1 = G4ThreeVector(minx,miny,500.0*mm);
+	G4ThreeVector newV2 = G4ThreeVector(0.0*mm,0.0*mm,500.0*mm);
 
-    theta   = acos((newV1.dot(newV2))/(newV1.mag() * newV2.mag()));
-    phi     = detectorPhi[idx];
+	theta   = acos((newV1.dot(newV2))/(newV1.mag() * newV2.mag()));
+	phi     = detectorPhi[idx];
 
-    if(insideVol)
-        moveZCut = 1.0*(volumeLength/2.0 + maxZ - (((fCanThickness)/(sin(theta))) - fCanThickness));
-    else
-        moveZCut = 1.0*(volumeLength/2.0 + maxZ);
+	if(insideVol)
+		moveZCut = 1.0*(volumeLength/2.0 + maxZ - (((fCanThickness)/(sin(theta))) - fCanThickness));
+	else
+		moveZCut = 1.0*(volumeLength/2.0 + maxZ);
 
-    if(volumeLength == fLeadShieldThickness) // this is the lead shield, push it a bit closer so the tapers match up
-        moveZCut = moveZCut - volumeLength;
+	if(volumeLength == fLeadShieldThickness) // this is the lead shield, push it a bit closer so the tapers match up
+		moveZCut = moveZCut - volumeLength;
 
-    G4Box* cutPlate = new G4Box("cutPlate", cutHalfLengthX, cutHalfLengthY, cutHalfLengthZ);
+	G4Box* cutPlate = new G4Box("cutPlate", cutHalfLengthX, cutHalfLengthY, cutHalfLengthZ);
 
-    moveCut = G4ThreeVector(cutHalfLengthX/cos(theta),0.0*mm,moveZCut);
-    moveCut.rotateZ(1.0*phi);
+	moveCut = G4ThreeVector(cutHalfLengthX/cos(theta),0.0*mm,moveZCut);
+	moveCut.rotateZ(1.0*phi);
 
-    // rotate our cutting block to the "chopping" angle
-    rotateCut = new G4RotationMatrix;
-    rotateCut->rotateZ(-1.0*phi);
-    rotateCut->rotateY(1.0*theta);
+	// rotate our cutting block to the "chopping" angle
+	rotateCut = new G4RotationMatrix;
+	rotateCut->rotateZ(-1.0*phi);
+	rotateCut->rotateY(1.0*theta);
 
-    // snip snip
-    G4SubtractionSolid* canVolumeCut = new G4SubtractionSolid("canVolumeCut", volume, cutPlate, rotateCut, moveCut);
+	// snip snip
+	G4SubtractionSolid* canVolumeCut = new G4SubtractionSolid("canVolumeCut", volume, cutPlate, rotateCut, moveCut);
 
-    return canVolumeCut;
+	return canVolumeCut;
 }
 
 //Calculate a direction vector from spherical theta & phi components
 G4ThreeVector DetectionSystemDescant::GetDirectionXYZ(G4double theta, G4double phi)
 {
-    G4double x,y,z;
-    x = sin(theta) * cos(phi);
-    y = sin(theta) * sin(phi);
-    z = cos(theta);
+	G4double x,y,z;
+	x = sin(theta) * cos(phi);
+	y = sin(theta) * sin(phi);
+	z = cos(theta);
 
-    G4ThreeVector direction = G4ThreeVector(x,y,z);
+	G4ThreeVector direction = G4ThreeVector(x,y,z);
 
-    return direction;
+	return direction;
 }
 
 G4ThreeVector DetectionSystemDescant::SolveLineEquationX(G4ThreeVector p1, G4ThreeVector p2, G4double x){
-    G4ThreeVector v, result;
-    v = p2 - p1;
-    G4double t = (x - p1.x())/(v.x());
-    result = G4ThreeVector(x,p1.y()+v.y()*t,p1.z()+v.z()*t);
-    return result;
+	G4ThreeVector v, result;
+	v = p2 - p1;
+	G4double t = (x - p1.x())/(v.x());
+	result = G4ThreeVector(x,p1.y()+v.y()*t,p1.z()+v.z()*t);
+	return result;
 }
 
 G4ThreeVector DetectionSystemDescant::SolveLineEquationY(G4ThreeVector p1, G4ThreeVector p2, G4double y){
-    G4ThreeVector v, result;
-    v = p2 - p1;
-    G4double t = (y - p1.y())/(v.y());
-    result = G4ThreeVector(p1.x()+v.x()*t,y,p1.z()+v.z()*t);
-    return result;
+	G4ThreeVector v, result;
+	v = p2 - p1;
+	G4double t = (y - p1.y())/(v.y());
+	result = G4ThreeVector(p1.x()+v.x()*t,y,p1.z()+v.z()*t);
+	return result;
 }
 
 G4ThreeVector DetectionSystemDescant::SolveLineEquationZ(G4ThreeVector p1, G4ThreeVector p2, G4double z){
-    G4ThreeVector v, result;
-    v = p2 - p1;
-    G4double t = (z - p1.z())/(v.z());
-    result = G4ThreeVector(p1.x()+v.x()*t,p1.y()+v.y()*t,z);
-    return result;
+	G4ThreeVector v, result;
+	v = p2 - p1;
+	G4double t = (z - p1.z())/(v.z());
+	result = G4ThreeVector(p1.x()+v.x()*t,p1.y()+v.y()*t,z);
+	return result;
 }

--- a/src/DetectionSystemGrid.cc
+++ b/src/DetectionSystemGrid.cc
@@ -26,138 +26,138 @@
 
 
 DetectionSystemGrid::DetectionSystemGrid(G4double xLengthIn, G4double yLengthIn, G4double zLengthIn, G4double cubeSizeIn, G4String gridMat, G4ThreeVector gridColour, G4ThreeVector posOffset) :
-    // LogicalVolumes
-    fGridcellLog(0)
+	// LogicalVolumes
+	fGridcellLog(0)
 { 
-    fXLength = xLengthIn;
-    fYLength = yLengthIn;
-    fZLength = zLengthIn;
+	fXLength = xLengthIn;
+	fYLength = yLengthIn;
+	fZLength = zLengthIn;
 
-    fXPosOffset = posOffset.x();
-    fYPosOffset = posOffset.y();
-    fZPosOffset = posOffset.z();
+	fXPosOffset = posOffset.x();
+	fYPosOffset = posOffset.y();
+	fZPosOffset = posOffset.z();
 
-    fCubeSize = cubeSizeIn;
+	fCubeSize = cubeSizeIn;
 
-    fCellsXRow = (G4int)(fXLength/cubeSizeIn);
-    fCellsYRow = (G4int)(fYLength/cubeSizeIn);
-    fCellsZRow = (G4int)(fZLength/cubeSizeIn);
+	fCellsXRow = (G4int)(fXLength/cubeSizeIn);
+	fCellsYRow = (G4int)(fYLength/cubeSizeIn);
+	fCellsZRow = (G4int)(fZLength/cubeSizeIn);
 
-    fNumberOfCells = fCellsXRow*fCellsYRow*fCellsZRow;
-    fCellsPerRow   = 10;
-    fCellWidth      = fCubeSize;
+	fNumberOfCells = fCellsXRow*fCellsYRow*fCellsZRow;
+	fCellsPerRow   = 10;
+	fCellWidth      = fCubeSize;
 
-    fCellMaterial = gridMat;
+	fCellMaterial = gridMat;
 
-    fCellColour = gridColour;
+	fCellColour = gridColour;
 
-    //fEmFieldSetup = theFieldSetup;
+	//fEmFieldSetup = theFieldSetup;
 
-    G4cout << "xLength = " << fXLength/cm << G4endl;
-    G4cout << "yLength = " << fYLength/cm << G4endl;
-    G4cout << "zLength = " << fZLength/cm << G4endl;
+	G4cout<<"xLength = "<<fXLength/cm<<G4endl;
+	G4cout<<"yLength = "<<fYLength/cm<<G4endl;
+	G4cout<<"zLength = "<<fZLength/cm<<G4endl;
 
-    G4cout << "cellsXRow = " << fCellsXRow << G4endl;
+	G4cout<<"cellsXRow = "<<fCellsXRow<<G4endl;
 }
 
 DetectionSystemGrid::~DetectionSystemGrid() {
-    // LogicalVolumes
-    delete fGridcellLog;
+	// LogicalVolumes
+	delete fGridcellLog;
 }
 
 
 G4int DetectionSystemGrid::Build() { 
 
-    // Build assembly volume
-    fAssembly = new G4AssemblyVolume(); 
+	// Build assembly volume
+	fAssembly = new G4AssemblyVolume(); 
 
-    G4cout << "BuildCellVolume" << G4endl;
-    BuildCellVolume();
+	G4cout<<"BuildCellVolume"<<G4endl;
+	BuildCellVolume();
 
-    return 1;
+	return 1;
 }
 
 G4int DetectionSystemGrid::PlaceDetector(G4LogicalVolume* expHallLog) {
-    G4double startX = (-1.0*fXLength/2.0);
-    G4double startY = (-1.0*fYLength/2.0);
-    G4double startZ = (-1.0*fZLength/2.0);
-    G4double posX;
-    G4double posY;
-    G4double posZ;
+	G4double startX = (-1.0*fXLength/2.0);
+	G4double startY = (-1.0*fYLength/2.0);
+	G4double startZ = (-1.0*fZLength/2.0);
+	G4double posX;
+	G4double posY;
+	G4double posZ;
 
-    G4int cellNumber = 0;
+	G4int cellNumber = 0;
 
-    G4ThreeVector position = G4ThreeVector(0.0*mm,0.0*mm,0.0*mm);
-    G4RotationMatrix* rotate  = new G4RotationMatrix;
+	G4ThreeVector position = G4ThreeVector(0.0*mm,0.0*mm,0.0*mm);
+	G4RotationMatrix* rotate  = new G4RotationMatrix;
 
-    for(G4int rowX = 0; rowX < fCellsXRow; rowX++) {
-        posX = startX+(fCellWidth*rowX)+(fCellWidth/2.0);
-        position.setX(posX + fXPosOffset);
+	for(G4int rowX = 0; rowX < fCellsXRow; rowX++) {
+		posX = startX+(fCellWidth*rowX)+(fCellWidth/2.0);
+		position.setX(posX + fXPosOffset);
 
-        for(G4int rowY = 0; rowY < fCellsYRow; rowY++) {
-            posY = startY+(fCellWidth*rowY)+(fCellWidth/2.0);
-            position.setY(posY + fYPosOffset);
+		for(G4int rowY = 0; rowY < fCellsYRow; rowY++) {
+			posY = startY+(fCellWidth*rowY)+(fCellWidth/2.0);
+			position.setY(posY + fYPosOffset);
 
-            for(G4int rowZ = 0; rowZ < fCellsZRow; rowZ++) {
-                posZ = startZ+(fCellWidth*rowZ)+(fCellWidth/2.0);
-                position.setZ(posZ + fZPosOffset);
+			for(G4int rowZ = 0; rowZ < fCellsZRow; rowZ++) {
+				posZ = startZ+(fCellWidth*rowZ)+(fCellWidth/2.0);
+				position.setZ(posZ + fZPosOffset);
 
-                cellNumber++;
-                //G4cout << "--------------------------- Grid Detector Number = " << cellNumber << G4endl;
+				cellNumber++;
+				//G4cout<<"--------------------------- Grid Detector Number = "<<cellNumber<<G4endl;
 
-                fAssembly->MakeImprint(expHallLog, position, rotate, cellNumber);
-            }
-        }
-    }
+				fAssembly->MakeImprint(expHallLog, position, rotate, cellNumber);
+			}
+		}
+	}
 
-    return 1;
+	return 1;
 }
 
 G4int DetectionSystemGrid::BuildCellVolume() {
-    G4Material* material = G4Material::GetMaterial(fCellMaterial);
-    if( !material ) {
-        G4cout << " ----> Material " << fCellMaterial << " not found, cannot build the detector shell! " << G4endl;
-        return 0;
-    }
+	G4Material* material = G4Material::GetMaterial(fCellMaterial);
+	if(!material) {
+		G4cout<<" ----> Material "<<fCellMaterial<<" not found, cannot build the detector shell! "<<G4endl;
+		return 0;
+	}
 
-    // Set visualization attributes
-    G4VisAttributes* visAtt = new G4VisAttributes(G4Colour(fCellColour));
-    visAtt->SetVisibility(true);
-
-
-    G4Box* gridcell = BuildCell();
-
-    // Define rotation and movement objects
-    G4ThreeVector direction 	= G4ThreeVector(0,0,0);
-    G4double zPosition		= 0.0*mm;
-    G4ThreeVector move 		= zPosition * direction;
-    G4RotationMatrix* rotate  = new G4RotationMatrix;
-
-    //logical volume
-    if( fGridcellLog == NULL ) {
-        fGridcellLog = new G4LogicalVolume(gridcell, material, "gridcellLog", 0, 0, 0);
-        fGridcellLog->SetVisAttributes(visAtt);
-
-        //// Set local field manager and local field in radiator and its daughters:
-        //G4bool allLocal = true ;
-        //gridcellLog->SetFieldManager( fEmFieldSetup->GetLocalFieldManager(), allLocal ) ;
-    }
+	// Set visualization attributes
+	G4VisAttributes* visAtt = new G4VisAttributes(G4Colour(fCellColour));
+	visAtt->SetVisibility(true);
 
 
-    fAssembly->AddPlacedVolume(fGridcellLog, move, rotate);
+	G4Box* gridcell = BuildCell();
 
-    return 1;
+	// Define rotation and movement objects
+	G4ThreeVector direction 	= G4ThreeVector(0,0,0);
+	G4double zPosition		= 0.0*mm;
+	G4ThreeVector move 		= zPosition * direction;
+	G4RotationMatrix* rotate  = new G4RotationMatrix;
+
+	//logical volume
+	if(fGridcellLog == nullptr) {
+		fGridcellLog = new G4LogicalVolume(gridcell, material, "gridcellLog", 0, 0, 0);
+		fGridcellLog->SetVisAttributes(visAtt);
+
+		//// Set local field manager and local field in radiator and its daughters:
+		//G4bool allLocal = true ;
+		//gridcellLog->SetFieldManager(fEmFieldSetup->GetLocalFieldManager(), allLocal) ;
+	}
+
+
+	fAssembly->AddPlacedVolume(fGridcellLog, move, rotate);
+
+	return 1;
 }
 
 ///////////////////////////////////////////////////////////////////////
 // Methods used to build shapes
 ///////////////////////////////////////////////////////////////////////
 G4Box* DetectionSystemGrid::BuildCell() {
-    G4double halfLengthX = fCellWidth/2.0;
-    G4double halfLengthY = fCellWidth/2.0;
-    G4double halfLengthZ = fCellWidth/2.0;
+	G4double halfLengthX = fCellWidth/2.0;
+	G4double halfLengthY = fCellWidth/2.0;
+	G4double halfLengthZ = fCellWidth/2.0;
 
-    G4Box* cell = new G4Box("cell", halfLengthX, halfLengthY, halfLengthZ);
+	G4Box* cell = new G4Box("cell", halfLengthX, halfLengthY, halfLengthZ);
 
-    return cell;
+	return cell;
 }//end ::BuildCell

--- a/src/DetectionSystemGriffin.cc
+++ b/src/DetectionSystemGriffin.cc
@@ -45,73 +45,73 @@
 ///////////////////////////////////////////////////////////////////////
 
 DetectionSystemGriffin::~DetectionSystemGriffin() {
-    // LogicalVolumes in ConstructNewHeavyMet
-    delete fHevimetLog;
+	// LogicalVolumes in ConstructNewHeavyMet
+	delete fHevimetLog;
 
-    // LogicalVolumes in ConstructNewSuppressorCasing
-    delete fLeftSuppressorExtensionLog;
-    delete fRightSuppressorExtensionLog;
-    delete fLeftSuppressorLog;
-    delete fRightSuppressorLog;
-    delete fBackQuarterSuppressorLog;
+	// LogicalVolumes in ConstructNewSuppressorCasing
+	delete fLeftSuppressorExtensionLog;
+	delete fRightSuppressorExtensionLog;
+	delete fLeftSuppressorLog;
+	delete fRightSuppressorLog;
+	delete fBackQuarterSuppressorLog;
 
-    delete fBackQuarterSuppressorShellLog;
-    delete fRightSuppressorShellLog;
-    delete fLeftSuppressorShellLog;
-    delete fRightSuppressorShellExtensionLog;
-    delete fLeftSuppressorShellExtensionLog;
-    // LogicalVolumes in ConstructBGOCasing
+	delete fBackQuarterSuppressorShellLog;
+	delete fRightSuppressorShellLog;
+	delete fLeftSuppressorShellLog;
+	delete fRightSuppressorShellExtensionLog;
+	delete fLeftSuppressorShellExtensionLog;
+	// LogicalVolumes in ConstructBGOCasing
 
-    delete fBGOCasingLog;
-    delete fBackBGOLog;
+	delete fBGOCasingLog;
+	delete fBackBGOLog;
 
-    // LogicalVolumes in ConstructColdFinger
-    delete fCoolingSideBlockLog;
-    delete fStructureMatColdFingerLog;
-    delete fCoolingBarLog;
-    delete fFetAirHoleLog;
-    delete fTrianglePostLog;
-    delete fExtraColdBlockLog;
-    delete fFingerLog;
-    delete fEndPlateLog;
+	// LogicalVolumes in ConstructColdFinger
+	delete fCoolingSideBlockLog;
+	delete fStructureMatColdFingerLog;
+	delete fCoolingBarLog;
+	delete fFetAirHoleLog;
+	delete fTrianglePostLog;
+	delete fExtraColdBlockLog;
+	delete fFingerLog;
+	delete fEndPlateLog;
 
-    // LogicalVolumes in ConstructComplexDetectorBlock
-    delete fGermaniumHoleLog;
-    delete fGermaniumBlock1Log;
-    delete fInnerDeadLayerLog;
-    delete fInterCrystalElectrodeMatBackLog;
-    delete fInterCrystalElectrodeMatFrontLog;
+	// LogicalVolumes in ConstructComplexDetectorBlock
+	delete fGermaniumHoleLog;
+	delete fGermaniumBlock1Log;
+	delete fInnerDeadLayerLog;
+	delete fInterCrystalElectrodeMatBackLog;
+	delete fInterCrystalElectrodeMatFrontLog;
 
-    // LogicalVolumes in ConstructBasicDetectorBlock
-    delete fGermaniumBlockLog;
+	// LogicalVolumes in ConstructBasicDetectorBlock
+	delete fGermaniumBlockLog;
 
-    // LogicalVolumes in ConstructDetector
-    delete fTankLog;
-    delete fTankLid1Log;
-    delete fTankLid2Log;
-    delete fFingerShellLog;
-    delete fRearPlateLog;
-    delete fBottomSidePanelLog;
-    delete fTopSidePanelLog;
-    delete fLeftSidePanelLog;
-    delete fRightSidePanelLog;
-    delete fLowerLeftTubeLog;
-    delete fUpperLeftTubeLog;
-    delete fLowerRightTubeLog;
-    delete fUpperRightTubeLog;
-    delete fLowerLeftConeLog;
-    delete fUpperLeftConeLog;
-    delete fLowerRightConeLog;
-    delete fUpperRightConeLog;
-    delete fBottomWedgeLog;
-    delete fTopWedgeLog;
-    delete fLeftWedgeLog;
-    delete fRightWedgeLog;
-    delete fBottomBentPieceLog;
-    delete fTopBentPieceLog;
-    delete fLeftBentPieceLog;
-    delete fRightBentPieceLog;
-    delete fFrontFaceLog;
+	// LogicalVolumes in ConstructDetector
+	delete fTankLog;
+	delete fTankLid1Log;
+	delete fTankLid2Log;
+	delete fFingerShellLog;
+	delete fRearPlateLog;
+	delete fBottomSidePanelLog;
+	delete fTopSidePanelLog;
+	delete fLeftSidePanelLog;
+	delete fRightSidePanelLog;
+	delete fLowerLeftTubeLog;
+	delete fUpperLeftTubeLog;
+	delete fLowerRightTubeLog;
+	delete fUpperRightTubeLog;
+	delete fLowerLeftConeLog;
+	delete fUpperLeftConeLog;
+	delete fLowerRightConeLog;
+	delete fUpperRightConeLog;
+	delete fBottomWedgeLog;
+	delete fTopWedgeLog;
+	delete fLeftWedgeLog;
+	delete fRightWedgeLog;
+	delete fBottomBentPieceLog;
+	delete fTopBentPieceLog;
+	delete fLeftBentPieceLog;
+	delete fRightBentPieceLog;
+	delete fFrontFaceLog;
 }// end ::~DetectionSystemGriffin
 
 ///////////////////////////////////////////////////////////////////////
@@ -120,368 +120,368 @@ DetectionSystemGriffin::~DetectionSystemGriffin() {
 ///////////////////////////////////////////////////////////////////////
 void DetectionSystemGriffin::Build() { 
 
-    fSurfCheck = true;
+	fSurfCheck = true;
 
-    BuildOneDetector();
+	BuildOneDetector();
 
 }//end ::Build
 
 G4double DetectionSystemGriffin::TransX(G4double x, G4double y, G4double z, G4double theta, G4double phi) {
-    return (x*cos(theta)+z*sin(theta))*cos(phi)-y*sin(phi);
+	return (x*cos(theta)+z*sin(theta))*cos(phi)-y*sin(phi);
 }
 
 G4double DetectionSystemGriffin::TransY(G4double x, G4double y, G4double z, G4double theta, G4double phi) {
-    return (x*cos(theta)+z*sin(theta))*sin(phi)+y*cos(phi);
+	return (x*cos(theta)+z*sin(theta))*sin(phi)+y*cos(phi);
 }
 
 G4double DetectionSystemGriffin::TransZ(G4double x, G4double z, G4double theta) {
-    return -x*sin(theta)+z*cos(theta);
+	return -x*sin(theta)+z*cos(theta);
 }
 
 G4int DetectionSystemGriffin::PlaceEverythingButCrystals(G4LogicalVolume* expHallLog, G4int detectorNumber, G4int positionNumber, G4bool posTigress) {
-  if(expHallLog == NULL) {
-	 std::cerr<<__PRETTY_FUNCTION__<<": expHallLog == NULL!"<<std::endl;
-	 exit(1);
-  }
+	if(expHallLog == nullptr) {
+		std::cerr<<__PRETTY_FUNCTION__<<": expHallLog == nullptr!"<<std::endl;
+		exit(1);
+	}
 
-    G4double theta  = fCoords[positionNumber][0]*deg;
-    G4double phi    = fCoords[positionNumber][1]*deg;
-    G4double alpha  = fCoords[positionNumber][2]*deg; // yaw
-    G4double beta   = fCoords[positionNumber][3]*deg; // pitch
-    G4double gamma  = fCoords[positionNumber][4]*deg; // roll
+	G4double theta  = fCoords[positionNumber][0]*deg;
+	G4double phi    = fCoords[positionNumber][1]*deg;
+	G4double alpha  = fCoords[positionNumber][2]*deg; // yaw
+	G4double beta   = fCoords[positionNumber][3]*deg; // pitch
+	G4double gamma  = fCoords[positionNumber][4]*deg; // roll
 
-    //In GRIFFIN upstream is now downstream relative to TIGRESS. However, we want to maintain the same numbering scheme as TIGRESS. Net result is that the lampshade angles change by 45 degrees.
-    if(posTigress && (positionNumber < 4 || positionNumber > 11)) {
-        phi       = fCoords[positionNumber][1]*deg - 45.0*deg;
-        gamma     = fCoords[positionNumber][4]*deg - 45.0*deg;
-    }
+	//In GRIFFIN upstream is now downstream relative to TIGRESS. However, we want to maintain the same numbering scheme as TIGRESS. Net result is that the lampshade angles change by 45 degrees.
+	if(posTigress && (positionNumber < 4 || positionNumber > 11)) {
+		phi       = fCoords[positionNumber][1]*deg - 45.0*deg;
+		gamma     = fCoords[positionNumber][4]*deg - 45.0*deg;
+	}
 
-    G4double x;
-    G4double y;
-    G4double z;
+	G4double x;
+	G4double y;
+	G4double z;
 
-    G4double x0, y0, z0;
+	G4double x0, y0, z0;
 
-    G4int i;
+	G4int i;
 
-    G4RotationMatrix* rotate = new G4RotationMatrix;    // rotation matrix corresponding to direction vector
-    rotate->rotateX(M_PI/2.0);
-    rotate->rotateX(alpha);
-    rotate->rotateY(beta);
-    rotate->rotateZ(gamma);
+	G4RotationMatrix* rotate = new G4RotationMatrix;    // rotation matrix corresponding to direction vector
+	rotate->rotateX(M_PI/2.0);
+	rotate->rotateX(alpha);
+	rotate->rotateY(beta);
+	rotate->rotateZ(gamma);
 
-    // positioning
-    G4double distFromOrigin = fAirBoxBackLength/2.0 +fAirBoxFrontLength + fNewRhombiRadius ;
-    G4double distFromOriginDet = fAirBoxBackLengthDet/2.0 +fAirBoxFrontLengthDet + fNewRhombiRadiusDet ;
+	// positioning
+	G4double distFromOrigin = fAirBoxBackLength/2.0 +fAirBoxFrontLength + fNewRhombiRadius ;
+	G4double distFromOriginDet = fAirBoxBackLengthDet/2.0 +fAirBoxFrontLengthDet + fNewRhombiRadiusDet ;
 
-    x = 0;
-    y = 0;
-    z = distFromOriginDet;
+	x = 0;
+	y = 0;
+	z = distFromOriginDet;
 
-    G4ThreeVector move(DetectionSystemGriffin::TransX(x,y,z,theta,phi), DetectionSystemGriffin::TransY(x,y,z,theta,phi), DetectionSystemGriffin::TransZ(x,z,theta));
-    fAssembly->MakeImprint(expHallLog, move, rotate, 0, fSurfCheck);
-    fBackAndSideSuppressorShellAssembly->MakeImprint(expHallLog, move, rotate, 0, fSurfCheck);
+	G4ThreeVector move(DetectionSystemGriffin::TransX(x,y,z,theta,phi), DetectionSystemGriffin::TransY(x,y,z,theta,phi), DetectionSystemGriffin::TransZ(x,z,theta));
+	fAssembly->MakeImprint(expHallLog, move, rotate, 0, fSurfCheck);
+	fBackAndSideSuppressorShellAssembly->MakeImprint(expHallLog, move, rotate, 0, fSurfCheck);
 
-    z = distFromOrigin ; // This isolates the motion of the extension suppressors from the rest of the suppressors.
+	z = distFromOrigin ; // This isolates the motion of the extension suppressors from the rest of the suppressors.
 
-    move = G4ThreeVector(DetectionSystemGriffin::TransX(x,y,z,theta,phi), DetectionSystemGriffin::TransY(x,y,z,theta,phi), DetectionSystemGriffin::TransZ(x,z,theta));
+	move = G4ThreeVector(DetectionSystemGriffin::TransX(x,y,z,theta,phi), DetectionSystemGriffin::TransY(x,y,z,theta,phi), DetectionSystemGriffin::TransZ(x,z,theta));
 
-    fExtensionSuppressorShellAssembly->MakeImprint(expHallLog, move, rotate, 0, fSurfCheck);
-    fHevimetAssembly->MakeImprint(expHallLog, move, rotate, 0, fSurfCheck) ;
+	fExtensionSuppressorShellAssembly->MakeImprint(expHallLog, move, rotate, 0, fSurfCheck);
+	fHevimetAssembly->MakeImprint(expHallLog, move, rotate, 0, fSurfCheck) ;
 
-    fCopyNumber = fBackSuppressorCopyNumber + detectorNumber*4;
+	fCopyNumber = fBackSuppressorCopyNumber + detectorNumber*4;
 
-    // Back Suppressors
-    if(fIncludeBackSuppressors) {
-        x0 = (fDetectorTotalWidth/4.0);
-        y0 = (fDetectorTotalWidth/4.0);
-        z0 = (fBackBGOThickness - fCanFaceThickness)/2.0 + fSuppressorShellThickness
-                + fDetectorTotalLength + fBGOCanSeperation + fShift + fAppliedBackShift + distFromOriginDet;
+	// Back Suppressors
+	if(fIncludeBackSuppressors) {
+		x0 = (fDetectorTotalWidth/4.0);
+		y0 = (fDetectorTotalWidth/4.0);
+		z0 = (fBackBGOThickness - fCanFaceThickness)/2.0 + fSuppressorShellThickness
+			+ fDetectorTotalLength + fBGOCanSeperation + fShift + fAppliedBackShift + distFromOriginDet;
 
-        G4RotationMatrix* rotateBackQuarterSuppressor[4];
-        G4ThreeVector moveBackQuarterSuppressor[4];
+		G4RotationMatrix* rotateBackQuarterSuppressor[4];
+		G4ThreeVector moveBackQuarterSuppressor[4];
 
-        for(i=0; i<4; i++) {
-            rotateBackQuarterSuppressor[i] = new G4RotationMatrix;
-            rotateBackQuarterSuppressor[i]->rotateX(M_PI/2.0-M_PI/2.0*i);
-            rotateBackQuarterSuppressor[i]->rotateX(alpha);
-            rotateBackQuarterSuppressor[i]->rotateY(beta);
-            rotateBackQuarterSuppressor[i]->rotateZ(gamma);
+		for(i=0; i<4; i++) {
+			rotateBackQuarterSuppressor[i] = new G4RotationMatrix;
+			rotateBackQuarterSuppressor[i]->rotateX(M_PI/2.0-M_PI/2.0*i);
+			rotateBackQuarterSuppressor[i]->rotateX(alpha);
+			rotateBackQuarterSuppressor[i]->rotateY(beta);
+			rotateBackQuarterSuppressor[i]->rotateZ(gamma);
 
-            x = -x0*pow(-1, floor((i+1)/2));
-            y = -y0*pow(-1, floor((i+2)/2));
-            z = z0;
+			x = -x0*pow(-1, floor((i+1)/2));
+			y = -y0*pow(-1, floor((i+2)/2));
+			z = z0;
 
-            moveBackQuarterSuppressor[i] = G4ThreeVector(DetectionSystemGriffin::TransX(x,y,z,theta,phi),DetectionSystemGriffin::TransY(x,y,z,theta,phi),DetectionSystemGriffin::TransZ(x,z,theta));
+			moveBackQuarterSuppressor[i] = G4ThreeVector(DetectionSystemGriffin::TransX(x,y,z,theta,phi),DetectionSystemGriffin::TransY(x,y,z,theta,phi),DetectionSystemGriffin::TransZ(x,z,theta));
 
-            fSuppressorBackAssembly->MakeImprint(expHallLog, moveBackQuarterSuppressor[i], rotateBackQuarterSuppressor[i], fCopyNumber++, fSurfCheck);
-        }
-    }
+			fSuppressorBackAssembly->MakeImprint(expHallLog, moveBackQuarterSuppressor[i], rotateBackQuarterSuppressor[i], fCopyNumber++, fSurfCheck);
+		}
+	}
 
-    // Now Side Suppressors
-    /////////////////////////////////////////////////////////////////////
-    // Note : Left and Right are read from the BACK of the detector
-    // Suppressors 1 and 2 cover germanium 1
-    // Suppressors 3 and 4 cover germanium 2
-    // Suppressors 5 and 6 cover germanium 3
-    // Suppressors 7 and 8 cover germanium 4
-    /////////////////////////////////////////////////////////////////////
-    fCopyNumber = fRightSuppressorSideCopyNumber + detectorNumber*4;
-    fCopyNumberTwo = fLeftSuppressorSideCopyNumber + detectorNumber*4;
+	// Now Side Suppressors
+	/////////////////////////////////////////////////////////////////////
+	// Note : Left and Right are read from the BACK of the detector
+	// Suppressors 1 and 2 cover germanium 1
+	// Suppressors 3 and 4 cover germanium 2
+	// Suppressors 5 and 6 cover germanium 3
+	// Suppressors 7 and 8 cover germanium 4
+	/////////////////////////////////////////////////////////////////////
+	fCopyNumber = fRightSuppressorSideCopyNumber + detectorNumber*4;
+	fCopyNumberTwo = fLeftSuppressorSideCopyNumber + detectorNumber*4;
 
-    // Replacement for sideSuppressorLength
-    G4double shellSideSuppressorLength = fSideSuppressorLength + (fSuppressorShellThickness*2.0);
+	// Replacement for sideSuppressorLength
+	G4double shellSideSuppressorLength = fSideSuppressorLength + (fSuppressorShellThickness*2.0);
 
-    // Replacement for suppressorExtensionLength
-    G4double shellSuppressorExtensionLength = fSuppressorExtensionLength + (fSuppressorShellThickness*2.0)*(1.0/tan(fBentEndAngle)
-                                                      - tan(fBentEndAngle));
+	// Replacement for suppressorExtensionLength
+	G4double shellSuppressorExtensionLength = fSuppressorExtensionLength + (fSuppressorShellThickness*2.0)*(1.0/tan(fBentEndAngle)
+			- tan(fBentEndAngle));
 
-    // Replacement for suppressorExtensionAngle: must totally recalculate
-	 G4double shellSuppressorExtensionAngle = atan(((fSuppressorBackRadius
-                                                        + fBentEndLength +(fBGOCanSeperation
-                                                                                  + fSideBGOThickness + fSuppressorShellThickness*2.0)
-                                                        / tan(fBentEndAngle)
-                                                        - (fSuppressorExtensionThickness + fSuppressorShellThickness * 2.0)
-                                                        * sin(fBentEndAngle))
-                                                      * tan(fBentEndAngle) -(fSuppressorForwardRadius + fHevimetTipThickness)
-                                                      * sin(fBentEndAngle))/(shellSuppressorExtensionLength));
+	// Replacement for suppressorExtensionAngle: must totally recalculate
+	G4double shellSuppressorExtensionAngle = atan(((fSuppressorBackRadius
+					+ fBentEndLength +(fBGOCanSeperation
+						+ fSideBGOThickness + fSuppressorShellThickness*2.0)
+					/ tan(fBentEndAngle)
+					- (fSuppressorExtensionThickness + fSuppressorShellThickness * 2.0)
+					* sin(fBentEndAngle))
+				* tan(fBentEndAngle) -(fSuppressorForwardRadius + fHevimetTipThickness)
+				* sin(fBentEndAngle))/(shellSuppressorExtensionLength));
 
-    // these two parameters are for shifting the extensions back and out when in their BACK position
-    G4double extensionBackShift = fAirBoxFrontLength
-            - (fHevimetTipThickness + shellSuppressorExtensionLength
-               + (fSuppressorExtensionThickness + fSuppressorShellThickness*2.0)
-               * tan(fBentEndAngle))
-            * cos(fBentEndAngle);
+	// these two parameters are for shifting the extensions back and out when in their BACK position
+	G4double extensionBackShift = fAirBoxFrontLength
+		- (fHevimetTipThickness + shellSuppressorExtensionLength
+				+ (fSuppressorExtensionThickness + fSuppressorShellThickness*2.0)
+				* tan(fBentEndAngle))
+		* cos(fBentEndAngle);
 
-    G4double extensionRadialShift = extensionBackShift*tan(fBentEndAngle);
+	G4double extensionRadialShift = extensionBackShift*tan(fBentEndAngle);
 
-	 if(fIncludeSideSuppressors) {
-		 G4RotationMatrix* rotateSideSuppressor[8];
-		 G4ThreeVector moveInnerSuppressor[8];
+	if(fIncludeSideSuppressors) {
+		G4RotationMatrix* rotateSideSuppressor[8];
+		G4ThreeVector moveInnerSuppressor[8];
 
-		 x0 = fSideBGOThickness/2.0 + fSuppressorShellThickness + fDetectorTotalWidth/2.0 +fBGOCanSeperation;
-		 y0 = (fDetectorTotalWidth/2.0 +fBGOCanSeperation + fSideBGOThickness/2.0)/2.0;
-		 z0 = (shellSideSuppressorLength/2.0 -fCanFaceThickness/2.0 + fBentEndLength
-				 +(fBGOCanSeperation + fBGOChoppedTip)/tan(fBentEndAngle) + fShift
-				 + fAppliedBackShift - fSuppressorShellThickness/2.0 + distFromOriginDet);
+		x0 = fSideBGOThickness/2.0 + fSuppressorShellThickness + fDetectorTotalWidth/2.0 +fBGOCanSeperation;
+		y0 = (fDetectorTotalWidth/2.0 +fBGOCanSeperation + fSideBGOThickness/2.0)/2.0;
+		z0 = (shellSideSuppressorLength/2.0 -fCanFaceThickness/2.0 + fBentEndLength
+				+(fBGOCanSeperation + fBGOChoppedTip)/tan(fBentEndAngle) + fShift
+				+ fAppliedBackShift - fSuppressorShellThickness/2.0 + distFromOriginDet);
 
-		 for(i=0; i<4; i++) {
-			 rotateSideSuppressor[2*i] = new G4RotationMatrix;
-			 rotateSideSuppressor[2*i]->rotateZ(M_PI/2.0);
-			 rotateSideSuppressor[2*i]->rotateY(M_PI/2.0);
-			 rotateSideSuppressor[2*i]->rotateX(M_PI/2.0-M_PI/2.0*i);
-			 rotateSideSuppressor[2*i]->rotateX(alpha);
-			 rotateSideSuppressor[2*i]->rotateY(beta);
-			 rotateSideSuppressor[2*i]->rotateZ(gamma);
+		for(i=0; i<4; i++) {
+			rotateSideSuppressor[2*i] = new G4RotationMatrix;
+			rotateSideSuppressor[2*i]->rotateZ(M_PI/2.0);
+			rotateSideSuppressor[2*i]->rotateY(M_PI/2.0);
+			rotateSideSuppressor[2*i]->rotateX(M_PI/2.0-M_PI/2.0*i);
+			rotateSideSuppressor[2*i]->rotateX(alpha);
+			rotateSideSuppressor[2*i]->rotateY(beta);
+			rotateSideSuppressor[2*i]->rotateZ(gamma);
 
-			 x = x0*cos((i-1)*M_PI/2.0) + y0*sin((i-1)*M_PI/2);
-			 y = -x0*sin((i-1)*M_PI/2.0) + y0*cos((i-1)*M_PI/2);
-			 z = z0;
+			x = x0*cos((i-1)*M_PI/2.0) + y0*sin((i-1)*M_PI/2);
+			y = -x0*sin((i-1)*M_PI/2.0) + y0*cos((i-1)*M_PI/2);
+			z = z0;
 
-			 moveInnerSuppressor[i*2] = G4ThreeVector(DetectionSystemGriffin::TransX(x,y,z,theta,phi),DetectionSystemGriffin::TransY(x,y,z,theta,phi),DetectionSystemGriffin::TransZ(x,z,theta));
+			moveInnerSuppressor[i*2] = G4ThreeVector(DetectionSystemGriffin::TransX(x,y,z,theta,phi),DetectionSystemGriffin::TransY(x,y,z,theta,phi),DetectionSystemGriffin::TransZ(x,z,theta));
 
-			 fRightSuppressorCasingAssembly->MakeImprint(expHallLog, moveInnerSuppressor[2*i], rotateSideSuppressor[2*i], fCopyNumber++, fSurfCheck);
+			fRightSuppressorCasingAssembly->MakeImprint(expHallLog, moveInnerSuppressor[2*i], rotateSideSuppressor[2*i], fCopyNumber++, fSurfCheck);
 
-			 rotateSideSuppressor[2*i+1] = new G4RotationMatrix;
-			 rotateSideSuppressor[2*i+1]->rotateY(-M_PI/2.0);
-			 rotateSideSuppressor[2*i+1]->rotateX(-M_PI/2.0*(i+2));
-			 rotateSideSuppressor[2*i+1]->rotateX(alpha);
-			 rotateSideSuppressor[2*i+1]->rotateY(beta);
-			 rotateSideSuppressor[2*i+1]->rotateZ(gamma);
+			rotateSideSuppressor[2*i+1] = new G4RotationMatrix;
+			rotateSideSuppressor[2*i+1]->rotateY(-M_PI/2.0);
+			rotateSideSuppressor[2*i+1]->rotateX(-M_PI/2.0*(i+2));
+			rotateSideSuppressor[2*i+1]->rotateX(alpha);
+			rotateSideSuppressor[2*i+1]->rotateY(beta);
+			rotateSideSuppressor[2*i+1]->rotateZ(gamma);
 
-			 x = x0*sin(i*M_PI/2.0) + y0*cos(i*M_PI/2);
-			 y = x0*cos(i*M_PI/2.0) - y0*sin(i*M_PI/2);
-			 z = z0;
+			x = x0*sin(i*M_PI/2.0) + y0*cos(i*M_PI/2);
+			y = x0*cos(i*M_PI/2.0) - y0*sin(i*M_PI/2);
+			z = z0;
 
-			 moveInnerSuppressor[i*2+1] = G4ThreeVector(DetectionSystemGriffin::TransX(x,y,z,theta,phi),DetectionSystemGriffin::TransY(x,y,z,theta,phi),DetectionSystemGriffin::TransZ(x,z,theta));
+			moveInnerSuppressor[i*2+1] = G4ThreeVector(DetectionSystemGriffin::TransX(x,y,z,theta,phi),DetectionSystemGriffin::TransY(x,y,z,theta,phi),DetectionSystemGriffin::TransZ(x,z,theta));
 
-			 fLeftSuppressorCasingAssembly->MakeImprint(expHallLog, moveInnerSuppressor[2*i+1], rotateSideSuppressor[2*i+1], fCopyNumberTwo++, fSurfCheck);
-		 }
-	 }
+			fLeftSuppressorCasingAssembly->MakeImprint(expHallLog, moveInnerSuppressor[2*i+1], rotateSideSuppressor[2*i+1], fCopyNumberTwo++, fSurfCheck);
+		}
+	}
 
-    // now we add the side pieces of suppressor that extend out in front of the can when it's in the back position
-    fCopyNumber = fRightSuppressorExtensionCopyNumber + detectorNumber*4;
-    fCopyNumberTwo = fLeftSuppressorExtensionCopyNumber + detectorNumber*4;
+	// now we add the side pieces of suppressor that extend out in front of the can when it's in the back position
+	fCopyNumber = fRightSuppressorExtensionCopyNumber + detectorNumber*4;
+	fCopyNumberTwo = fLeftSuppressorExtensionCopyNumber + detectorNumber*4;
 
-    G4RotationMatrix* rotateExtension[8];
-    G4ThreeVector moveInnerExtension[8];
+	G4RotationMatrix* rotateExtension[8];
+	G4ThreeVector moveInnerExtension[8];
 
-    x0 =  - ((fSuppressorExtensionThickness/2.0 + fSuppressorShellThickness)
-             / cos(fBentEndAngle)
-             + (shellSuppressorExtensionLength/2.0 - (fSuppressorExtensionThickness
-                                                         + fSuppressorShellThickness*2.0)
-                * tan(fBentEndAngle)/2.0) * sin(fBentEndAngle) - (fSuppressorBackRadius
-                                                                                + fBentEndLength + (fBGOCanSeperation + fSideBGOThickness
-                                                                                                           + fSuppressorShellThickness*2.0)
-                                                                                / tan(fBentEndAngle) - (fSuppressorExtensionThickness
-                                                                                                               + fSuppressorShellThickness*2.0)
-                                                                                * sin(fBentEndAngle))
-             * tan(fBentEndAngle));
+	x0 =  - ((fSuppressorExtensionThickness/2.0 + fSuppressorShellThickness)
+			/ cos(fBentEndAngle)
+			+ (shellSuppressorExtensionLength/2.0 - (fSuppressorExtensionThickness
+					+ fSuppressorShellThickness*2.0)
+				* tan(fBentEndAngle)/2.0) * sin(fBentEndAngle) - (fSuppressorBackRadius
+				+ fBentEndLength + (fBGOCanSeperation + fSideBGOThickness
+					+ fSuppressorShellThickness*2.0)
+				/ tan(fBentEndAngle) - (fSuppressorExtensionThickness
+					+ fSuppressorShellThickness*2.0)
+				* sin(fBentEndAngle))
+			* tan(fBentEndAngle));
 
-    y0 =  (shellSuppressorExtensionLength*tan(shellSuppressorExtensionAngle)/2.0
-           + (fSuppressorForwardRadius
-              + fHevimetTipThickness)*sin(fBentEndAngle) - fBGOCanSeperation*2.0 - fDetectorPlacementCxn)/2.0;
+	y0 =  (shellSuppressorExtensionLength*tan(shellSuppressorExtensionAngle)/2.0
+			+ (fSuppressorForwardRadius
+				+ fHevimetTipThickness)*sin(fBentEndAngle) - fBGOCanSeperation*2.0 - fDetectorPlacementCxn)/2.0;
 
-    z0 =  - fCanFaceThickness/2.0 -(shellSuppressorExtensionLength/2.0
-                                           - (fSuppressorExtensionThickness
-                                              + fSuppressorShellThickness*2.0)
-                                           * tan(fBentEndAngle)/2.0)
-            * cos(fBentEndAngle) +fBentEndLength +(fBGOCanSeperation
-                                                                 + fSideBGOThickness
-                                                                 + fSuppressorShellThickness*2.0)/tan(fBentEndAngle)
-            - (fSuppressorExtensionThickness + fSuppressorShellThickness*2.0)
-            * sin(fBentEndAngle) +fSuppShift + fSuppressorBackRadius
-            - fSuppressorForwardRadius
-            - fSuppressorShellThickness/2.0 + distFromOrigin;
-
-
-    if(!(fSuppressorPositionSelector) && fIncludeExtensionSuppressors)
-    {
-        // If the detectors are forward, put the extensions in the back position
-        // the placement of the extensions matches the placement of the sideSuppressor pieces
-
-        x0 += extensionRadialShift ;
-
-        z0 += extensionBackShift ;
+	z0 =  - fCanFaceThickness/2.0 -(shellSuppressorExtensionLength/2.0
+			- (fSuppressorExtensionThickness
+				+ fSuppressorShellThickness*2.0)
+			* tan(fBentEndAngle)/2.0)
+		* cos(fBentEndAngle) +fBentEndLength +(fBGOCanSeperation
+				+ fSideBGOThickness
+				+ fSuppressorShellThickness*2.0)/tan(fBentEndAngle)
+		- (fSuppressorExtensionThickness + fSuppressorShellThickness*2.0)
+		* sin(fBentEndAngle) +fSuppShift + fSuppressorBackRadius
+		- fSuppressorForwardRadius
+		- fSuppressorShellThickness/2.0 + distFromOrigin;
 
 
-        for(i=0; i<4; i++)
-        {
-            rotateExtension[2*i] = new G4RotationMatrix;
-            rotateExtension[2*i]->rotateZ(M_PI/2.0);
-            rotateExtension[2*i]->rotateY(fBentEndAngle);
-            rotateExtension[2*i]->rotateX(M_PI/2.0 - M_PI/2.0*i);
-            rotateExtension[2*i]->rotateX(alpha);
-            rotateExtension[2*i]->rotateY(beta);
-            rotateExtension[2*i]->rotateZ(gamma);
+	if(!(fSuppressorPositionSelector) && fIncludeExtensionSuppressors)
+	{
+		// If the detectors are forward, put the extensions in the back position
+		// the placement of the extensions matches the placement of the sideSuppressor pieces
 
-            x = x0*cos((i-1)*M_PI/2.0) + y0*sin((i-1)*M_PI/2);
-            y = -x0*sin((i-1)*M_PI/2.0) + y0*cos((i-1)*M_PI/2);
-            z = z0;
+		x0 += extensionRadialShift ;
 
-            moveInnerExtension[2*i] = G4ThreeVector(DetectionSystemGriffin::TransX(x,y,z,theta,phi),DetectionSystemGriffin::TransY(x,y,z,theta,phi),DetectionSystemGriffin::TransZ(x,z,theta));
-            fRightSuppressorExtensionAssembly->MakeImprint(expHallLog, moveInnerExtension[2*i], rotateExtension[2*i], fCopyNumber++, fSurfCheck);
+		z0 += extensionBackShift ;
 
-            rotateExtension[2*i+1] = new G4RotationMatrix;
-            rotateExtension[2*i+1]->rotateY(M_PI/2.0);
-            rotateExtension[2*i+1]->rotateZ(M_PI/2.0 + fBentEndAngle);
-            rotateExtension[2*i+1]->rotateX(-M_PI/2.0*i);
-            rotateExtension[2*i+1]->rotateX(alpha);
-            rotateExtension[2*i+1]->rotateY(beta);
-            rotateExtension[2*i+1]->rotateZ(gamma);
 
-            x = x0*sin(i*M_PI/2.0) + y0*cos(i*M_PI/2);
-            y = x0*cos(i*M_PI/2.0) - y0*sin(i*M_PI/2);
-            z = z0;
+		for(i=0; i<4; i++)
+		{
+			rotateExtension[2*i] = new G4RotationMatrix;
+			rotateExtension[2*i]->rotateZ(M_PI/2.0);
+			rotateExtension[2*i]->rotateY(fBentEndAngle);
+			rotateExtension[2*i]->rotateX(M_PI/2.0 - M_PI/2.0*i);
+			rotateExtension[2*i]->rotateX(alpha);
+			rotateExtension[2*i]->rotateY(beta);
+			rotateExtension[2*i]->rotateZ(gamma);
 
-            moveInnerExtension[2*i+1] = G4ThreeVector(DetectionSystemGriffin::TransX(x,y,z,theta,phi),DetectionSystemGriffin::TransY(x,y,z,theta,phi),DetectionSystemGriffin::TransZ(x,z,theta));
-            fLeftSuppressorExtensionAssembly->MakeImprint(expHallLog, moveInnerExtension[2*i+1], rotateExtension[2*i+1], fCopyNumberTwo++, fSurfCheck);
-        }
+			x = x0*cos((i-1)*M_PI/2.0) + y0*sin((i-1)*M_PI/2);
+			y = -x0*sin((i-1)*M_PI/2.0) + y0*cos((i-1)*M_PI/2);
+			z = z0;
 
-    }//end if(detectors forward) statement
+			moveInnerExtension[2*i] = G4ThreeVector(DetectionSystemGriffin::TransX(x,y,z,theta,phi),DetectionSystemGriffin::TransY(x,y,z,theta,phi),DetectionSystemGriffin::TransZ(x,z,theta));
+			fRightSuppressorExtensionAssembly->MakeImprint(expHallLog, moveInnerExtension[2*i], rotateExtension[2*i], fCopyNumber++, fSurfCheck);
 
-    // Otherwise, put them forward
-    else if((fSuppressorPositionSelector == 1) && fIncludeExtensionSuppressors)
-    {
+			rotateExtension[2*i+1] = new G4RotationMatrix;
+			rotateExtension[2*i+1]->rotateY(M_PI/2.0);
+			rotateExtension[2*i+1]->rotateZ(M_PI/2.0 + fBentEndAngle);
+			rotateExtension[2*i+1]->rotateX(-M_PI/2.0*i);
+			rotateExtension[2*i+1]->rotateX(alpha);
+			rotateExtension[2*i+1]->rotateY(beta);
+			rotateExtension[2*i+1]->rotateZ(gamma);
 
-        for(i=0; i<4; i++)
-        {
+			x = x0*sin(i*M_PI/2.0) + y0*cos(i*M_PI/2);
+			y = x0*cos(i*M_PI/2.0) - y0*sin(i*M_PI/2);
+			z = z0;
 
-            rotateExtension[2*i] = new G4RotationMatrix;
-            rotateExtension[2*i]->rotateZ(M_PI/2.0);
-            rotateExtension[2*i]->rotateY(fBentEndAngle);
-            rotateExtension[2*i]->rotateX(M_PI/2.0-M_PI/2.0*i);
-            rotateExtension[2*i]->rotateX(alpha);
-            rotateExtension[2*i]->rotateY(beta);
-            rotateExtension[2*i]->rotateZ(gamma);
+			moveInnerExtension[2*i+1] = G4ThreeVector(DetectionSystemGriffin::TransX(x,y,z,theta,phi),DetectionSystemGriffin::TransY(x,y,z,theta,phi),DetectionSystemGriffin::TransZ(x,z,theta));
+			fLeftSuppressorExtensionAssembly->MakeImprint(expHallLog, moveInnerExtension[2*i+1], rotateExtension[2*i+1], fCopyNumberTwo++, fSurfCheck);
+		}
 
-            x = x0*cos((i-1)*M_PI/2.0) + y0*sin((i-1)*M_PI/2);
-            y = -x0*sin((i-1)*M_PI/2.0) + y0*cos((i-1)*M_PI/2);
-            z = z0;
+	}//end if(detectors forward) statement
 
-            moveInnerExtension[2*i] = G4ThreeVector(DetectionSystemGriffin::TransX(x,y,z,theta,phi),DetectionSystemGriffin::TransY(x,y,z,theta,phi),DetectionSystemGriffin::TransZ(x,z,theta));
-            fRightSuppressorExtensionAssembly->MakeImprint(expHallLog, moveInnerExtension[2*i], rotateExtension[2*i], fCopyNumber++, fSurfCheck);
+	// Otherwise, put them forward
+	else if((fSuppressorPositionSelector == 1) && fIncludeExtensionSuppressors)
+	{
 
-            rotateExtension[2*i+1] = new G4RotationMatrix;
-            rotateExtension[2*i+1]->rotateY(M_PI/2.0);
-            rotateExtension[2*i+1]->rotateZ(M_PI/2.0 + fBentEndAngle);
-            rotateExtension[2*i+1]->rotateX(-M_PI/2.0*i);
-            rotateExtension[2*i+1]->rotateX(alpha);
-            rotateExtension[2*i+1]->rotateY(beta);
-            rotateExtension[2*i+1]->rotateZ(gamma);
+		for(i=0; i<4; i++)
+		{
 
-            x = x0*sin(i*M_PI/2.0) + y0*cos(i*M_PI/2);
-            y = x0*cos(i*M_PI/2.0) - y0*sin(i*M_PI/2);
-            z = z0;
+			rotateExtension[2*i] = new G4RotationMatrix;
+			rotateExtension[2*i]->rotateZ(M_PI/2.0);
+			rotateExtension[2*i]->rotateY(fBentEndAngle);
+			rotateExtension[2*i]->rotateX(M_PI/2.0-M_PI/2.0*i);
+			rotateExtension[2*i]->rotateX(alpha);
+			rotateExtension[2*i]->rotateY(beta);
+			rotateExtension[2*i]->rotateZ(gamma);
 
-            moveInnerExtension[2*i+1] = G4ThreeVector(DetectionSystemGriffin::TransX(x,y,z,theta,phi),DetectionSystemGriffin::TransY(x,y,z,theta,phi),DetectionSystemGriffin::TransZ(x,z,theta));
-            fLeftSuppressorExtensionAssembly->MakeImprint(expHallLog, moveInnerExtension[2*i+1], rotateExtension[2*i+1], fCopyNumberTwo++, fSurfCheck);
-        }
+			x = x0*cos((i-1)*M_PI/2.0) + y0*sin((i-1)*M_PI/2);
+			y = -x0*sin((i-1)*M_PI/2.0) + y0*cos((i-1)*M_PI/2);
+			z = z0;
 
-    }//end if(detectors back) statement
-    return 1;
+			moveInnerExtension[2*i] = G4ThreeVector(DetectionSystemGriffin::TransX(x,y,z,theta,phi),DetectionSystemGriffin::TransY(x,y,z,theta,phi),DetectionSystemGriffin::TransZ(x,z,theta));
+			fRightSuppressorExtensionAssembly->MakeImprint(expHallLog, moveInnerExtension[2*i], rotateExtension[2*i], fCopyNumber++, fSurfCheck);
+
+			rotateExtension[2*i+1] = new G4RotationMatrix;
+			rotateExtension[2*i+1]->rotateY(M_PI/2.0);
+			rotateExtension[2*i+1]->rotateZ(M_PI/2.0 + fBentEndAngle);
+			rotateExtension[2*i+1]->rotateX(-M_PI/2.0*i);
+			rotateExtension[2*i+1]->rotateX(alpha);
+			rotateExtension[2*i+1]->rotateY(beta);
+			rotateExtension[2*i+1]->rotateZ(gamma);
+
+			x = x0*sin(i*M_PI/2.0) + y0*cos(i*M_PI/2);
+			y = x0*cos(i*M_PI/2.0) - y0*sin(i*M_PI/2);
+			z = z0;
+
+			moveInnerExtension[2*i+1] = G4ThreeVector(DetectionSystemGriffin::TransX(x,y,z,theta,phi),DetectionSystemGriffin::TransY(x,y,z,theta,phi),DetectionSystemGriffin::TransZ(x,z,theta));
+			fLeftSuppressorExtensionAssembly->MakeImprint(expHallLog, moveInnerExtension[2*i+1], rotateExtension[2*i+1], fCopyNumberTwo++, fSurfCheck);
+		}
+
+	}//end if(detectors back) statement
+	return 1;
 } // End PlaceEverythingButCrystals
 
 G4int DetectionSystemGriffin::PlaceDeadLayerSpecificCrystal(G4LogicalVolume* expHallLog, G4int detectorNumber, G4int positionNumber, G4bool posTigress) {
 
-    G4double theta  = fCoords[positionNumber][0]*deg;
-    G4double phi    = fCoords[positionNumber][1]*deg;
-    G4double alpha  = fCoords[positionNumber][2]*deg; // yaw
-    G4double beta   = fCoords[positionNumber][3]*deg; // pitch
-    G4double gamma  = fCoords[positionNumber][4]*deg; // roll
+	G4double theta  = fCoords[positionNumber][0]*deg;
+	G4double phi    = fCoords[positionNumber][1]*deg;
+	G4double alpha  = fCoords[positionNumber][2]*deg; // yaw
+	G4double beta   = fCoords[positionNumber][3]*deg; // pitch
+	G4double gamma  = fCoords[positionNumber][4]*deg; // roll
 
-    //In GRIFFIN upstream is now downstream relative to TIGRESS. However, we want to maintain the same numbering scheme as TIGRESS. Net result is that the lampshade angles change by 45 degrees.
-    if(posTigress && (positionNumber < 4 || positionNumber > 11)) {
-        phi       = fCoords[positionNumber][1]*deg - 45.0*deg;
-        gamma     = fCoords[positionNumber][4]*deg - 45.0*deg;
-    }
+	//In GRIFFIN upstream is now downstream relative to TIGRESS. However, we want to maintain the same numbering scheme as TIGRESS. Net result is that the lampshade angles change by 45 degrees.
+	if(posTigress && (positionNumber < 4 || positionNumber > 11)) {
+		phi       = fCoords[positionNumber][1]*deg - 45.0*deg;
+		gamma     = fCoords[positionNumber][4]*deg - 45.0*deg;
+	}
 
-    G4double x;
-    G4double y;
-    G4double z;
+	G4double x;
+	G4double y;
+	G4double z;
 
-    G4double x0, y0, z0;
+	G4double x0, y0, z0;
 
-    G4int i;
+	G4int i;
 
-    // positioning
-    G4double distFromOriginDet = fAirBoxBackLengthDet/2.0 +fAirBoxFrontLengthDet + fNewRhombiRadiusDet;
+	// positioning
+	G4double distFromOriginDet = fAirBoxBackLengthDet/2.0 +fAirBoxFrontLengthDet + fNewRhombiRadiusDet;
 
-    x0 = (fGermaniumWidth + fGermaniumSeparation)/2.0;
-    y0 = (fGermaniumWidth + fGermaniumSeparation)/2.0;
-    z0 = fGermaniumLength/2.0 + fCanFaceThickness/2.0 + fGermaniumDistFromCanFace + fShift + fAppliedBackShift + distFromOriginDet;
+	x0 = (fGermaniumWidth + fGermaniumSeparation)/2.0;
+	y0 = (fGermaniumWidth + fGermaniumSeparation)/2.0;
+	z0 = fGermaniumLength/2.0 + fCanFaceThickness/2.0 + fGermaniumDistFromCanFace + fShift + fAppliedBackShift + distFromOriginDet;
 
-    /////////////////////////////////////////////////////////////////////
-    // now we place all 4 of the 1/4 detectors using the LogicalVolume
-    // of the 1st, ensuring that they too will have the hole
-    /////////////////////////////////////////////////////////////////////
-    fCopyNumber = fGermaniumCopyNumber + detectorNumber*4;
+	/////////////////////////////////////////////////////////////////////
+	// now we place all 4 of the 1/4 detectors using the LogicalVolume
+	// of the 1st, ensuring that they too will have the hole
+	/////////////////////////////////////////////////////////////////////
+	fCopyNumber = fGermaniumCopyNumber + detectorNumber*4;
 
-    G4RotationMatrix* rotateGermanium[4];
-    G4ThreeVector moveGermanium[4];
+	G4RotationMatrix* rotateGermanium[4];
+	G4ThreeVector moveGermanium[4];
 
-    for(i=0; i<4; i++){
-        rotateGermanium[i] = new G4RotationMatrix;
-        rotateGermanium[i]->rotateY(-M_PI/2.0);
-        rotateGermanium[i]->rotateX(M_PI/2.0-M_PI/2.0*i);
-        rotateGermanium[i]->rotateX(alpha);
-        rotateGermanium[i]->rotateY(beta);
-        rotateGermanium[i]->rotateZ(gamma);
+	for(i=0; i<4; i++){
+		rotateGermanium[i] = new G4RotationMatrix;
+		rotateGermanium[i]->rotateY(-M_PI/2.0);
+		rotateGermanium[i]->rotateX(M_PI/2.0-M_PI/2.0*i);
+		rotateGermanium[i]->rotateX(alpha);
+		rotateGermanium[i]->rotateY(beta);
+		rotateGermanium[i]->rotateZ(gamma);
 
-        x = -x0*pow(-1, floor((i+1)/2));
-        y = -y0*pow(-1, floor((i+2)/2));
-        z = z0;
+		x = -x0*pow(-1, floor((i+1)/2));
+		y = -y0*pow(-1, floor((i+2)/2));
+		z = z0;
 
-        moveGermanium[i] = G4ThreeVector(DetectionSystemGriffin::TransX(x,y,z,theta,phi), DetectionSystemGriffin::TransY(x,y,z,theta,phi), DetectionSystemGriffin::TransZ(x,z,theta));
+		moveGermanium[i] = G4ThreeVector(DetectionSystemGriffin::TransX(x,y,z,theta,phi), DetectionSystemGriffin::TransY(x,y,z,theta,phi), DetectionSystemGriffin::TransZ(x,z,theta));
 
-        fGermaniumAssemblyCry[i]->MakeImprint(expHallLog, moveGermanium[i], rotateGermanium[i], fCopyNumber++, fSurfCheck);
-    }
+		fGermaniumAssemblyCry[i]->MakeImprint(expHallLog, moveGermanium[i], rotateGermanium[i], fCopyNumber++, fSurfCheck);
+	}
 
-    /////////////////////////////////////////////////////////////////////
-    // end germaniumBlock1Log
-    /////////////////////////////////////////////////////////////////////
+	/////////////////////////////////////////////////////////////////////
+	// end germaniumBlock1Log
+	/////////////////////////////////////////////////////////////////////
 
-    return 1;
+	return 1;
 } // end PlaceDeadLayerSpecificCrystal()
 
 
@@ -489,109 +489,109 @@ G4int DetectionSystemGriffin::PlaceDeadLayerSpecificCrystal(G4LogicalVolume* exp
 // BuildOneDetector()
 ///////////////////////////////////////////////////////////////////////
 void DetectionSystemGriffin::BuildOneDetector() {
-    // Build assembly volumes
-    // Holds all pieces that are not a detector (ie. the can, nitrogen tank, cold finger, electrodes, etc.)
-    fAssembly                           = new G4AssemblyVolume();
+	// Build assembly volumes
+	// Holds all pieces that are not a detector (ie. the can, nitrogen tank, cold finger, electrodes, etc.)
+	fAssembly                           = new G4AssemblyVolume();
 
-    // Holds germanium cores
-    fGermaniumAssembly                  = new G4AssemblyVolume();
+	// Holds germanium cores
+	fGermaniumAssembly                  = new G4AssemblyVolume();
 
-    // Holds left suppressors
-    fLeftSuppressorCasingAssembly       = new G4AssemblyVolume();
+	// Holds left suppressors
+	fLeftSuppressorCasingAssembly       = new G4AssemblyVolume();
 
-    // Holds right suppressors
-    fRightSuppressorCasingAssembly      = new G4AssemblyVolume();
+	// Holds right suppressors
+	fRightSuppressorCasingAssembly      = new G4AssemblyVolume();
 
-    // holds left suppressor extensions
-    fLeftSuppressorExtensionAssembly    = new G4AssemblyVolume();
+	// holds left suppressor extensions
+	fLeftSuppressorExtensionAssembly    = new G4AssemblyVolume();
 
-    // holds right suppressor extensions
-    fRightSuppressorExtensionAssembly   = new G4AssemblyVolume();
+	// holds right suppressor extensions
+	fRightSuppressorExtensionAssembly   = new G4AssemblyVolume();
 
-    // Holds back suppressors
-    fSuppressorBackAssembly             = new G4AssemblyVolume();
+	// Holds back suppressors
+	fSuppressorBackAssembly             = new G4AssemblyVolume();
 
-    // Holds the extension suppressor shells
-    fExtensionSuppressorShellAssembly   = new G4AssemblyVolume() ;
+	// Holds the extension suppressor shells
+	fExtensionSuppressorShellAssembly   = new G4AssemblyVolume() ;
 
-    // Holds the back and side suppressor shells
-    fBackAndSideSuppressorShellAssembly = new G4AssemblyVolume() ;
+	// Holds the back and side suppressor shells
+	fBackAndSideSuppressorShellAssembly = new G4AssemblyVolume() ;
 
-    // Holds the Hevimets
-    fHevimetAssembly                    = new G4AssemblyVolume() ;
+	// Holds the Hevimets
+	fHevimetAssembly                    = new G4AssemblyVolume() ;
 
-    ConstructComplexDetectorBlockWithDeadLayer();
-    BuildelectrodeMatElectrodes();
+	ConstructComplexDetectorBlockWithDeadLayer();
+	BuildelectrodeMatElectrodes();
 
-    ConstructDetector();
+	ConstructDetector();
 
-    // Include BGOs?
-    if(fBGOSelector == 1) {
-        ConstructNewSuppressorCasingWithShells() ;
-    } else if(fBGOSelector == 0) {
-        //G4cout<<"Not building BGO "<<G4endl ;
-    } else {
-        G4cout<<"Error 234235"<<G4endl ;
-        exit(1);
-    }
+	// Include BGOs?
+	if(fBGOSelector == 1) {
+		ConstructNewSuppressorCasingWithShells() ;
+	} else if(fBGOSelector == 0) {
+		//G4cout<<"Not building BGO "<<G4endl ;
+	} else {
+		G4cout<<"Error 234235"<<G4endl ;
+		exit(1);
+	}
 
-    ConstructColdFinger();
+	ConstructColdFinger();
 
-    if(fSuppressorPositionSelector && fHevimetSelector)
-        ConstructNewHeavyMet();
+	if(fSuppressorPositionSelector && fHevimetSelector)
+		ConstructNewHeavyMet();
 
 } // end BuildOneDetector()
 
 void DetectionSystemGriffin::BuildEverythingButCrystals() {
-    // Build assembly volumes
-    fAssembly                           = new G4AssemblyVolume();
-    fLeftSuppressorCasingAssembly       = new G4AssemblyVolume();
-    fRightSuppressorCasingAssembly      = new G4AssemblyVolume();
-    fLeftSuppressorExtensionAssembly    = new G4AssemblyVolume();
-    fRightSuppressorExtensionAssembly   = new G4AssemblyVolume();
-    fSuppressorBackAssembly             = new G4AssemblyVolume();
+	// Build assembly volumes
+	fAssembly                           = new G4AssemblyVolume();
+	fLeftSuppressorCasingAssembly       = new G4AssemblyVolume();
+	fRightSuppressorCasingAssembly      = new G4AssemblyVolume();
+	fLeftSuppressorExtensionAssembly    = new G4AssemblyVolume();
+	fRightSuppressorExtensionAssembly   = new G4AssemblyVolume();
+	fSuppressorBackAssembly             = new G4AssemblyVolume();
 
-    // Holds the extension suppressor shells
-    fExtensionSuppressorShellAssembly   = new G4AssemblyVolume() ;
+	// Holds the extension suppressor shells
+	fExtensionSuppressorShellAssembly   = new G4AssemblyVolume() ;
 
-    // Holds the back and side suppressor shells
-    fBackAndSideSuppressorShellAssembly = new G4AssemblyVolume() ;
+	// Holds the back and side suppressor shells
+	fBackAndSideSuppressorShellAssembly = new G4AssemblyVolume() ;
 
-    // Holds the hevimets
-    fHevimetAssembly                    = new G4AssemblyVolume() ;
+	// Holds the hevimets
+	fHevimetAssembly                    = new G4AssemblyVolume() ;
 
-    BuildelectrodeMatElectrodes();
+	BuildelectrodeMatElectrodes();
 
-    ConstructDetector();
+	ConstructDetector();
 
-    // Include BGOs?
-    if(fBGOSelector == 1) {
-        ConstructNewSuppressorCasingWithShells();
-    } else if(fBGOSelector == 0) {
-        //G4cout<<"Not building BGO "<<G4endl;
-    } else {
-        G4cout<<"Error 234235"<<G4endl;
-        exit(1);
-    }
+	// Include BGOs?
+	if(fBGOSelector == 1) {
+		ConstructNewSuppressorCasingWithShells();
+	} else if(fBGOSelector == 0) {
+		//G4cout<<"Not building BGO "<<G4endl;
+	} else {
+		G4cout<<"Error 234235"<<G4endl;
+		exit(1);
+	}
 
-    ConstructColdFinger();
+	ConstructColdFinger();
 
-    if(fSuppressorPositionSelector &&  fHevimetSelector)
-        ConstructNewHeavyMet();
+	if(fSuppressorPositionSelector &&  fHevimetSelector)
+		ConstructNewHeavyMet();
 
 
 } // end BuildEverythingButCrystals()
 
 
 void DetectionSystemGriffin::BuildDeadLayerSpecificCrystal(G4int det) {
-    fGermaniumAssemblyCry[0] = new G4AssemblyVolume();
-    fGermaniumAssemblyCry[1] = new G4AssemblyVolume();
-    fGermaniumAssemblyCry[2] = new G4AssemblyVolume();
-    fGermaniumAssemblyCry[3] = new G4AssemblyVolume();
+	fGermaniumAssemblyCry[0] = new G4AssemblyVolume();
+	fGermaniumAssemblyCry[1] = new G4AssemblyVolume();
+	fGermaniumAssemblyCry[2] = new G4AssemblyVolume();
+	fGermaniumAssemblyCry[3] = new G4AssemblyVolume();
 
-    for(G4int i=0; i<4; i++) {
+	for(G4int i=0; i<4; i++) {
 		ConstructComplexDetectorBlockWithDetectorSpecificDeadLayer(det,i);
-	 }
+	}
 }
 
 
@@ -599,52 +599,52 @@ void DetectionSystemGriffin::BuildDeadLayerSpecificCrystal(G4int det) {
 // ConstructComplexDetectorBlock builds four quarters of germanium
 ///////////////////////////////////////////////////////////////////////
 void DetectionSystemGriffin::ConstructComplexDetectorBlock() {
-    G4Material* materialGe = G4Material::GetMaterial("G4_Ge");
-    if(!materialGe) {
-        G4cout<<" ----> Material G4_Ge not found, cannot build the detector shell! "<<G4endl;
-        exit(1);
-    }
-    G4Material* materialVacuum = G4Material::GetMaterial("Vacuum");
-    if(!materialVacuum) {
-        G4cout<<" ----> Material Vacuum not found, cannot build the detector shell! "<<G4endl;
-        exit(1);
-    }
+	G4Material* materialGe = G4Material::GetMaterial("G4_Ge");
+	if(!materialGe) {
+		G4cout<<" ----> Material G4_Ge not found, cannot build the detector shell! "<<G4endl;
+		exit(1);
+	}
+	G4Material* materialVacuum = G4Material::GetMaterial("Vacuum");
+	if(!materialVacuum) {
+		G4cout<<" ----> Material Vacuum not found, cannot build the detector shell! "<<G4endl;
+		exit(1);
+	}
 
-    G4VisAttributes* germaniumBlock1VisAtt = new G4VisAttributes(G4Colour(1.0,0.0,0.0));
-    germaniumBlock1VisAtt->SetVisibility(true);
+	G4VisAttributes* germaniumBlock1VisAtt = new G4VisAttributes(G4Colour(1.0,0.0,0.0));
+	germaniumBlock1VisAtt->SetVisibility(true);
 
-    G4VisAttributes* deadLayerVisAtt = new G4VisAttributes(G4Colour(0.80, 0.0, 0.0));
-    deadLayerVisAtt->SetVisibility(true);
+	G4VisAttributes* deadLayerVisAtt = new G4VisAttributes(G4Colour(0.80, 0.0, 0.0));
+	deadLayerVisAtt->SetVisibility(true);
 
-    G4VisAttributes* airVisAtt = new G4VisAttributes(G4Colour(0.8,0.8,0.8));
-    airVisAtt->SetVisibility(true);
+	G4VisAttributes* airVisAtt = new G4VisAttributes(G4Colour(0.8,0.8,0.8));
+	airVisAtt->SetVisibility(true);
 
-    G4VisAttributes* electrodeMatVisAtt = new G4VisAttributes(G4Colour(1.0,1.0,0.0));
-    electrodeMatVisAtt->SetVisibility(true);
+	G4VisAttributes* electrodeMatVisAtt = new G4VisAttributes(G4Colour(1.0,1.0,0.0));
+	electrodeMatVisAtt->SetVisibility(true);
 
-    G4SubtractionSolid* detector1 = QuarterDetector();
+	G4SubtractionSolid* detector1 = QuarterDetector();
 
-    fGermaniumBlock1Log = new G4LogicalVolume(detector1, materialGe, "germaniumBlock1Log", 0, 0, 0);
-    fGermaniumBlock1Log->SetVisAttributes(germaniumBlock1VisAtt);
+	fGermaniumBlock1Log = new G4LogicalVolume(detector1, materialGe, "germaniumBlock1Log", 0, 0, 0);
+	fGermaniumBlock1Log->SetVisAttributes(germaniumBlock1VisAtt);
 
-    fGermaniumAssembly->AddPlacedVolume(fGermaniumBlock1Log, fMoveNull, fRotateNull);
+	fGermaniumAssembly->AddPlacedVolume(fGermaniumBlock1Log, fMoveNull, fRotateNull);
 
-    // now we make the hole that will go in the back of each quarter detector,
-    G4double startAngle = 0.0*M_PI;
-    G4double finalAngle = 2.0*M_PI;
-    G4double holeRadius = fGermaniumHoleRadius;
-    G4double holeHalfLengthZ = (fGermaniumLength -fGermaniumHoleDistFromFace)/2.0;
+	// now we make the hole that will go in the back of each quarter detector,
+	G4double startAngle = 0.0*M_PI;
+	G4double finalAngle = 2.0*M_PI;
+	G4double holeRadius = fGermaniumHoleRadius;
+	G4double holeHalfLengthZ = (fGermaniumLength -fGermaniumHoleDistFromFace)/2.0;
 
 
-    G4Tubs* holeTubs = new G4Tubs("holeTubs", 0.0, holeRadius, holeHalfLengthZ, startAngle, finalAngle);
+	G4Tubs* holeTubs = new G4Tubs("holeTubs", 0.0, holeRadius, holeHalfLengthZ, startAngle, finalAngle);
 
-    G4ThreeVector moveHole(fGermaniumShift, -(fGermaniumShift),
-                            -((fGermaniumHoleDistFromFace)));
+	G4ThreeVector moveHole(fGermaniumShift, -(fGermaniumShift),
+			-((fGermaniumHoleDistFromFace)));
 
-    fGermaniumHoleLog = new G4LogicalVolume(holeTubs, materialVacuum, "germaniumHoleLog", 0, 0, 0);
-    fGermaniumHoleLog->SetVisAttributes(airVisAtt);
+	fGermaniumHoleLog = new G4LogicalVolume(holeTubs, materialVacuum, "germaniumHoleLog", 0, 0, 0);
+	fGermaniumHoleLog->SetVisAttributes(airVisAtt);
 
-    fGermaniumAssembly->AddPlacedVolume(fGermaniumHoleLog, moveHole, fRotateNull);
+	fGermaniumAssembly->AddPlacedVolume(fGermaniumHoleLog, moveHole, fRotateNull);
 
 }//end ::ConstructComplexDetectorBlock
 
@@ -653,191 +653,191 @@ void DetectionSystemGriffin::ConstructComplexDetectorBlock() {
 // germanium, with dead layers
 ///////////////////////////////////////////////////////////////////////
 void DetectionSystemGriffin::ConstructComplexDetectorBlockWithDeadLayer() {
-    G4Material* materialGe = G4Material::GetMaterial("G4_Ge");
-    if(!materialGe) {
-        G4cout<<" ----> Material G4_Ge not found, cannot build the detector shell! "<<G4endl;
-        exit(1);
-    }
-    G4Material* materialVacuum = G4Material::GetMaterial("Vacuum");
-    if(!materialVacuum) {
-        G4cout<<" ----> Material Vacuum not found, cannot build the detector shell! "<<G4endl;
-        exit(1);
-    }
+	G4Material* materialGe = G4Material::GetMaterial("G4_Ge");
+	if(!materialGe) {
+		G4cout<<" ----> Material G4_Ge not found, cannot build the detector shell! "<<G4endl;
+		exit(1);
+	}
+	G4Material* materialVacuum = G4Material::GetMaterial("Vacuum");
+	if(!materialVacuum) {
+		G4cout<<" ----> Material Vacuum not found, cannot build the detector shell! "<<G4endl;
+		exit(1);
+	}
 
-    G4VisAttributes* germaniumBlock1VisAtt = new G4VisAttributes(G4Colour(1.0,0.0,0.0));
-    germaniumBlock1VisAtt->SetVisibility(true);
+	G4VisAttributes* germaniumBlock1VisAtt = new G4VisAttributes(G4Colour(1.0,0.0,0.0));
+	germaniumBlock1VisAtt->SetVisibility(true);
 
-    G4VisAttributes* deadLayerVisAtt = new G4VisAttributes(G4Colour(0.80, 0.0, 0.0));
-    deadLayerVisAtt->SetVisibility(true);
+	G4VisAttributes* deadLayerVisAtt = new G4VisAttributes(G4Colour(0.80, 0.0, 0.0));
+	deadLayerVisAtt->SetVisibility(true);
 
-    G4VisAttributes* airVisAtt = new G4VisAttributes(G4Colour(0.8,0.8,0.8));
-    airVisAtt->SetVisibility(true);
+	G4VisAttributes* airVisAtt = new G4VisAttributes(G4Colour(0.8,0.8,0.8));
+	airVisAtt->SetVisibility(true);
 
-    G4VisAttributes* electrodeMatVisAtt = new G4VisAttributes(G4Colour(1.0,1.0,0.0));
-    electrodeMatVisAtt->SetVisibility(true);
+	G4VisAttributes* electrodeMatVisAtt = new G4VisAttributes(G4Colour(1.0,1.0,0.0));
+	electrodeMatVisAtt->SetVisibility(true);
 
-    G4SubtractionSolid* detector1 = QuarterDetector();
+	G4SubtractionSolid* detector1 = QuarterDetector();
 
-    fGermaniumBlock1Log = new G4LogicalVolume(detector1, materialGe, "germaniumBlock1Log", 0, 0, 0);
-    fGermaniumBlock1Log->SetVisAttributes(germaniumBlock1VisAtt);
+	fGermaniumBlock1Log = new G4LogicalVolume(detector1, materialGe, "germaniumBlock1Log", 0, 0, 0);
+	fGermaniumBlock1Log->SetVisAttributes(germaniumBlock1VisAtt);
 
-    fGermaniumAssembly->AddPlacedVolume(fGermaniumBlock1Log, fMoveNull, fRotateNull);
+	fGermaniumAssembly->AddPlacedVolume(fGermaniumBlock1Log, fMoveNull, fRotateNull);
 
-    /////////////////////////////////////////////////////////////////////
-    // Since if we are using this method, the inner dead layer must be
-    // simulated, make a cylinder of germanium, place the air cylinder
-    // inside it, and then place the whole thing in the crystal
-    /////////////////////////////////////////////////////////////////////
-    G4double startAngle = 0.0*M_PI;
-    G4double finalAngle = 2.0*M_PI;
-    G4double deadLayerRadius = fGermaniumHoleRadius + fInnerDeadLayerThickness;
-    G4double deadLayerHalfLengthZ = (fGermaniumLength
-                                         - fGermaniumHoleDistFromFace
-                                         + fInnerDeadLayerThickness)/2.0;
+	/////////////////////////////////////////////////////////////////////
+	// Since if we are using this method, the inner dead layer must be
+	// simulated, make a cylinder of germanium, place the air cylinder
+	// inside it, and then place the whole thing in the crystal
+	/////////////////////////////////////////////////////////////////////
+	G4double startAngle = 0.0*M_PI;
+	G4double finalAngle = 2.0*M_PI;
+	G4double deadLayerRadius = fGermaniumHoleRadius + fInnerDeadLayerThickness;
+	G4double deadLayerHalfLengthZ = (fGermaniumLength
+			- fGermaniumHoleDistFromFace
+			+ fInnerDeadLayerThickness)/2.0;
 
-    G4Tubs* deadLayerTubs = new G4Tubs("deadLayerTubs", fGermaniumHoleRadius,
-                                         deadLayerRadius, deadLayerHalfLengthZ, startAngle,finalAngle);
+	G4Tubs* deadLayerTubs = new G4Tubs("deadLayerTubs", fGermaniumHoleRadius,
+			deadLayerRadius, deadLayerHalfLengthZ, startAngle,finalAngle);
 
-    G4ThreeVector moveDeadLayer(fGermaniumShift, -(fGermaniumShift),
-                                  -((fGermaniumHoleDistFromFace
-                                     - fInnerDeadLayerThickness)/2.0));
+	G4ThreeVector moveDeadLayer(fGermaniumShift, -(fGermaniumShift),
+			-((fGermaniumHoleDistFromFace
+					- fInnerDeadLayerThickness)/2.0));
 
-    fInnerDeadLayerLog = new G4LogicalVolume(deadLayerTubs, materialGe, "innerDeadLayerLog", 0, 0, 0);
-    fInnerDeadLayerLog->SetVisAttributes(deadLayerVisAtt);
+	fInnerDeadLayerLog = new G4LogicalVolume(deadLayerTubs, materialGe, "innerDeadLayerLog", 0, 0, 0);
+	fInnerDeadLayerLog->SetVisAttributes(deadLayerVisAtt);
 
-    fGermaniumAssembly->AddPlacedVolume(fInnerDeadLayerLog, moveDeadLayer, fRotateNull);
+	fGermaniumAssembly->AddPlacedVolume(fInnerDeadLayerLog, moveDeadLayer, fRotateNull);
 
-    // dead layer cap
-    deadLayerRadius = fGermaniumHoleRadius;
-    G4double deadLayerCapHalfLengthZ = (fInnerDeadLayerThickness)/2.0;
+	// dead layer cap
+	deadLayerRadius = fGermaniumHoleRadius;
+	G4double deadLayerCapHalfLengthZ = (fInnerDeadLayerThickness)/2.0;
 
-    G4Tubs* deadLayerCap = new G4Tubs("deadLayerCap", 0.0,
-                                        deadLayerRadius, deadLayerCapHalfLengthZ, startAngle,finalAngle);
+	G4Tubs* deadLayerCap = new G4Tubs("deadLayerCap", 0.0,
+			deadLayerRadius, deadLayerCapHalfLengthZ, startAngle,finalAngle);
 
-    G4ThreeVector moveDeadLayerCap(fGermaniumShift, -(fGermaniumShift),
-                                      -((fGermaniumHoleDistFromFace - fInnerDeadLayerThickness)/2.0 - deadLayerHalfLengthZ + fInnerDeadLayerThickness/2.0));
+	G4ThreeVector moveDeadLayerCap(fGermaniumShift, -(fGermaniumShift),
+			-((fGermaniumHoleDistFromFace - fInnerDeadLayerThickness)/2.0 - deadLayerHalfLengthZ + fInnerDeadLayerThickness/2.0));
 
-    fInnerDeadLayerCapLog = new G4LogicalVolume(deadLayerCap, materialGe, "innerDeadLayerCapLog", 0, 0, 0);
-    fInnerDeadLayerCapLog->SetVisAttributes(deadLayerVisAtt);
+	fInnerDeadLayerCapLog = new G4LogicalVolume(deadLayerCap, materialGe, "innerDeadLayerCapLog", 0, 0, 0);
+	fInnerDeadLayerCapLog->SetVisAttributes(deadLayerVisAtt);
 
-    fGermaniumAssembly->AddPlacedVolume(fInnerDeadLayerCapLog, moveDeadLayerCap, fRotateNull);
+	fGermaniumAssembly->AddPlacedVolume(fInnerDeadLayerCapLog, moveDeadLayerCap, fRotateNull);
 
 
-    // now we make the hole that will go in the back of each quarter detector,
-    // and place it inside the dead layer cylinder
-    startAngle = 0.0*M_PI;
-    finalAngle = 2.0*M_PI;
-    G4double holeRadius = fGermaniumHoleRadius;
-    G4double holeHalfLengthZ = (fGermaniumLength -fGermaniumHoleDistFromFace)/2.0;
+	// now we make the hole that will go in the back of each quarter detector,
+	// and place it inside the dead layer cylinder
+	startAngle = 0.0*M_PI;
+	finalAngle = 2.0*M_PI;
+	G4double holeRadius = fGermaniumHoleRadius;
+	G4double holeHalfLengthZ = (fGermaniumLength -fGermaniumHoleDistFromFace)/2.0;
 
-    G4Tubs* holeTubs = new G4Tubs("holeTubs", 0.0, holeRadius, holeHalfLengthZ, startAngle, finalAngle);
+	G4Tubs* holeTubs = new G4Tubs("holeTubs", 0.0, holeRadius, holeHalfLengthZ, startAngle, finalAngle);
 
-    G4ThreeVector moveHole(fGermaniumShift, -(fGermaniumShift),
-                            -((fGermaniumHoleDistFromFace
-                               - fInnerDeadLayerThickness)/2.0)
-                            -(fInnerDeadLayerThickness/2.0));
+	G4ThreeVector moveHole(fGermaniumShift, -(fGermaniumShift),
+			-((fGermaniumHoleDistFromFace
+					- fInnerDeadLayerThickness)/2.0)
+			-(fInnerDeadLayerThickness/2.0));
 
-    fGermaniumHoleLog = new G4LogicalVolume(holeTubs, materialVacuum, "germaniumHoleLog", 0, 0, 0);
-    fGermaniumHoleLog->SetVisAttributes(airVisAtt);
+	fGermaniumHoleLog = new G4LogicalVolume(holeTubs, materialVacuum, "germaniumHoleLog", 0, 0, 0);
+	fGermaniumHoleLog->SetVisAttributes(airVisAtt);
 
-    fGermaniumAssembly->AddPlacedVolume(fGermaniumHoleLog, moveHole, fRotateNull);
+	fGermaniumAssembly->AddPlacedVolume(fGermaniumHoleLog, moveHole, fRotateNull);
 
 }//end ::ConstructComplexDetectorBlockWithDeadLayer
 
 void DetectionSystemGriffin::ConstructComplexDetectorBlockWithDetectorSpecificDeadLayer(G4int det, G4int cry) {
-    G4String strdet = G4UIcommand::ConvertToString(det);
-    G4String strcry = G4UIcommand::ConvertToString(cry);
+	G4String strdet = G4UIcommand::ConvertToString(det);
+	G4String strcry = G4UIcommand::ConvertToString(cry);
 
-    G4Material* materialGe = G4Material::GetMaterial("G4_Ge");
-    if(!materialGe) {
-		  G4cout<<" ----> Material G4_Ge not found, cannot build the detector shell! "<<G4endl;
-        exit(1);
-    }
-    G4Material* materialVacuum = G4Material::GetMaterial("Vacuum");
-    if(!materialVacuum) {
-		  G4cout<<" ----> Material Vacuum not found, cannot build the detector shell! "<<G4endl;
-        exit(1);
-    }
+	G4Material* materialGe = G4Material::GetMaterial("G4_Ge");
+	if(!materialGe) {
+		G4cout<<" ----> Material G4_Ge not found, cannot build the detector shell! "<<G4endl;
+		exit(1);
+	}
+	G4Material* materialVacuum = G4Material::GetMaterial("Vacuum");
+	if(!materialVacuum) {
+		G4cout<<" ----> Material Vacuum not found, cannot build the detector shell! "<<G4endl;
+		exit(1);
+	}
 
-    G4VisAttributes* germaniumBlock1VisAtt = new G4VisAttributes(fGriffinCrystalColours[cry]);
-    germaniumBlock1VisAtt->SetVisibility(true);
+	G4VisAttributes* germaniumBlock1VisAtt = new G4VisAttributes(fGriffinCrystalColours[cry]);
+	germaniumBlock1VisAtt->SetVisibility(true);
 
-    G4VisAttributes* deadLayerVisAtt = new G4VisAttributes(fGriffinDeadLayerColours[cry]);
-    deadLayerVisAtt->SetVisibility(true);
+	G4VisAttributes* deadLayerVisAtt = new G4VisAttributes(fGriffinDeadLayerColours[cry]);
+	deadLayerVisAtt->SetVisibility(true);
 
-    G4VisAttributes* airVisAtt = new G4VisAttributes(G4Colour(0.8,0.8,0.8));
-    airVisAtt->SetVisibility(true);
+	G4VisAttributes* airVisAtt = new G4VisAttributes(G4Colour(0.8,0.8,0.8));
+	airVisAtt->SetVisibility(true);
 
-    G4VisAttributes* electrodeMatVisAtt = new G4VisAttributes(G4Colour(1.0,1.0,0.0));
-    electrodeMatVisAtt->SetVisibility(true);
+	G4VisAttributes* electrodeMatVisAtt = new G4VisAttributes(G4Colour(1.0,1.0,0.0));
+	electrodeMatVisAtt->SetVisibility(true);
 
-    G4SubtractionSolid* detector1 = QuarterSpecificDeadLayerDetector(det, cry);
+	G4SubtractionSolid* detector1 = QuarterSpecificDeadLayerDetector(det, cry);
 
-    G4String germaniumBlock1Name = "germaniumDlsBlock1_" + strdet + "_" + strcry + "_log" ;
+	G4String germaniumBlock1Name = "germaniumDlsBlock1_" + strdet + "_" + strcry + "_log" ;
 
-    fGermaniumBlock1Log = new G4LogicalVolume(detector1, materialGe, germaniumBlock1Name, 0, 0, 0);
-    fGermaniumBlock1Log->SetVisAttributes(germaniumBlock1VisAtt);
+	fGermaniumBlock1Log = new G4LogicalVolume(detector1, materialGe, germaniumBlock1Name, 0, 0, 0);
+	fGermaniumBlock1Log->SetVisAttributes(germaniumBlock1VisAtt);
 
-    fGermaniumAssemblyCry[cry]->AddPlacedVolume(fGermaniumBlock1Log, fMoveNull, fRotateNull);
+	fGermaniumAssemblyCry[cry]->AddPlacedVolume(fGermaniumBlock1Log, fMoveNull, fRotateNull);
 
-    /////////////////////////////////////////////////////////////////////
-    // Since if we are using this method, the inner dead layer must be
-    // simulated, make a cylinder of germanium, place the air cylinder
-    // inside it, and then place the whole thing in the crystal
-    /////////////////////////////////////////////////////////////////////
-    G4double startAngle = 0.0*M_PI;
-    G4double finalAngle = 2.0*M_PI;
-    G4double deadLayerRadius = fGermaniumHoleRadius + fGriffinDeadLayers[det][cry];
-    G4double deadLayerHalfLengthZ = (fGermaniumLength
-                                         - fGermaniumHoleDistFromFace
-                                         + fGriffinDeadLayers[det][cry])/2.0;
+	/////////////////////////////////////////////////////////////////////
+	// Since if we are using this method, the inner dead layer must be
+	// simulated, make a cylinder of germanium, place the air cylinder
+	// inside it, and then place the whole thing in the crystal
+	/////////////////////////////////////////////////////////////////////
+	G4double startAngle = 0.0*M_PI;
+	G4double finalAngle = 2.0*M_PI;
+	G4double deadLayerRadius = fGermaniumHoleRadius + fGriffinDeadLayers[det][cry];
+	G4double deadLayerHalfLengthZ = (fGermaniumLength
+			- fGermaniumHoleDistFromFace
+			+ fGriffinDeadLayers[det][cry])/2.0;
 
-    G4Tubs* deadLayerTubs = new G4Tubs("deadLayerTubs", fGermaniumHoleRadius,
-                                         deadLayerRadius, deadLayerHalfLengthZ, startAngle,finalAngle);
+	G4Tubs* deadLayerTubs = new G4Tubs("deadLayerTubs", fGermaniumHoleRadius,
+			deadLayerRadius, deadLayerHalfLengthZ, startAngle,finalAngle);
 
-    G4ThreeVector moveDeadLayer(fGermaniumShift, -(fGermaniumShift),
-                                  -((fGermaniumHoleDistFromFace
-                                     - fGriffinDeadLayers[det][cry])/2.0));
+	G4ThreeVector moveDeadLayer(fGermaniumShift, -(fGermaniumShift),
+			-((fGermaniumHoleDistFromFace
+					- fGriffinDeadLayers[det][cry])/2.0));
 
-    fInnerDeadLayerLog = new G4LogicalVolume(deadLayerTubs, materialGe, "innerDeadLayerLog", 0, 0, 0);
-    fInnerDeadLayerLog->SetVisAttributes(deadLayerVisAtt);
+	fInnerDeadLayerLog = new G4LogicalVolume(deadLayerTubs, materialGe, "innerDeadLayerLog", 0, 0, 0);
+	fInnerDeadLayerLog->SetVisAttributes(deadLayerVisAtt);
 
-    fGermaniumAssemblyCry[cry]->AddPlacedVolume(fInnerDeadLayerLog, moveDeadLayer, fRotateNull);
+	fGermaniumAssemblyCry[cry]->AddPlacedVolume(fInnerDeadLayerLog, moveDeadLayer, fRotateNull);
 
-    // dead layer cap
-    deadLayerRadius = fGermaniumHoleRadius;
-    G4double deadLayerCapHalfLengthZ = (fGriffinDeadLayers[det][cry])/2.0;
+	// dead layer cap
+	deadLayerRadius = fGermaniumHoleRadius;
+	G4double deadLayerCapHalfLengthZ = (fGriffinDeadLayers[det][cry])/2.0;
 
-    G4Tubs* deadLayerCap = new G4Tubs("deadLayerCap", 0.0,
-                                        deadLayerRadius, deadLayerCapHalfLengthZ, startAngle,finalAngle);
+	G4Tubs* deadLayerCap = new G4Tubs("deadLayerCap", 0.0,
+			deadLayerRadius, deadLayerCapHalfLengthZ, startAngle,finalAngle);
 
-    G4ThreeVector moveDeadLayerCap(fGermaniumShift, -(fGermaniumShift),
-                                      -((fGermaniumHoleDistFromFace - fGriffinDeadLayers[det][cry])/2.0 - deadLayerHalfLengthZ + fGriffinDeadLayers[det][cry]/2.0));
+	G4ThreeVector moveDeadLayerCap(fGermaniumShift, -(fGermaniumShift),
+			-((fGermaniumHoleDistFromFace - fGriffinDeadLayers[det][cry])/2.0 - deadLayerHalfLengthZ + fGriffinDeadLayers[det][cry]/2.0));
 
-    fInnerDeadLayerCapLog = new G4LogicalVolume(deadLayerCap, materialGe, "innerDeadLayerCapLog", 0, 0, 0);
-    fInnerDeadLayerCapLog->SetVisAttributes(deadLayerVisAtt);
+	fInnerDeadLayerCapLog = new G4LogicalVolume(deadLayerCap, materialGe, "innerDeadLayerCapLog", 0, 0, 0);
+	fInnerDeadLayerCapLog->SetVisAttributes(deadLayerVisAtt);
 
-    fGermaniumAssemblyCry[cry]->AddPlacedVolume(fInnerDeadLayerCapLog, moveDeadLayerCap, fRotateNull);
+	fGermaniumAssemblyCry[cry]->AddPlacedVolume(fInnerDeadLayerCapLog, moveDeadLayerCap, fRotateNull);
 
 
-    // now we make the hole that will go in the back of each quarter detector,
-    // and place it inside the dead layer cylinder
-    startAngle = 0.0*M_PI;
-    finalAngle = 2.0*M_PI;
-    G4double holeRadius = fGermaniumHoleRadius;
-    G4double holeHalfLengthZ = (fGermaniumLength -fGermaniumHoleDistFromFace)/2.0;
+	// now we make the hole that will go in the back of each quarter detector,
+	// and place it inside the dead layer cylinder
+	startAngle = 0.0*M_PI;
+	finalAngle = 2.0*M_PI;
+	G4double holeRadius = fGermaniumHoleRadius;
+	G4double holeHalfLengthZ = (fGermaniumLength -fGermaniumHoleDistFromFace)/2.0;
 
-    G4Tubs* holeTubs = new G4Tubs("holeTubs", 0.0, holeRadius, holeHalfLengthZ, startAngle, finalAngle);
+	G4Tubs* holeTubs = new G4Tubs("holeTubs", 0.0, holeRadius, holeHalfLengthZ, startAngle, finalAngle);
 
-    G4ThreeVector moveHole(fGermaniumShift, -(fGermaniumShift),
-                            -((fGermaniumHoleDistFromFace
-                               - fGriffinDeadLayers[det][cry])/2.0)
-                            -(fGriffinDeadLayers[det][cry]/2.0));
+	G4ThreeVector moveHole(fGermaniumShift, -(fGermaniumShift),
+			-((fGermaniumHoleDistFromFace
+					- fGriffinDeadLayers[det][cry])/2.0)
+			-(fGriffinDeadLayers[det][cry]/2.0));
 
-    fGermaniumHoleLog = new G4LogicalVolume(holeTubs, materialVacuum, "germaniumHoleLog", 0, 0, 0);
-    fGermaniumHoleLog->SetVisAttributes(airVisAtt);
+	fGermaniumHoleLog = new G4LogicalVolume(holeTubs, materialVacuum, "germaniumHoleLog", 0, 0, 0);
+	fGermaniumHoleLog->SetVisAttributes(airVisAtt);
 
-    fGermaniumAssemblyCry[cry]->AddPlacedVolume(fGermaniumHoleLog, moveHole, fRotateNull);
+	fGermaniumAssemblyCry[cry]->AddPlacedVolume(fGermaniumHoleLog, moveHole, fRotateNull);
 
 }//end ::ConstructComplexDetectorBlockWithDetectorSpecificDeadLayer
 
@@ -847,48 +847,48 @@ void DetectionSystemGriffin::ConstructComplexDetectorBlockWithDetectorSpecificDe
 ///////////////////////////////////////////////////////////////////////
 void DetectionSystemGriffin::BuildelectrodeMatElectrodes() {
 
-    G4Material* electrodeMat = G4Material::GetMaterial(fElectrodeMaterial);
-    if(!electrodeMat) {
-        G4cout<<" ----> Electrode material "<<fElectrodeMaterial<<" not found, cannot build the detector shell! "<<G4endl;
-        exit(1);
-    }
+	G4Material* electrodeMat = G4Material::GetMaterial(fElectrodeMaterial);
+	if(!electrodeMat) {
+		G4cout<<" ----> Electrode material "<<fElectrodeMaterial<<" not found, cannot build the detector shell! "<<G4endl;
+		exit(1);
+	}
 
-    G4VisAttributes* electrodeMatVisAtt = new G4VisAttributes(G4Colour(1.0,1.0,0.0));
-    electrodeMatVisAtt->SetVisibility(true);
+	G4VisAttributes* electrodeMatVisAtt = new G4VisAttributes(G4Colour(1.0,1.0,0.0));
+	electrodeMatVisAtt->SetVisibility(true);
 
-    // electrodeMat layers between crystals - back part
-    G4RotationMatrix* rotateElectrodeMatBack = new G4RotationMatrix;
-    rotateElectrodeMatBack->rotateZ(M_PI/2.0);
-    G4ThreeVector moveInterCrystalElectrodeMatBack(fGermaniumLength/2.0
-                                                       + fGermaniumBentLength/2.0
-                                                       + fCanFaceThickness/2.0
-                                                       + fGermaniumDistFromCanFace + fShift
-                                                       + fAppliedBackShift, 0,0);
+	// electrodeMat layers between crystals - back part
+	G4RotationMatrix* rotateElectrodeMatBack = new G4RotationMatrix;
+	rotateElectrodeMatBack->rotateZ(M_PI/2.0);
+	G4ThreeVector moveInterCrystalElectrodeMatBack(fGermaniumLength/2.0
+			+ fGermaniumBentLength/2.0
+			+ fCanFaceThickness/2.0
+			+ fGermaniumDistFromCanFace + fShift
+			+ fAppliedBackShift, 0,0);
 
-    G4UnionSolid* interCrystalElectrodeMatBack = InterCrystalelectrodeMatBack();
+	G4UnionSolid* interCrystalElectrodeMatBack = InterCrystalelectrodeMatBack();
 
-    fInterCrystalElectrodeMatBackLog = new G4LogicalVolume(interCrystalElectrodeMatBack,
-                                                              electrodeMat, "interCrystalElectrodeMatBackLog", 0, 0, 0);
-    fInterCrystalElectrodeMatBackLog->SetVisAttributes(electrodeMatVisAtt);
+	fInterCrystalElectrodeMatBackLog = new G4LogicalVolume(interCrystalElectrodeMatBack,
+			electrodeMat, "interCrystalElectrodeMatBackLog", 0, 0, 0);
+	fInterCrystalElectrodeMatBackLog->SetVisAttributes(electrodeMatVisAtt);
 
-	 fAssembly->AddPlacedVolume(fInterCrystalElectrodeMatBackLog, moveInterCrystalElectrodeMatBack, rotateElectrodeMatBack);
+	fAssembly->AddPlacedVolume(fInterCrystalElectrodeMatBackLog, moveInterCrystalElectrodeMatBack, rotateElectrodeMatBack);
 
-    // electrodeMat between crystals - front part
-    G4RotationMatrix* rotateElectrodeMatFront = new G4RotationMatrix;
-    rotateElectrodeMatFront->rotateY(M_PI/2.0);
-    G4UnionSolid* interCrystalElectrodeMatFront = InterCrystalelectrodeMatFront();
+	// electrodeMat between crystals - front part
+	G4RotationMatrix* rotateElectrodeMatFront = new G4RotationMatrix;
+	rotateElectrodeMatFront->rotateY(M_PI/2.0);
+	G4UnionSolid* interCrystalElectrodeMatFront = InterCrystalelectrodeMatFront();
 
-    G4ThreeVector moveInterCrystalElectrodeMatFront(fGermaniumBentLength/2.0
-                                                        + fElectrodeMatStartingDepth/2.0
-                                                        + fCanFaceThickness/2.0
-                                                        + fGermaniumDistFromCanFace + fShift
-                                                        + fAppliedBackShift, 0,0);
+	G4ThreeVector moveInterCrystalElectrodeMatFront(fGermaniumBentLength/2.0
+			+ fElectrodeMatStartingDepth/2.0
+			+ fCanFaceThickness/2.0
+			+ fGermaniumDistFromCanFace + fShift
+			+ fAppliedBackShift, 0,0);
 
-    fInterCrystalElectrodeMatFrontLog = new G4LogicalVolume(interCrystalElectrodeMatFront,
-                                                               electrodeMat, "interCrystalElectrodeMatFrontLog", 0, 0, 0);
-    fInterCrystalElectrodeMatFrontLog->SetVisAttributes(electrodeMatVisAtt);
+	fInterCrystalElectrodeMatFrontLog = new G4LogicalVolume(interCrystalElectrodeMatFront,
+			electrodeMat, "interCrystalElectrodeMatFrontLog", 0, 0, 0);
+	fInterCrystalElectrodeMatFrontLog->SetVisAttributes(electrodeMatVisAtt);
 
-    fAssembly->AddPlacedVolume(fInterCrystalElectrodeMatFrontLog, moveInterCrystalElectrodeMatFront, rotateElectrodeMatFront);
+	fAssembly->AddPlacedVolume(fInterCrystalElectrodeMatFrontLog, moveInterCrystalElectrodeMatFront, rotateElectrodeMatFront);
 }//end ::BuildelectrodeMatElectrodes
 
 ///////////////////////////////////////////////////////////////////////
@@ -898,316 +898,316 @@ void DetectionSystemGriffin::BuildelectrodeMatElectrodes() {
 ///////////////////////////////////////////////////////////////////////
 void DetectionSystemGriffin::ConstructDetector()  {
 
-    G4double x0, y0, z0, yMov, zMov;
-    G4int i;
-    G4RotationMatrix* rotatePiece[4] ;
-    G4ThreeVector movePiece[4] ;
+	G4double x0, y0, z0, yMov, zMov;
+	G4int i;
+	G4RotationMatrix* rotatePiece[4] ;
+	G4ThreeVector movePiece[4] ;
 
-    G4Material* structureMat = G4Material::GetMaterial(fStructureMaterial);
-    if(!structureMat) {
-        G4cout<<" ----> Structure material "<<fStructureMaterial<<" not found, cannot build the detector shell! "<<G4endl;
-        exit(1);
-    }
-    G4Material* liquidN2Material = G4Material::GetMaterial("LiquidN2");
-    if(!liquidN2Material) {
-        G4cout<<" ----> Material LiquidN2 not found, cannot build the detector shell! "<<G4endl;
-        exit(1);
-    }
-    // first we make the can's front face
-    G4Box* frontFace = SquareFrontFace();
-    fFrontFaceLog = new G4LogicalVolume(frontFace, structureMat, "frontFaceLog", 0, 0, 0);
+	G4Material* structureMat = G4Material::GetMaterial(fStructureMaterial);
+	if(!structureMat) {
+		G4cout<<" ----> Structure material "<<fStructureMaterial<<" not found, cannot build the detector shell! "<<G4endl;
+		exit(1);
+	}
+	G4Material* liquidN2Material = G4Material::GetMaterial("LiquidN2");
+	if(!liquidN2Material) {
+		G4cout<<" ----> Material LiquidN2 not found, cannot build the detector shell! "<<G4endl;
+		exit(1);
+	}
+	// first we make the can's front face
+	G4Box* frontFace = SquareFrontFace();
+	fFrontFaceLog = new G4LogicalVolume(frontFace, structureMat, "frontFaceLog", 0, 0, 0);
 
-    G4ThreeVector moveFrontFace(fShift + fAppliedBackShift, 0, 0);
+	G4ThreeVector moveFrontFace(fShift + fAppliedBackShift, 0, 0);
 
-    fAssembly->AddPlacedVolume(fFrontFaceLog, moveFrontFace, fRotateNull);
+	fAssembly->AddPlacedVolume(fFrontFaceLog, moveFrontFace, fRotateNull);
 
-    // now we put on the four angled side pieces
+	// now we put on the four angled side pieces
 
-    x0 = ((fBentEndLength)/2.0) + fShift + fAppliedBackShift ;
+	x0 = ((fBentEndLength)/2.0) + fShift + fAppliedBackShift ;
 
-    z0 = ((fCanFaceThickness - fBentEndLength) * tan(fBentEndAngle)
-          + fDetectorTotalWidth - fCanFaceThickness)/2.0 ;
+	z0 = ((fCanFaceThickness - fBentEndLength) * tan(fBentEndAngle)
+			+ fDetectorTotalWidth - fCanFaceThickness)/2.0 ;
 
-    G4Para* sidePiece[4] ;
-    
-    for(i = 0 ; i < 4 ; i++)
-    {
-        // Top, Right, Bottom, Left
-        sidePiece[i] = BentSidePiece() ;
-        rotatePiece[i] = new G4RotationMatrix ;
+	G4Para* sidePiece[4] ;
 
-        // The left side is slightly different than the others, so this if statement is required. The order of rotation matters.
-        if(i == 3)
-        {
-            rotatePiece[i]->rotateX(-M_PI/2.0 + i*M_PI/2.0) ;
-            rotatePiece[i]->rotateY(fBentEndAngle) ;
-        }
-        else
-        {
-            rotatePiece[i]->rotateY(-fBentEndAngle) ;
-            rotatePiece[i]->rotateX(-M_PI/2.0 + i*M_PI/2.0) ;
-        }
+	for(i = 0 ; i < 4 ; i++)
+	{
+		// Top, Right, Bottom, Left
+		sidePiece[i] = BentSidePiece() ;
+		rotatePiece[i] = new G4RotationMatrix ;
 
-        yMov = z0 * cos(i * M_PI/2.0) ;
-        zMov = z0 * sin(i * M_PI/2.0) ;
+		// The left side is slightly different than the others, so this if statement is required. The order of rotation matters.
+		if(i == 3)
+		{
+			rotatePiece[i]->rotateX(-M_PI/2.0 + i*M_PI/2.0) ;
+			rotatePiece[i]->rotateY(fBentEndAngle) ;
+		}
+		else
+		{
+			rotatePiece[i]->rotateY(-fBentEndAngle) ;
+			rotatePiece[i]->rotateX(-M_PI/2.0 + i*M_PI/2.0) ;
+		}
 
-        movePiece[i] = G4ThreeVector(x0, yMov, zMov) ;
-    }
+		yMov = z0 * cos(i * M_PI/2.0) ;
+		zMov = z0 * sin(i * M_PI/2.0) ;
 
-    fTopBentPieceLog = new G4LogicalVolume(sidePiece[0], structureMat, "topBentPiece", 0, 0, 0);
-    fAssembly->AddPlacedVolume(fTopBentPieceLog, movePiece[0], rotatePiece[0]);
+		movePiece[i] = G4ThreeVector(x0, yMov, zMov) ;
+	}
 
-    fRightBentPieceLog = new G4LogicalVolume(sidePiece[1], structureMat, "rightBentPiece", 0, 0, 0);
-    fAssembly->AddPlacedVolume(fRightBentPieceLog, movePiece[1], rotatePiece[1]);
+	fTopBentPieceLog = new G4LogicalVolume(sidePiece[0], structureMat, "topBentPiece", 0, 0, 0);
+	fAssembly->AddPlacedVolume(fTopBentPieceLog, movePiece[0], rotatePiece[0]);
 
-    fBottomBentPieceLog = new G4LogicalVolume(sidePiece[2], structureMat, "bottomBentPiece", 0, 0, 0);
-    fAssembly->AddPlacedVolume(fBottomBentPieceLog, movePiece[2], rotatePiece[2]);
+	fRightBentPieceLog = new G4LogicalVolume(sidePiece[1], structureMat, "rightBentPiece", 0, 0, 0);
+	fAssembly->AddPlacedVolume(fRightBentPieceLog, movePiece[1], rotatePiece[1]);
 
-    fLeftBentPieceLog = new G4LogicalVolume(sidePiece[3], structureMat, "leftBentPiece", 0, 0, 0);
-    fAssembly->AddPlacedVolume(fRightBentPieceLog, movePiece[3], rotatePiece[3]);
+	fBottomBentPieceLog = new G4LogicalVolume(sidePiece[2], structureMat, "bottomBentPiece", 0, 0, 0);
+	fAssembly->AddPlacedVolume(fBottomBentPieceLog, movePiece[2], rotatePiece[2]);
 
+	fLeftBentPieceLog = new G4LogicalVolume(sidePiece[3], structureMat, "leftBentPiece", 0, 0, 0);
+	fAssembly->AddPlacedVolume(fRightBentPieceLog, movePiece[3], rotatePiece[3]);
 
-    //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-    // now we add the wedges to the edges of the face. These complete the angled side pieces
-    G4Trap* sideWedge[4] ;
+	//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-    x0 = fShift +fAppliedBackShift ;
+	// now we add the wedges to the edges of the face. These complete the angled side pieces
+	G4Trap* sideWedge[4] ;
 
-    y0 = (fDetectorTotalWidth/2.0) - (fBentEndLength * tan(fBentEndAngle))
-            + (fCanFaceThickness/2.0) *tan(fBentEndAngle)/2.0 ;
+	x0 = fShift +fAppliedBackShift ;
 
-    for(i = 0 ; i < 4 ; i++) {
-        // Top, Right, Bottom, Left
-        sideWedge[i] = CornerWedge() ;
-        rotatePiece[i] = new G4RotationMatrix ;
+	y0 = (fDetectorTotalWidth/2.0) - (fBentEndLength * tan(fBentEndAngle))
+		+ (fCanFaceThickness/2.0) *tan(fBentEndAngle)/2.0 ;
 
-        rotatePiece[i]->rotateX(M_PI/2.0) ;
-        rotatePiece[i]->rotateY(-M_PI/2.0) ;
-        rotatePiece[i]->rotateX(-M_PI/2.0 + i*M_PI/2.0) ;
+	for(i = 0 ; i < 4 ; i++) {
+		// Top, Right, Bottom, Left
+		sideWedge[i] = CornerWedge() ;
+		rotatePiece[i] = new G4RotationMatrix ;
 
-        yMov = y0 * cos(i*M_PI/2.0) ;
-        zMov = y0 * sin(i*M_PI/2.0) ;
+		rotatePiece[i]->rotateX(M_PI/2.0) ;
+		rotatePiece[i]->rotateY(-M_PI/2.0) ;
+		rotatePiece[i]->rotateX(-M_PI/2.0 + i*M_PI/2.0) ;
 
-        movePiece[i] = G4ThreeVector(x0, yMov, zMov) ;
-    }
+		yMov = y0 * cos(i*M_PI/2.0) ;
+		zMov = y0 * sin(i*M_PI/2.0) ;
 
-    fTopWedgeLog = new G4LogicalVolume(sideWedge[0], structureMat, "topWedgeLog", 0, 0, 0);
-    fAssembly->AddPlacedVolume(fTopWedgeLog, movePiece[0], rotatePiece[0]);
+		movePiece[i] = G4ThreeVector(x0, yMov, zMov) ;
+	}
 
-    fRightWedgeLog = new G4LogicalVolume(sideWedge[1], structureMat, "rightWedgeLog", 0, 0, 0);
-    fAssembly->AddPlacedVolume(fRightWedgeLog, movePiece[1], rotatePiece[1]);
+	fTopWedgeLog = new G4LogicalVolume(sideWedge[0], structureMat, "topWedgeLog", 0, 0, 0);
+	fAssembly->AddPlacedVolume(fTopWedgeLog, movePiece[0], rotatePiece[0]);
 
-    fBottomWedgeLog = new G4LogicalVolume(sideWedge[2], structureMat, "bottomWedgeLog", 0, 0, 0);
-    fAssembly->AddPlacedVolume(fBottomWedgeLog, movePiece[2], rotatePiece[2]);
+	fRightWedgeLog = new G4LogicalVolume(sideWedge[1], structureMat, "rightWedgeLog", 0, 0, 0);
+	fAssembly->AddPlacedVolume(fRightWedgeLog, movePiece[1], rotatePiece[1]);
 
-    fLeftWedgeLog = new G4LogicalVolume(sideWedge[3], structureMat, "leftWedgeLog", 0, 0, 0);
-    fAssembly->AddPlacedVolume(fLeftWedgeLog, movePiece[3], rotatePiece[3]);
+	fBottomWedgeLog = new G4LogicalVolume(sideWedge[2], structureMat, "bottomWedgeLog", 0, 0, 0);
+	fAssembly->AddPlacedVolume(fBottomWedgeLog, movePiece[2], rotatePiece[2]);
 
+	fLeftWedgeLog = new G4LogicalVolume(sideWedge[3], structureMat, "leftWedgeLog", 0, 0, 0);
+	fAssembly->AddPlacedVolume(fLeftWedgeLog, movePiece[3], rotatePiece[3]);
 
-    //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-    // now we add the rounded corners, made from a quarter of a cone
+	//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-    // Correction factor used to move the corner cones so as to avoid
-    // holes left in the can caused by the bent side pieces
+	// now we add the rounded corners, made from a quarter of a cone
 
-    G4double holeEliminator = fCanFaceThickness *(1.0 -tan(fBentEndAngle));
-    G4Cons* coneLocation[4] ;
+	// Correction factor used to move the corner cones so as to avoid
+	// holes left in the can caused by the bent side pieces
 
-    x0 = fBentEndLength/2.0 + fShift + fAppliedBackShift ;
+	G4double holeEliminator = fCanFaceThickness *(1.0 -tan(fBentEndAngle));
+	G4Cons* coneLocation[4] ;
 
-    y0 = (fDetectorTotalWidth/2.0) - (fBentEndLength * tan(fBentEndAngle)) - holeEliminator ;
+	x0 = fBentEndLength/2.0 + fShift + fAppliedBackShift ;
 
-    for(i = 0 ; i < 4 ; i++)
-    {
-        // Lower Left, Upper Left, Upper Right, Lower Right
-        coneLocation[i] = RoundedEndEdge() ;
-        rotatePiece[i] = new G4RotationMatrix ;
+	y0 = (fDetectorTotalWidth/2.0) - (fBentEndLength * tan(fBentEndAngle)) - holeEliminator ;
 
-        rotatePiece[i]->rotateY(M_PI/2.0) ;
-        rotatePiece[i]->rotateX(-M_PI/2.0 + i*M_PI/2.0) ;
+	for(i = 0 ; i < 4 ; i++)
+	{
+		// Lower Left, Upper Left, Upper Right, Lower Right
+		coneLocation[i] = RoundedEndEdge() ;
+		rotatePiece[i] = new G4RotationMatrix ;
 
-        yMov = y0 * (-cos(i*M_PI/2.0) + sin(i*M_PI/2.0)) ;
-        zMov = y0 * (-cos(i*M_PI/2.0) - sin(i*M_PI/2.0)) ;
+		rotatePiece[i]->rotateY(M_PI/2.0) ;
+		rotatePiece[i]->rotateX(-M_PI/2.0 + i*M_PI/2.0) ;
 
-        movePiece[i] = G4ThreeVector(x0, yMov, zMov) ;
-    }
+		yMov = y0 * (-cos(i*M_PI/2.0) + sin(i*M_PI/2.0)) ;
+		zMov = y0 * (-cos(i*M_PI/2.0) - sin(i*M_PI/2.0)) ;
 
-    fLowerLeftConeLog = new G4LogicalVolume(coneLocation[0], structureMat, "lowerLeftConeLog", 0, 0, 0);
-    fAssembly->AddPlacedVolume(fLowerLeftConeLog, movePiece[0],  rotatePiece[0]);
+		movePiece[i] = G4ThreeVector(x0, yMov, zMov) ;
+	}
 
-    fUpperLeftConeLog = new G4LogicalVolume(coneLocation[1], structureMat, "upperLeftConeLog", 0, 0, 0);
-    fAssembly->AddPlacedVolume(fUpperLeftConeLog, movePiece[1], rotatePiece[1]);
+	fLowerLeftConeLog = new G4LogicalVolume(coneLocation[0], structureMat, "lowerLeftConeLog", 0, 0, 0);
+	fAssembly->AddPlacedVolume(fLowerLeftConeLog, movePiece[0],  rotatePiece[0]);
 
-    fUpperRightConeLog = new G4LogicalVolume(coneLocation[2], structureMat, "upperRightConeLog", 0, 0, 0);
-    fAssembly->AddPlacedVolume(fUpperRightConeLog, movePiece[2], rotatePiece[2]);
+	fUpperLeftConeLog = new G4LogicalVolume(coneLocation[1], structureMat, "upperLeftConeLog", 0, 0, 0);
+	fAssembly->AddPlacedVolume(fUpperLeftConeLog, movePiece[1], rotatePiece[1]);
 
-    fLowerRightConeLog = new G4LogicalVolume(coneLocation[3], structureMat, "lowerRightConeLog", 0, 0, 0);
-    fAssembly->AddPlacedVolume(fLowerRightConeLog, movePiece[3], rotatePiece[3]);
+	fUpperRightConeLog = new G4LogicalVolume(coneLocation[2], structureMat, "upperRightConeLog", 0, 0, 0);
+	fAssembly->AddPlacedVolume(fUpperRightConeLog, movePiece[2], rotatePiece[2]);
 
+	fLowerRightConeLog = new G4LogicalVolume(coneLocation[3], structureMat, "lowerRightConeLog", 0, 0, 0);
+	fAssembly->AddPlacedVolume(fLowerRightConeLog, movePiece[3], rotatePiece[3]);
 
-    //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-    /* now we add the corner tubes which extend the rounded corners to the back of the can
-  *
-  * This is extremely similar to the previous loop but they are not exactly the same. While it would be
-  * possible to consolidate them into one, they would only share the rotation variables, so it
-  * might not be a huge benefit.
-  */
+	//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-    G4Tubs* tubeLocation[4] ;
+	/* now we add the corner tubes which extend the rounded corners to the back of the can
+	 *
+	 * This is extremely similar to the previous loop but they are not exactly the same. While it would be
+	 * possible to consolidate them into one, they would only share the rotation variables, so it
+	 * might not be a huge benefit.
+	 */
 
-    x0 = (fDetectorTotalLength +fBentEndLength
-          - fRearPlateThickness -fCanFaceThickness)/2.0
-            + fShift +fAppliedBackShift ;
+	G4Tubs* tubeLocation[4] ;
 
-    y0 = (fDetectorTotalWidth/2.0) - (fBentEndLength * tan(fBentEndAngle)) ;
+	x0 = (fDetectorTotalLength +fBentEndLength
+			- fRearPlateThickness -fCanFaceThickness)/2.0
+		+ fShift +fAppliedBackShift ;
 
-    for(i = 0 ; i < 4 ; i++)
-    {
-        // Lower Left, Upper Left, Upper Right, Lower Right
-        tubeLocation[i] = CornerTube() ;
-        rotatePiece[i] = new G4RotationMatrix ;
-        rotatePiece[i]->rotateY(M_PI/2.0) ;
-        rotatePiece[i]->rotateX(-M_PI/2.0 + i*M_PI/2.0) ;
+	y0 = (fDetectorTotalWidth/2.0) - (fBentEndLength * tan(fBentEndAngle)) ;
 
-        yMov = y0 * (-cos(i*M_PI/2.0) + sin(i*M_PI/2.0)) ;
-        zMov = y0 * (-cos(i*M_PI/2.0) - sin(i*M_PI/2.0)) ;
+	for(i = 0 ; i < 4 ; i++)
+	{
+		// Lower Left, Upper Left, Upper Right, Lower Right
+		tubeLocation[i] = CornerTube() ;
+		rotatePiece[i] = new G4RotationMatrix ;
+		rotatePiece[i]->rotateY(M_PI/2.0) ;
+		rotatePiece[i]->rotateX(-M_PI/2.0 + i*M_PI/2.0) ;
 
-        movePiece[i] = G4ThreeVector(x0, yMov, zMov) ;
+		yMov = y0 * (-cos(i*M_PI/2.0) + sin(i*M_PI/2.0)) ;
+		zMov = y0 * (-cos(i*M_PI/2.0) - sin(i*M_PI/2.0)) ;
 
-    }
+		movePiece[i] = G4ThreeVector(x0, yMov, zMov) ;
 
-    fLowerLeftTubeLog = new G4LogicalVolume(tubeLocation[0], structureMat, "lowerLeftTubeLog", 0, 0, 0);
-    fAssembly->AddPlacedVolume(fLowerLeftTubeLog, movePiece[0], rotatePiece[0]);
+	}
 
-    fUpperLeftTubeLog = new G4LogicalVolume(tubeLocation[1], structureMat, "upperLeftTubeLog", 0, 0, 0);
-    fAssembly->AddPlacedVolume(fUpperLeftTubeLog, movePiece[1], rotatePiece[1]);
+	fLowerLeftTubeLog = new G4LogicalVolume(tubeLocation[0], structureMat, "lowerLeftTubeLog", 0, 0, 0);
+	fAssembly->AddPlacedVolume(fLowerLeftTubeLog, movePiece[0], rotatePiece[0]);
 
-    fUpperRightTubeLog = new G4LogicalVolume(tubeLocation[2], structureMat, "upperRightTubeLog", 0, 0, 0);
-    fAssembly->AddPlacedVolume(fUpperRightTubeLog, movePiece[2], rotatePiece[2]);
+	fUpperLeftTubeLog = new G4LogicalVolume(tubeLocation[1], structureMat, "upperLeftTubeLog", 0, 0, 0);
+	fAssembly->AddPlacedVolume(fUpperLeftTubeLog, movePiece[1], rotatePiece[1]);
 
-    fLowerRightTubeLog = new G4LogicalVolume(tubeLocation[3], structureMat, "lowerRightTubeLog", 0, 0, 0);
-    fAssembly->AddPlacedVolume(fLowerRightTubeLog, movePiece[3], rotatePiece[3]);
+	fUpperRightTubeLog = new G4LogicalVolume(tubeLocation[2], structureMat, "upperRightTubeLog", 0, 0, 0);
+	fAssembly->AddPlacedVolume(fUpperRightTubeLog, movePiece[2], rotatePiece[2]);
 
+	fLowerRightTubeLog = new G4LogicalVolume(tubeLocation[3], structureMat, "lowerRightTubeLog", 0, 0, 0);
+	fAssembly->AddPlacedVolume(fLowerRightTubeLog, movePiece[3], rotatePiece[3]);
 
-    //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-    // now we add the side panels that extend from the bent pieces to the back of the can
+	//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+	// now we add the side panels that extend from the bent pieces to the back of the can
 
-    G4Box* panelLocation[4] ;
 
-    x0 = (fDetectorTotalLength + fBentEndLength - fRearPlateThickness - fCanFaceThickness)/2.0
-            + fShift + fAppliedBackShift ;
+	G4Box* panelLocation[4] ;
 
-    y0 = 0 ;
+	x0 = (fDetectorTotalLength + fBentEndLength - fRearPlateThickness - fCanFaceThickness)/2.0
+		+ fShift + fAppliedBackShift ;
 
-    z0 = (fDetectorTotalWidth - fCanSideThickness)/2.0 ;
+	y0 = 0 ;
 
-    for(i = 0 ; i < 4 ; i++)
-    {
-        // Right, Top, Left, Bottom
-        panelLocation[i] = SidePanel() ;
-        rotatePiece[i] = new G4RotationMatrix ;
-        rotatePiece[i]->rotateX(M_PI/2.0 - i*M_PI/2.0) ;
+	z0 = (fDetectorTotalWidth - fCanSideThickness)/2.0 ;
 
-        yMov = z0*sin(i*M_PI/2.0) ;
-        zMov = z0*cos(i*M_PI/2.0) ;
+	for(i = 0 ; i < 4 ; i++)
+	{
+		// Right, Top, Left, Bottom
+		panelLocation[i] = SidePanel() ;
+		rotatePiece[i] = new G4RotationMatrix ;
+		rotatePiece[i]->rotateX(M_PI/2.0 - i*M_PI/2.0) ;
 
-        movePiece[i] = G4ThreeVector(x0, yMov, zMov) ;
+		yMov = z0*sin(i*M_PI/2.0) ;
+		zMov = z0*cos(i*M_PI/2.0) ;
 
-    }
+		movePiece[i] = G4ThreeVector(x0, yMov, zMov) ;
 
-    fRightSidePanelLog = new G4LogicalVolume(panelLocation[0], structureMat, "rightSidePanelLog", 0, 0, 0);
-    fAssembly->AddPlacedVolume(fRightSidePanelLog, movePiece[0], rotatePiece[0]);
+	}
 
-    fTopSidePanelLog = new G4LogicalVolume(panelLocation[1], structureMat, "topSidePanelLog", 0, 0, 0);
-    fAssembly->AddPlacedVolume(fTopSidePanelLog, movePiece[1], fRotateNull);
+	fRightSidePanelLog = new G4LogicalVolume(panelLocation[0], structureMat, "rightSidePanelLog", 0, 0, 0);
+	fAssembly->AddPlacedVolume(fRightSidePanelLog, movePiece[0], rotatePiece[0]);
 
-    fLeftSidePanelLog = new G4LogicalVolume(panelLocation[2], structureMat, "leftSidePanelLog", 0, 0, 0);
-    fAssembly->AddPlacedVolume(fLeftSidePanelLog, movePiece[2], rotatePiece[2]);
+	fTopSidePanelLog = new G4LogicalVolume(panelLocation[1], structureMat, "topSidePanelLog", 0, 0, 0);
+	fAssembly->AddPlacedVolume(fTopSidePanelLog, movePiece[1], fRotateNull);
 
-    fBottomSidePanelLog = new G4LogicalVolume(panelLocation[3], structureMat, "bottomSidePanelLog", 0, 0, 0);
-    fAssembly->AddPlacedVolume(fBottomSidePanelLog, movePiece[3], rotatePiece[3]);
+	fLeftSidePanelLog = new G4LogicalVolume(panelLocation[2], structureMat, "leftSidePanelLog", 0, 0, 0);
+	fAssembly->AddPlacedVolume(fLeftSidePanelLog, movePiece[2], rotatePiece[2]);
 
-    //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+	fBottomSidePanelLog = new G4LogicalVolume(panelLocation[3], structureMat, "bottomSidePanelLog", 0, 0, 0);
+	fAssembly->AddPlacedVolume(fBottomSidePanelLog, movePiece[3], rotatePiece[3]);
 
-    // now we add the rear plate, which has a hole for the cold finger to pass through
-    G4SubtractionSolid* rearPlate = RearPlate();
+	//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-    G4RotationMatrix* rotateRearPlate = new G4RotationMatrix;
-    rotateRearPlate->rotateY(M_PI/2.0);
+	// now we add the rear plate, which has a hole for the cold finger to pass through
+	G4SubtractionSolid* rearPlate = RearPlate();
 
-    x0 = fDetectorTotalLength -fCanFaceThickness/2.0
-            - fRearPlateThickness/2.0 +fShift
-            + fAppliedBackShift ;
+	G4RotationMatrix* rotateRearPlate = new G4RotationMatrix;
+	rotateRearPlate->rotateY(M_PI/2.0);
 
-    G4ThreeVector moveRearPlate(fDetectorTotalLength -fCanFaceThickness/2.0
-                                  - fRearPlateThickness/2.0 +fShift
-                                  + fAppliedBackShift, 0, 0);
+	x0 = fDetectorTotalLength -fCanFaceThickness/2.0
+		- fRearPlateThickness/2.0 +fShift
+		+ fAppliedBackShift ;
 
-    fRearPlateLog = new G4LogicalVolume(rearPlate, structureMat, "rearPlateLog", 0, 0, 0);
+	G4ThreeVector moveRearPlate(fDetectorTotalLength -fCanFaceThickness/2.0
+			- fRearPlateThickness/2.0 +fShift
+			+ fAppliedBackShift, 0, 0);
 
-    fAssembly->AddPlacedVolume(fRearPlateLog, moveRearPlate, rotateRearPlate);
+	fRearPlateLog = new G4LogicalVolume(rearPlate, structureMat, "rearPlateLog", 0, 0, 0);
 
-    // we know add the cold finger shell, which extends out the back of the can
-    G4Tubs* fingerShell = ColdFingerShell();
+	fAssembly->AddPlacedVolume(fRearPlateLog, moveRearPlate, rotateRearPlate);
 
-    G4RotationMatrix* rotateFingerShell = new G4RotationMatrix;
-    rotateFingerShell->rotateY(M_PI/2.0);
+	// we know add the cold finger shell, which extends out the back of the can
+	G4Tubs* fingerShell = ColdFingerShell();
 
-    G4ThreeVector moveFingerShell(fColdFingerShellLength/2.0 -fCanFaceThickness/2.0
-                                    + fDetectorTotalLength +fShift
-                                    + fAppliedBackShift, 0, 0);
+	G4RotationMatrix* rotateFingerShell = new G4RotationMatrix;
+	rotateFingerShell->rotateY(M_PI/2.0);
 
-    fFingerShellLog = new G4LogicalVolume(fingerShell, structureMat, "fingerShellLog", 0, 0, 0);
+	G4ThreeVector moveFingerShell(fColdFingerShellLength/2.0 -fCanFaceThickness/2.0
+			+ fDetectorTotalLength +fShift
+			+ fAppliedBackShift, 0, 0);
 
-    fAssembly->AddPlacedVolume(fFingerShellLog, moveFingerShell, rotateFingerShell);
+	fFingerShellLog = new G4LogicalVolume(fingerShell, structureMat, "fingerShellLog", 0, 0, 0);
 
-    // lastly we add the liquid nitrogen tank at the back, past the cold finger shell
-    G4Tubs* tank = LiquidNitrogenTank();
+	fAssembly->AddPlacedVolume(fFingerShellLog, moveFingerShell, rotateFingerShell);
 
-    G4RotationMatrix* rotateTank = new G4RotationMatrix;
-    rotateTank->rotateY(M_PI/2.0);
+	// lastly we add the liquid nitrogen tank at the back, past the cold finger shell
+	G4Tubs* tank = LiquidNitrogenTank();
 
-    G4ThreeVector moveTank((fCoolantLength -fCanFaceThickness)/2.0 + fDetectorTotalLength
-                            + fColdFingerShellLength + fShift +fAppliedBackShift, 0, 0);
+	G4RotationMatrix* rotateTank = new G4RotationMatrix;
+	rotateTank->rotateY(M_PI/2.0);
 
-    fTankLog = new G4LogicalVolume(tank, structureMat, "tankLog", 0, 0, 0);
+	G4ThreeVector moveTank((fCoolantLength -fCanFaceThickness)/2.0 + fDetectorTotalLength
+			+ fColdFingerShellLength + fShift +fAppliedBackShift, 0, 0);
 
-    fAssembly->AddPlacedVolume(fTankLog, moveTank, rotateTank);
+	fTankLog = new G4LogicalVolume(tank, structureMat, "tankLog", 0, 0, 0);
 
-    // lids
-    G4Tubs* lid = LiquidNitrogenTankLid();
+	fAssembly->AddPlacedVolume(fTankLog, moveTank, rotateTank);
 
-    G4RotationMatrix* rotateLid = new G4RotationMatrix;
-    rotateLid->rotateY(M_PI/2.0);
+	// lids
+	G4Tubs* lid = LiquidNitrogenTankLid();
 
-    G4ThreeVector moveLid1(fCoolantLength/2.0 - fCoolantThickness/2.0 + (fCoolantLength -fCanFaceThickness)/2.0 + fDetectorTotalLength
-                            + fColdFingerShellLength + fShift +fAppliedBackShift, 0, 0);
-    G4ThreeVector moveLid2(-1.0*fCoolantLength/2.0 + fCoolantThickness/2.0 + (fCoolantLength -fCanFaceThickness)/2.0 + fDetectorTotalLength
-                            + fColdFingerShellLength + fShift +fAppliedBackShift, 0, 0);
+	G4RotationMatrix* rotateLid = new G4RotationMatrix;
+	rotateLid->rotateY(M_PI/2.0);
 
-    fTankLid1Log = new G4LogicalVolume(lid, structureMat, "tankLid1Log", 0, 0, 0);
-    fTankLid2Log = new G4LogicalVolume(lid, structureMat, "tankLid2Log", 0, 0, 0);
+	G4ThreeVector moveLid1(fCoolantLength/2.0 - fCoolantThickness/2.0 + (fCoolantLength -fCanFaceThickness)/2.0 + fDetectorTotalLength
+			+ fColdFingerShellLength + fShift +fAppliedBackShift, 0, 0);
+	G4ThreeVector moveLid2(-1.0*fCoolantLength/2.0 + fCoolantThickness/2.0 + (fCoolantLength -fCanFaceThickness)/2.0 + fDetectorTotalLength
+			+ fColdFingerShellLength + fShift +fAppliedBackShift, 0, 0);
 
-    fAssembly->AddPlacedVolume(fTankLid1Log, moveLid1, rotateLid);
-    fAssembly->AddPlacedVolume(fTankLid2Log, moveLid2, rotateLid);
+	fTankLid1Log = new G4LogicalVolume(lid, structureMat, "tankLid1Log", 0, 0, 0);
+	fTankLid2Log = new G4LogicalVolume(lid, structureMat, "tankLid2Log", 0, 0, 0);
 
-    // LN2
-    G4Tubs* liquidn2 = LiquidNitrogen();
+	fAssembly->AddPlacedVolume(fTankLid1Log, moveLid1, rotateLid);
+	fAssembly->AddPlacedVolume(fTankLid2Log, moveLid2, rotateLid);
 
-    G4RotationMatrix* rotateLiquidn2 = new G4RotationMatrix;
-    rotateLiquidn2->rotateY(M_PI/2.0);
+	// LN2
+	G4Tubs* liquidn2 = LiquidNitrogen();
 
-    G4ThreeVector moveLiquidn2((fCoolantLength -fCanFaceThickness)/2.0 + fDetectorTotalLength
-                            + fColdFingerShellLength + fShift +fAppliedBackShift, 0, 0);
+	G4RotationMatrix* rotateLiquidn2 = new G4RotationMatrix;
+	rotateLiquidn2->rotateY(M_PI/2.0);
 
-    fTankLiquidLog = new G4LogicalVolume(liquidn2, liquidN2Material, "tankLiquidLog", 0, 0, 0);
+	G4ThreeVector moveLiquidn2((fCoolantLength -fCanFaceThickness)/2.0 + fDetectorTotalLength
+			+ fColdFingerShellLength + fShift +fAppliedBackShift, 0, 0);
 
-    fAssembly->AddPlacedVolume(fTankLiquidLog, moveLiquidn2, rotateLiquidn2);
+	fTankLiquidLog = new G4LogicalVolume(liquidn2, liquidN2Material, "tankLiquidLog", 0, 0, 0);
+
+	fAssembly->AddPlacedVolume(fTankLiquidLog, moveLiquidn2, rotateLiquidn2);
 }// end::ConstructDetector
 
 ///////////////////////////////////////////////////////////////////////
@@ -1219,429 +1219,429 @@ void DetectionSystemGriffin::ConstructDetector()  {
 ///////////////////////////////////////////////////////////////////////
 void DetectionSystemGriffin::ConstructColdFinger() {
 
-    G4Material* materialAir = G4Material::GetMaterial("Air");
-    if(!materialAir) {
-        G4cout<<" ----> Material Air not found, cannot build the detector shell! "<<G4endl;
-        exit(1);
-    }
-    G4Material* structureMat = G4Material::GetMaterial(fStructureMaterial);
-    if(!structureMat) {
-        G4cout<<" ----> Structure material "<<fStructureMaterial<<" not found, cannot build the detector shell! "<<G4endl;
-        exit(1);
-    }
-    G4Material* electrodeMat = G4Material::GetMaterial(fElectrodeMaterial);
-    if(!electrodeMat) {
-        G4cout<<" ----> Electrode material "<<fElectrodeMaterial<<" not found, cannot build the detector shell! "<<G4endl;
-        exit(1);
-    }
+	G4Material* materialAir = G4Material::GetMaterial("Air");
+	if(!materialAir) {
+		G4cout<<" ----> Material Air not found, cannot build the detector shell! "<<G4endl;
+		exit(1);
+	}
+	G4Material* structureMat = G4Material::GetMaterial(fStructureMaterial);
+	if(!structureMat) {
+		G4cout<<" ----> Structure material "<<fStructureMaterial<<" not found, cannot build the detector shell! "<<G4endl;
+		exit(1);
+	}
+	G4Material* electrodeMat = G4Material::GetMaterial(fElectrodeMaterial);
+	if(!electrodeMat) {
+		G4cout<<" ----> Electrode material "<<fElectrodeMaterial<<" not found, cannot build the detector shell! "<<G4endl;
+		exit(1);
+	}
 
-    G4VisAttributes* coldFingerVisAtt = new G4VisAttributes(G4Colour(0.0,0.0,1.0));
-    coldFingerVisAtt->SetVisibility(true);
+	G4VisAttributes* coldFingerVisAtt = new G4VisAttributes(G4Colour(0.0,0.0,1.0));
+	coldFingerVisAtt->SetVisibility(true);
 
-    G4VisAttributes* structureMatVisAtt = new G4VisAttributes(G4Colour(1.0,1.0,1.0));
-    structureMatVisAtt->SetVisibility(true);
+	G4VisAttributes* structureMatVisAtt = new G4VisAttributes(G4Colour(1.0,1.0,1.0));
+	structureMatVisAtt->SetVisibility(true);
 
-    G4VisAttributes* airVisAtt = new G4VisAttributes(G4Colour(0.8,0.8,0.8));
-    airVisAtt->SetVisibility(true);
+	G4VisAttributes* airVisAtt = new G4VisAttributes(G4Colour(0.8,0.8,0.8));
+	airVisAtt->SetVisibility(true);
 
-    G4Box* endPlate = EndPlate();
+	G4Box* endPlate = EndPlate();
 
-    // cut out holes
-    G4double airHoleDistance = fGermaniumSeparation/2.0
-            + (fGermaniumWidth/2.0 - fGermaniumShift); //centre of the middle hole
+	// cut out holes
+	G4double airHoleDistance = fGermaniumSeparation/2.0
+		+ (fGermaniumWidth/2.0 - fGermaniumShift); //centre of the middle hole
 
-    G4RotationMatrix* rotateFetAirHole = new G4RotationMatrix;
-    rotateFetAirHole->rotateY(M_PI/2.0);
+	G4RotationMatrix* rotateFetAirHole = new G4RotationMatrix;
+	rotateFetAirHole->rotateY(M_PI/2.0);
 
-    G4Tubs* fetAirHoleCut = AirHoleCut();
+	G4Tubs* fetAirHoleCut = AirHoleCut();
 
-    G4ThreeVector movePiece[8] ;
-    G4SubtractionSolid* endPlateCut[8] ;
-    G4int i ;
-    G4double x, y, z, y0, z0, y01, y02;
+	G4ThreeVector movePiece[8] ;
+	G4SubtractionSolid* endPlateCut[8] ;
+	G4int i ;
+	G4double x, y, z, y0, z0, y01, y02;
 
-    y0 = airHoleDistance ;
-    z0 = airHoleDistance ;
+	y0 = airHoleDistance ;
+	z0 = airHoleDistance ;
 
-    for(i = 0 ; i < 4 ; i++)
-    {
-        y = y0 * (-cos(i*M_PI/2.0) + sin(i*M_PI/2.0)) ;
-        z = z0 * (cos(i*M_PI/2.0) + sin(i*M_PI/2.0)) ;
-        movePiece[i] = G4ThreeVector(0 , y, z) ;
+	for(i = 0 ; i < 4 ; i++)
+	{
+		y = y0 * (-cos(i*M_PI/2.0) + sin(i*M_PI/2.0)) ;
+		z = z0 * (cos(i*M_PI/2.0) + sin(i*M_PI/2.0)) ;
+		movePiece[i] = G4ThreeVector(0 , y, z) ;
 
-        if(i == 0)
-            // Slightly different than the rest. Sorry I couldnt think of a better workaround
-            endPlateCut[i] = new G4SubtractionSolid("endPlateCut", endPlate, fetAirHoleCut, rotateFetAirHole, movePiece[i]) ;
-        else
-            endPlateCut[i] = new G4SubtractionSolid("endPlateCut", endPlateCut[i-1], fetAirHoleCut, rotateFetAirHole, movePiece[i]) ;
-    }
+		if(i == 0)
+			// Slightly different than the rest. Sorry I couldnt think of a better workaround
+			endPlateCut[i] = new G4SubtractionSolid("endPlateCut", endPlate, fetAirHoleCut, rotateFetAirHole, movePiece[i]) ;
+		else
+			endPlateCut[i] = new G4SubtractionSolid("endPlateCut", endPlateCut[i-1], fetAirHoleCut, rotateFetAirHole, movePiece[i]) ;
+	}
 
-    x = fColdFingerEndPlateThickness/2.0 +fCanFaceThickness/2.0
-            + fGermaniumDistFromCanFace +fGermaniumLength
-            + fColdFingerSpace +fShift +fAppliedBackShift ;
-    
-    G4ThreeVector moveEndPlate(x, 0, 0) ;
+	x = fColdFingerEndPlateThickness/2.0 +fCanFaceThickness/2.0
+		+ fGermaniumDistFromCanFace +fGermaniumLength
+		+ fColdFingerSpace +fShift +fAppliedBackShift ;
 
+	G4ThreeVector moveEndPlate(x, 0, 0) ;
 
 
-    // Fix overlap.
 
-    G4double cutTubeY0, cutYMov, cutZMov;
-    G4RotationMatrix* cutRotatePiece[4] ;
-    G4ThreeVector cutMovePiece[4] ;
-    G4Tubs* cutTubeLocation[4] ;
+	// Fix overlap.
 
-    cutTubeY0 = (fDetectorTotalWidth/2.0) - (fBentEndLength * tan(fBentEndAngle)) ;
+	G4double cutTubeY0, cutYMov, cutZMov;
+	G4RotationMatrix* cutRotatePiece[4] ;
+	G4ThreeVector cutMovePiece[4] ;
+	G4Tubs* cutTubeLocation[4] ;
 
-    for(i = 0 ; i < 4 ; i++)
-    {
-        // Lower Left, Upper Left, Upper Right, Lower Right
-        cutTubeLocation[i] = CornerTube() ;
-        cutRotatePiece[i] = new G4RotationMatrix ;
-        cutRotatePiece[i]->rotateY(M_PI/2.0) ;
-        cutRotatePiece[i]->rotateZ(-M_PI/2.0 + (i-1)*M_PI/2.0) ;
+	cutTubeY0 = (fDetectorTotalWidth/2.0) - (fBentEndLength * tan(fBentEndAngle)) ;
 
-        //cutRotatePiece[i]->rotateX(-M_PI/2.0 + i*M_PI/2.0) ;
+	for(i = 0 ; i < 4 ; i++)
+	{
+		// Lower Left, Upper Left, Upper Right, Lower Right
+		cutTubeLocation[i] = CornerTube() ;
+		cutRotatePiece[i] = new G4RotationMatrix ;
+		cutRotatePiece[i]->rotateY(M_PI/2.0) ;
+		cutRotatePiece[i]->rotateZ(-M_PI/2.0 + (i-1)*M_PI/2.0) ;
 
-        cutYMov = cutTubeY0 * (-cos(i*M_PI/2.0) + sin(i*M_PI/2.0)) ;
-        cutZMov = cutTubeY0 * (-cos(i*M_PI/2.0) - sin(i*M_PI/2.0)) ;
+		//cutRotatePiece[i]->rotateX(-M_PI/2.0 + i*M_PI/2.0) ;
 
-        cutMovePiece[i] = G4ThreeVector(0, cutYMov, cutZMov) ;
+		cutYMov = cutTubeY0 * (-cos(i*M_PI/2.0) + sin(i*M_PI/2.0)) ;
+		cutZMov = cutTubeY0 * (-cos(i*M_PI/2.0) - sin(i*M_PI/2.0)) ;
 
-        endPlateCut[i+4] = new G4SubtractionSolid("endPlateCut", endPlateCut[i+3], cutTubeLocation[i], cutRotatePiece[i], cutMovePiece[i]) ;
-    }
+		cutMovePiece[i] = G4ThreeVector(0, cutYMov, cutZMov) ;
 
-    fEndPlateLog = new G4LogicalVolume(endPlateCut[7], structureMat, "endPlateLog", 0, 0, 0);
+		endPlateCut[i+4] = new G4SubtractionSolid("endPlateCut", endPlateCut[i+3], cutTubeLocation[i], cutRotatePiece[i], cutMovePiece[i]) ;
+	}
 
-    fEndPlateLog->SetVisAttributes(structureMatVisAtt);
+	fEndPlateLog = new G4LogicalVolume(endPlateCut[7], structureMat, "endPlateLog", 0, 0, 0);
 
-    fAssembly->AddPlacedVolume(fEndPlateLog, moveEndPlate, 0);
+	fEndPlateLog->SetVisAttributes(structureMatVisAtt);
 
-    // Place holes in the old cold plate
-    G4Tubs* fetAirHole = AirHole();
+	fAssembly->AddPlacedVolume(fEndPlateLog, moveEndPlate, 0);
 
-    fFetAirHoleLog = new G4LogicalVolume(fetAirHole, materialAir, "fetAirHoleLog", 0, 0, 0);
-    fFetAirHoleLog->SetVisAttributes(airVisAtt);
+	// Place holes in the old cold plate
+	G4Tubs* fetAirHole = AirHole();
 
-    for(i = 0 ; i < 4 ; i++) {
-        y = y0 * (-cos(i*M_PI/2.0) + sin(i*M_PI/2.0)) ;
-        z = z0 * (cos(i*M_PI/2.0) + sin(i*M_PI/2.0)) ;
-        movePiece[i] = G4ThreeVector(x, y, z) ;
-        fAssembly->AddPlacedVolume(fFetAirHoleLog, movePiece[i], rotateFetAirHole) ;
-    }
+	fFetAirHoleLog = new G4LogicalVolume(fetAirHole, materialAir, "fetAirHoleLog", 0, 0, 0);
+	fFetAirHoleLog->SetVisAttributes(airVisAtt);
 
-    // Cold Finger
-    G4Tubs* fing = Finger();
+	for(i = 0 ; i < 4 ; i++) {
+		y = y0 * (-cos(i*M_PI/2.0) + sin(i*M_PI/2.0)) ;
+		z = z0 * (cos(i*M_PI/2.0) + sin(i*M_PI/2.0)) ;
+		movePiece[i] = G4ThreeVector(x, y, z) ;
+		fAssembly->AddPlacedVolume(fFetAirHoleLog, movePiece[i], rotateFetAirHole) ;
+	}
 
-    G4RotationMatrix* rotateFinger = new G4RotationMatrix;
-    rotateFinger->rotateY(M_PI/2.0);
+	// Cold Finger
+	G4Tubs* fing = Finger();
 
-    G4ThreeVector moveFinger((fColdFingerLength +fCanFaceThickness)/2.0
-                              + fGermaniumDistFromCanFace +fGermaniumLength
-                              + fColdFingerSpace +fColdFingerEndPlateThickness
-                              + fShift +fAppliedBackShift
-                              + fStructureMatColdFingerThickness/2.0 , 0, 0); //changed Jan 2005
+	G4RotationMatrix* rotateFinger = new G4RotationMatrix;
+	rotateFinger->rotateY(M_PI/2.0);
 
-    fFingerLog = new G4LogicalVolume(fing, electrodeMat, "fingerLog", 0, 0, 0);
-    fFingerLog->SetVisAttributes(coldFingerVisAtt);
+	G4ThreeVector moveFinger((fColdFingerLength +fCanFaceThickness)/2.0
+			+ fGermaniumDistFromCanFace +fGermaniumLength
+			+ fColdFingerSpace +fColdFingerEndPlateThickness
+			+ fShift +fAppliedBackShift
+			+ fStructureMatColdFingerThickness/2.0 , 0, 0); //changed Jan 2005
 
-    fAssembly->AddPlacedVolume(fFingerLog, moveFinger, rotateFinger);
+	fFingerLog = new G4LogicalVolume(fing, electrodeMat, "fingerLog", 0, 0, 0);
+	fFingerLog->SetVisAttributes(coldFingerVisAtt);
 
-    // The extra block of structureMat that's in the diagram "Cut C"
-    G4SubtractionSolid* extraColdBlock = ExtraColdBlock();
-    G4RotationMatrix* rotateExtraColdBlock = new G4RotationMatrix;
-    rotateExtraColdBlock->rotateY(M_PI/2.0);
+	fAssembly->AddPlacedVolume(fFingerLog, moveFinger, rotateFinger);
 
-    G4ThreeVector moveExtraColdBlock(fDetectorTotalLength - fCanFaceThickness/2.0
-                                        - fRearPlateThickness + fShift
-                                        + fAppliedBackShift - fExtraBlockDistanceFromBackPlate
-                                        - fExtraBlockThickness/2.0, 0, 0);
+	// The extra block of structureMat that's in the diagram "Cut C"
+	G4SubtractionSolid* extraColdBlock = ExtraColdBlock();
+	G4RotationMatrix* rotateExtraColdBlock = new G4RotationMatrix;
+	rotateExtraColdBlock->rotateY(M_PI/2.0);
 
-    fExtraColdBlockLog = new G4LogicalVolume(extraColdBlock, structureMat, "extraColdBlockLog", 0, 0, 0);
+	G4ThreeVector moveExtraColdBlock(fDetectorTotalLength - fCanFaceThickness/2.0
+			- fRearPlateThickness + fShift
+			+ fAppliedBackShift - fExtraBlockDistanceFromBackPlate
+			- fExtraBlockThickness/2.0, 0, 0);
 
-    fAssembly->AddPlacedVolume(fExtraColdBlockLog, moveExtraColdBlock, rotateExtraColdBlock);
+	fExtraColdBlockLog = new G4LogicalVolume(extraColdBlock, structureMat, "extraColdBlockLog", 0, 0, 0);
 
-    // The structures above the cooling end plate
-    G4Tubs* structureMatColdFinger = StructureMatColdFinger();
-    fStructureMatColdFingerLog = new G4LogicalVolume(structureMatColdFinger, structureMat, "structureMatColdFingerLog", 0, 0, 0);
-    fStructureMatColdFingerLog->SetVisAttributes(structureMatVisAtt);
+	fAssembly->AddPlacedVolume(fExtraColdBlockLog, moveExtraColdBlock, rotateExtraColdBlock);
 
-    G4RotationMatrix* rotateStructureMatColdFinger = new G4RotationMatrix;
-    rotateStructureMatColdFinger->rotateY(M_PI/2.0);
-    G4ThreeVector moveStructureMatColdFinger(fStructureMatColdFingerThickness/2.0
-                                                + fColdFingerEndPlateThickness
-                                                + fCanFaceThickness/2.0
-                                                + fGermaniumDistFromCanFace +fGermaniumLength
-                                                + fColdFingerSpace +fShift +fAppliedBackShift, 0, 0);
+	// The structures above the cooling end plate
+	G4Tubs* structureMatColdFinger = StructureMatColdFinger();
+	fStructureMatColdFingerLog = new G4LogicalVolume(structureMatColdFinger, structureMat, "structureMatColdFingerLog", 0, 0, 0);
+	fStructureMatColdFingerLog->SetVisAttributes(structureMatVisAtt);
 
-    fAssembly->AddPlacedVolume(fStructureMatColdFingerLog, moveStructureMatColdFinger, rotateStructureMatColdFinger);
+	G4RotationMatrix* rotateStructureMatColdFinger = new G4RotationMatrix;
+	rotateStructureMatColdFinger->rotateY(M_PI/2.0);
+	G4ThreeVector moveStructureMatColdFinger(fStructureMatColdFingerThickness/2.0
+			+ fColdFingerEndPlateThickness
+			+ fCanFaceThickness/2.0
+			+ fGermaniumDistFromCanFace +fGermaniumLength
+			+ fColdFingerSpace +fShift +fAppliedBackShift, 0, 0);
 
-    // Cooling Side Block
-    G4Box* coolingSideBlock = CoolingSideBlock();
-    fCoolingSideBlockLog = new G4LogicalVolume(coolingSideBlock, structureMat, "coolingSideBlockLog", 0, 0, 0);
-    fCoolingSideBlockLog->SetVisAttributes(structureMatVisAtt);
+	fAssembly->AddPlacedVolume(fStructureMatColdFingerLog, moveStructureMatColdFinger, rotateStructureMatColdFinger);
 
-    G4Box* coolingBar = CoolingBar();
-    fCoolingBarLog = new G4LogicalVolume(coolingBar, structureMat, "coolingBarLog", 0, 0, 0);
-    fCoolingBarLog->SetVisAttributes(structureMatVisAtt);
+	// Cooling Side Block
+	G4Box* coolingSideBlock = CoolingSideBlock();
+	fCoolingSideBlockLog = new G4LogicalVolume(coolingSideBlock, structureMat, "coolingSideBlockLog", 0, 0, 0);
+	fCoolingSideBlockLog->SetVisAttributes(structureMatVisAtt);
 
-    G4RotationMatrix* rotatePiece[8] ;
+	G4Box* coolingBar = CoolingBar();
+	fCoolingBarLog = new G4LogicalVolume(coolingBar, structureMat, "coolingBarLog", 0, 0, 0);
+	fCoolingBarLog->SetVisAttributes(structureMatVisAtt);
 
-    x = fCoolingSideBlockThickness/2.0
-            + fColdFingerEndPlateThickness
-            + fCanFaceThickness/2.0
-            + fGermaniumDistFromCanFace +fGermaniumLength
-            + fColdFingerSpace +fShift +fAppliedBackShift ;
+	G4RotationMatrix* rotatePiece[8] ;
 
-    y01 = fGermaniumWidth - fCoolingSideBlockHorizontalDepth/2.0 ;
+	x = fCoolingSideBlockThickness/2.0
+		+ fColdFingerEndPlateThickness
+		+ fCanFaceThickness/2.0
+		+ fGermaniumDistFromCanFace +fGermaniumLength
+		+ fColdFingerSpace +fShift +fAppliedBackShift ;
 
-    y02 = fGermaniumWidth
-            - fCoolingSideBlockHorizontalDepth
-            - (fGermaniumWidth
-               - fCoolingSideBlockHorizontalDepth
-               - fStructureMatColdFingerRadius)/2.0 ;
+	y01 = fGermaniumWidth - fCoolingSideBlockHorizontalDepth/2.0 ;
 
-    for(i = 0 ; i < 4 ; i++)
-    {
-        // Add cooling side blocks and cooling bars at the same time.
-        rotatePiece[2*i] = new G4RotationMatrix ; // cooling side blocks
-        rotatePiece[2*i]->rotateZ(M_PI/2.0) ;
-        rotatePiece[2*i]->rotateX(M_PI/2.0 - i*M_PI/2.0) ;
+	y02 = fGermaniumWidth
+		- fCoolingSideBlockHorizontalDepth
+		- (fGermaniumWidth
+				- fCoolingSideBlockHorizontalDepth
+				- fStructureMatColdFingerRadius)/2.0 ;
 
-        y = -y01 * cos(i*M_PI/2.0) ;
-        z = -y01 * sin(i*M_PI/2.0) ;
+	for(i = 0 ; i < 4 ; i++)
+	{
+		// Add cooling side blocks and cooling bars at the same time.
+		rotatePiece[2*i] = new G4RotationMatrix ; // cooling side blocks
+		rotatePiece[2*i]->rotateZ(M_PI/2.0) ;
+		rotatePiece[2*i]->rotateX(M_PI/2.0 - i*M_PI/2.0) ;
 
-        movePiece[2*i] = G4ThreeVector(x, y, z) ;
+		y = -y01 * cos(i*M_PI/2.0) ;
+		z = -y01 * sin(i*M_PI/2.0) ;
 
-        rotatePiece[2*i+1] = new G4RotationMatrix ; // cooling bars
-        rotatePiece[2*i+1]->rotateZ(M_PI/2.0) ;
-        rotatePiece[2*i+1]->rotateX(M_PI/2.0 - i*M_PI/2.0) ;
+		movePiece[2*i] = G4ThreeVector(x, y, z) ;
 
-        y = -y02 * cos(i*M_PI/2.0) ;
-        z = -y02 * sin(i*M_PI/2.0) ;
+		rotatePiece[2*i+1] = new G4RotationMatrix ; // cooling bars
+		rotatePiece[2*i+1]->rotateZ(M_PI/2.0) ;
+		rotatePiece[2*i+1]->rotateX(M_PI/2.0 - i*M_PI/2.0) ;
 
-        movePiece[2*i+1] = G4ThreeVector(x, y, z) ;
+		y = -y02 * cos(i*M_PI/2.0) ;
+		z = -y02 * sin(i*M_PI/2.0) ;
 
-        fAssembly->AddPlacedVolume(fCoolingSideBlockLog, movePiece[2*i], rotatePiece[2*i]);
-        fAssembly->AddPlacedVolume(fCoolingBarLog, movePiece[2*i+1], rotatePiece[2*i+1]);
-    }
+		movePiece[2*i+1] = G4ThreeVector(x, y, z) ;
 
-    // Triangle posts from "Cut A"
-    // First, find how far from the centre to place the tips of the triangles
+		fAssembly->AddPlacedVolume(fCoolingSideBlockLog, movePiece[2*i], rotatePiece[2*i]);
+		fAssembly->AddPlacedVolume(fCoolingBarLog, movePiece[2*i+1], rotatePiece[2*i+1]);
+	}
 
-    G4double distanceOfTheTip = fGermaniumSeparation/2.0
-            + (fGermaniumWidth/2.0 - fGermaniumShift) //centre of the middle hole
-            + sqrt(pow((fGermaniumOuterRadius
-                         + fTrianglePostsDistanceFromCrystals), 2.0)
-                    - pow(fGermaniumWidth/2.0 - fGermaniumShift, 2.0));
+	// Triangle posts from "Cut A"
+	// First, find how far from the centre to place the tips of the triangles
 
-    // The distance of the base from the detector centre
-    G4double distanceOfTheBase = fGermaniumSeparation/2.0 + fGermaniumWidth;
+	G4double distanceOfTheTip = fGermaniumSeparation/2.0
+		+ (fGermaniumWidth/2.0 - fGermaniumShift) //centre of the middle hole
+		+ sqrt(pow((fGermaniumOuterRadius
+						+ fTrianglePostsDistanceFromCrystals), 2.0)
+				- pow(fGermaniumWidth/2.0 - fGermaniumShift, 2.0));
 
-    G4double trianglePostLength = fGermaniumLength - fTrianglePostStartingDepth
-            + fColdFingerSpace;
+	// The distance of the base from the detector centre
+	G4double distanceOfTheBase = fGermaniumSeparation/2.0 + fGermaniumWidth;
 
-    G4Trd* trianglePost = TrianglePost();
-    fTrianglePostLog = new G4LogicalVolume(trianglePost, structureMat, "trianglePostLog", 0, 0, 0);
+	G4double trianglePostLength = fGermaniumLength - fTrianglePostStartingDepth
+		+ fColdFingerSpace;
 
-    x = fCanFaceThickness/2.0
-            + fGermaniumDistFromCanFace +fGermaniumLength
-            + fColdFingerSpace +fShift +fAppliedBackShift
-            - trianglePostLength/2.0 ;
+	G4Trd* trianglePost = TrianglePost();
+	fTrianglePostLog = new G4LogicalVolume(trianglePost, structureMat, "trianglePostLog", 0, 0, 0);
 
-    y0 = (distanceOfTheBase + distanceOfTheTip)/2.0 ;
+	x = fCanFaceThickness/2.0
+		+ fGermaniumDistFromCanFace +fGermaniumLength
+		+ fColdFingerSpace +fShift +fAppliedBackShift
+		- trianglePostLength/2.0 ;
 
-    for(i = 0 ; i < 4 ; i++)
-    {
-        rotatePiece[i] = new G4RotationMatrix ;
-        rotatePiece[i]->rotateY(0) ; // Initially included...seems a little redundant.
-        rotatePiece[i]->rotateX(M_PI/2.0 - i*M_PI/2.0) ;  // 4, 1, 2, 3
+	y0 = (distanceOfTheBase + distanceOfTheTip)/2.0 ;
 
-        y = -y0 * cos(i*M_PI/2.0) ;
-        z =  y0 * sin(i*M_PI/2.0) ;
+	for(i = 0 ; i < 4 ; i++)
+	{
+		rotatePiece[i] = new G4RotationMatrix ;
+		rotatePiece[i]->rotateY(0) ; // Initially included...seems a little redundant.
+		rotatePiece[i]->rotateX(M_PI/2.0 - i*M_PI/2.0) ;  // 4, 1, 2, 3
 
-        movePiece[i] = G4ThreeVector(x, y, z) ;
+		y = -y0 * cos(i*M_PI/2.0) ;
+		z =  y0 * sin(i*M_PI/2.0) ;
 
-        fAssembly->AddPlacedVolume(fTrianglePostLog, movePiece[i], rotatePiece[i]);
-    }
+		movePiece[i] = G4ThreeVector(x, y, z) ;
+
+		fAssembly->AddPlacedVolume(fTrianglePostLog, movePiece[i], rotatePiece[i]);
+	}
 }//end ::ConstructColdFinger
 
 ///////////////////////////////////////////////////////////////////////
 // methods used in ConstructColdFinger()
 ///////////////////////////////////////////////////////////////////////
 G4Box* DetectionSystemGriffin::EndPlate() {
-    G4double halfThicknessX = fColdFingerEndPlateThickness/2.0;
-    G4double halfLengthY = fGermaniumWidth;  //Since it must cover the back of the detector
-    G4double halfLengthZ = halfLengthY;  //Since it is symmetric
+	G4double halfThicknessX = fColdFingerEndPlateThickness/2.0;
+	G4double halfLengthY = fGermaniumWidth;  //Since it must cover the back of the detector
+	G4double halfLengthZ = halfLengthY;  //Since it is symmetric
 
-    G4Box* endPlate = new G4Box("endPlate", halfThicknessX, halfLengthY, halfLengthZ);
+	G4Box* endPlate = new G4Box("endPlate", halfThicknessX, halfLengthY, halfLengthZ);
 
-    return endPlate;
+	return endPlate;
 }//end ::endPlate
 
 
 G4Tubs* DetectionSystemGriffin::Finger() {
-    G4double innerRadius = 0.0*cm;
-    G4double outerRadius = fColdFingerRadius;
-    G4double halfLengthZ = (fColdFingerLength
-                              - fStructureMatColdFingerThickness)/2.0;
-    G4double startAngle = 0.0*M_PI;
-    G4double finalAngle = 2.0*M_PI;
+	G4double innerRadius = 0.0*cm;
+	G4double outerRadius = fColdFingerRadius;
+	G4double halfLengthZ = (fColdFingerLength
+			- fStructureMatColdFingerThickness)/2.0;
+	G4double startAngle = 0.0*M_PI;
+	G4double finalAngle = 2.0*M_PI;
 
-    G4Tubs* fing = new G4Tubs("finger", innerRadius, outerRadius, halfLengthZ, startAngle, finalAngle);
+	G4Tubs* fing = new G4Tubs("finger", innerRadius, outerRadius, halfLengthZ, startAngle, finalAngle);
 
-    return fing;
+	return fing;
 }//end ::finger
 
 
 G4SubtractionSolid* DetectionSystemGriffin::ExtraColdBlock() {
-    G4double halfWidthX = fGermaniumWidth;
-    G4double halfWidthY = halfWidthX;
-    G4double halfThicknessZ = fExtraBlockThickness/2.0;
+	G4double halfWidthX = fGermaniumWidth;
+	G4double halfWidthY = halfWidthX;
+	G4double halfThicknessZ = fExtraBlockThickness/2.0;
 
-    G4Box* plate = new G4Box("plate", halfWidthX, halfWidthY, halfThicknessZ);
+	G4Box* plate = new G4Box("plate", halfWidthX, halfWidthY, halfThicknessZ);
 
-    G4double innerRadius = 0.0;
-    G4double outerRadius = fExtraBlockInnerDiameter/2.0;
+	G4double innerRadius = 0.0;
+	G4double outerRadius = fExtraBlockInnerDiameter/2.0;
 
-    G4double halfHeightZ = halfThicknessZ +1.0*cm;  //+1.0*cm just to make sure the hole goes completely through the plate
-    G4double startAngle = 0.0*M_PI;
-    G4double finalAngle = 2.0*M_PI;
+	G4double halfHeightZ = halfThicknessZ +1.0*cm;  //+1.0*cm just to make sure the hole goes completely through the plate
+	G4double startAngle = 0.0*M_PI;
+	G4double finalAngle = 2.0*M_PI;
 
-    G4Tubs* hole = new G4Tubs("hole", innerRadius, outerRadius, halfHeightZ, startAngle, finalAngle);
+	G4Tubs* hole = new G4Tubs("hole", innerRadius, outerRadius, halfHeightZ, startAngle, finalAngle);
 
-    G4SubtractionSolid* extraColdBlock = new G4SubtractionSolid("extraColdBlock", plate, hole);
+	G4SubtractionSolid* extraColdBlock = new G4SubtractionSolid("extraColdBlock", plate, hole);
 
 
 
-    // Fix overlap
-    G4SubtractionSolid* fixExtraColdBlock[4];
-    G4double cutTubeY0, cutYMov, cutZMov;
-    G4RotationMatrix* cutRotatePiece[4] ;
-    G4ThreeVector cutMovePiece[4] ;
-    G4Tubs* cutTubeLocation[4] ;
+	// Fix overlap
+	G4SubtractionSolid* fixExtraColdBlock[4];
+	G4double cutTubeY0, cutYMov, cutZMov;
+	G4RotationMatrix* cutRotatePiece[4] ;
+	G4ThreeVector cutMovePiece[4] ;
+	G4Tubs* cutTubeLocation[4] ;
 
-    cutTubeY0 = (fDetectorTotalWidth/2.0) - (fBentEndLength * tan(fBentEndAngle)) ;
+	cutTubeY0 = (fDetectorTotalWidth/2.0) - (fBentEndLength * tan(fBentEndAngle)) ;
 
-    for(G4int i = 0 ; i < 4 ; i++) {
-        // Lower Left, Upper Left, Upper Right, Lower Right
-        cutTubeLocation[i] = CornerTube() ;
-        cutRotatePiece[i] = new G4RotationMatrix ;
-        cutRotatePiece[i]->rotateZ(-M_PI/2.0 + (i-1)*M_PI/2.0) ;
+	for(G4int i = 0 ; i < 4 ; i++) {
+		// Lower Left, Upper Left, Upper Right, Lower Right
+		cutTubeLocation[i] = CornerTube() ;
+		cutRotatePiece[i] = new G4RotationMatrix ;
+		cutRotatePiece[i]->rotateZ(-M_PI/2.0 + (i-1)*M_PI/2.0) ;
 
-        cutYMov = cutTubeY0 * (-cos(i*M_PI/2.0) + sin(i*M_PI/2.0)) ;
-        cutZMov = cutTubeY0  * (-cos(i*M_PI/2.0) - sin(i*M_PI/2.0)) ;
+		cutYMov = cutTubeY0 * (-cos(i*M_PI/2.0) + sin(i*M_PI/2.0)) ;
+		cutZMov = cutTubeY0  * (-cos(i*M_PI/2.0) - sin(i*M_PI/2.0)) ;
 
-        cutMovePiece[i] = G4ThreeVector(cutZMov, cutYMov, 0) ;
+		cutMovePiece[i] = G4ThreeVector(cutZMov, cutYMov, 0) ;
 
-        if(i == 0) {
-            fixExtraColdBlock[i] = new G4SubtractionSolid("extraColdBlock", extraColdBlock, cutTubeLocation[i], cutRotatePiece[i], cutMovePiece[i]) ;
-        } else {
-			 fixExtraColdBlock[i] = new G4SubtractionSolid("extraColdBlock", fixExtraColdBlock[i-1], cutTubeLocation[i], cutRotatePiece[i], cutMovePiece[i]) ;
-        }
-    }
+		if(i == 0) {
+			fixExtraColdBlock[i] = new G4SubtractionSolid("extraColdBlock", extraColdBlock, cutTubeLocation[i], cutRotatePiece[i], cutMovePiece[i]) ;
+		} else {
+			fixExtraColdBlock[i] = new G4SubtractionSolid("extraColdBlock", fixExtraColdBlock[i-1], cutTubeLocation[i], cutRotatePiece[i], cutMovePiece[i]) ;
+		}
+	}
 
-    return fixExtraColdBlock[3];
+	return fixExtraColdBlock[3];
 }//end ::extraColdBlock
 
 
 G4Trd* DetectionSystemGriffin::TrianglePost() {
-    // Calculations that are also done in ConstructColdFinger for positioning
-    // First, find how far from the centre to place the tips of the triangles
-    G4double distanceOfTheTip	= fGermaniumSeparation/2.0
-            + (fGermaniumWidth/2.0 - fGermaniumShift) //centre of the middle hole
-            + sqrt(pow((fGermaniumOuterRadius
-                         + fTrianglePostsDistanceFromCrystals), 2.0)
-                    - pow(fGermaniumWidth/2.0 - fGermaniumShift, 2.0));
+	// Calculations that are also done in ConstructColdFinger for positioning
+	// First, find how far from the centre to place the tips of the triangles
+	G4double distanceOfTheTip	= fGermaniumSeparation/2.0
+		+ (fGermaniumWidth/2.0 - fGermaniumShift) //centre of the middle hole
+		+ sqrt(pow((fGermaniumOuterRadius
+						+ fTrianglePostsDistanceFromCrystals), 2.0)
+				- pow(fGermaniumWidth/2.0 - fGermaniumShift, 2.0));
 
-    // The distance of the base from the detector centre
-    G4double distanceOfTheBase = fGermaniumSeparation/2.0
-            + fGermaniumWidth;
+	// The distance of the base from the detector centre
+	G4double distanceOfTheBase = fGermaniumSeparation/2.0
+		+ fGermaniumWidth;
 
-    // The distance away from the boundary between crystals of the side points
-    G4double distanceOfTheSidePoints 	= sqrt(pow((fGermaniumOuterRadius
-                                                         + fTrianglePostsDistanceFromCrystals), 2.0)
-                                                    - pow(fGermaniumWidth/2.0 +/*notice*/ fGermaniumShift, 2.0));
+	// The distance away from the boundary between crystals of the side points
+	G4double distanceOfTheSidePoints 	= sqrt(pow((fGermaniumOuterRadius
+					+ fTrianglePostsDistanceFromCrystals), 2.0)
+			- pow(fGermaniumWidth/2.0 +/*notice*/ fGermaniumShift, 2.0));
 
-    // Measurements to make the posts with
-    G4double length = fGermaniumLength - fTrianglePostStartingDepth
-            + fColdFingerSpace;
+	// Measurements to make the posts with
+	G4double length = fGermaniumLength - fTrianglePostStartingDepth
+		+ fColdFingerSpace;
 
-    G4double baseToTipHeight = (distanceOfTheBase-distanceOfTheTip);
+	G4double baseToTipHeight = (distanceOfTheBase-distanceOfTheTip);
 
-    G4double halfWidthOfBase = distanceOfTheSidePoints;
+	G4double halfWidthOfBase = distanceOfTheSidePoints;
 
-    G4double halfWidthOfTop = fTrianglePostDim; //the easiest way to make a triangle
-    //G4Trd(const G4String& pName,G4double  dx1, G4double dx2, G4double  dy1, G4double dy2,G4double  dz)
-    G4Trd* trianglePost = new G4Trd(	"trianglePost", length / 2.0, length / 2.0,
-                                        halfWidthOfTop, halfWidthOfBase, baseToTipHeight / 2.0);
+	G4double halfWidthOfTop = fTrianglePostDim; //the easiest way to make a triangle
+	//G4Trd(const G4String& pName,G4double  dx1, G4double dx2, G4double  dy1, G4double dy2,G4double  dz)
+	G4Trd* trianglePost = new G4Trd(	"trianglePost", length / 2.0, length / 2.0,
+			halfWidthOfTop, halfWidthOfBase, baseToTipHeight / 2.0);
 
-    return trianglePost;
+	return trianglePost;
 }//end ::trianglePost
 
 
 G4Tubs* DetectionSystemGriffin::AirHole() {
-    G4double innerRadius = 0.0*cm;
-    G4double outerRadius = fFetAirHoleRadius;
-    G4double halfLengthZ = fColdFingerEndPlateThickness/2.0;
-    G4double startAngle = 0.0*M_PI;
-    G4double finalAngle = 2.0*M_PI;
+	G4double innerRadius = 0.0*cm;
+	G4double outerRadius = fFetAirHoleRadius;
+	G4double halfLengthZ = fColdFingerEndPlateThickness/2.0;
+	G4double startAngle = 0.0*M_PI;
+	G4double finalAngle = 2.0*M_PI;
 
-    G4Tubs* fetAirHole = new G4Tubs("fetAirHole", innerRadius,
-                                      outerRadius, halfLengthZ, startAngle, finalAngle);
+	G4Tubs* fetAirHole = new G4Tubs("fetAirHole", innerRadius,
+			outerRadius, halfLengthZ, startAngle, finalAngle);
 
-    return fetAirHole;
+	return fetAirHole;
 }//end ::airHole
 
 G4Tubs* DetectionSystemGriffin::AirHoleCut() {
-    G4double innerRadius = 0.0*cm;
-    G4double outerRadius = fFetAirHoleRadius;
-    G4double halfLengthZ = fColdFingerEndPlateThickness/2.0 + 1.0*cm;
-    G4double startAngle = 0.0*M_PI;
-    G4double finalAngle = 2.0*M_PI;
+	G4double innerRadius = 0.0*cm;
+	G4double outerRadius = fFetAirHoleRadius;
+	G4double halfLengthZ = fColdFingerEndPlateThickness/2.0 + 1.0*cm;
+	G4double startAngle = 0.0*M_PI;
+	G4double finalAngle = 2.0*M_PI;
 
-    G4Tubs* fetAirHole = new G4Tubs("fetAirHole", innerRadius,
-                                      outerRadius, halfLengthZ, startAngle, finalAngle);
+	G4Tubs* fetAirHole = new G4Tubs("fetAirHole", innerRadius,
+			outerRadius, halfLengthZ, startAngle, finalAngle);
 
-    return fetAirHole;
+	return fetAirHole;
 }//end ::airHoleCut
 
 G4Box* DetectionSystemGriffin::CoolingBar() {
-    G4double halfThicknessX = fCoolingBarThickness/2.0;
-    G4double halfLengthY = fCoolingBarWidth/2.0;
-    G4double halfLengthZ = (fGermaniumWidth
-                              - fCoolingSideBlockHorizontalDepth
-                              - fStructureMatColdFingerRadius)/2.0;
+	G4double halfThicknessX = fCoolingBarThickness/2.0;
+	G4double halfLengthY = fCoolingBarWidth/2.0;
+	G4double halfLengthZ = (fGermaniumWidth
+			- fCoolingSideBlockHorizontalDepth
+			- fStructureMatColdFingerRadius)/2.0;
 
-    G4Box* coolingBar = new G4Box("coolingBar", halfThicknessX, halfLengthY, halfLengthZ);
+	G4Box* coolingBar = new G4Box("coolingBar", halfThicknessX, halfLengthY, halfLengthZ);
 
-    return coolingBar;
+	return coolingBar;
 }//end ::coolingBar
 
 
 G4Box* DetectionSystemGriffin::CoolingSideBlock() {
-    G4double halfThicknessX = fCoolingSideBlockWidth/2.0;
-    G4double halfLengthY = fCoolingSideBlockThickness/2.0;
-    G4double halfLengthZ = fCoolingSideBlockHorizontalDepth/2.0;
+	G4double halfThicknessX = fCoolingSideBlockWidth/2.0;
+	G4double halfLengthY = fCoolingSideBlockThickness/2.0;
+	G4double halfLengthZ = fCoolingSideBlockHorizontalDepth/2.0;
 
-    G4Box* coolingSideBlock = new G4Box("coolingSideBlock",
-                                          halfThicknessX, halfLengthY, halfLengthZ);
+	G4Box* coolingSideBlock = new G4Box("coolingSideBlock",
+			halfThicknessX, halfLengthY, halfLengthZ);
 
-    return coolingSideBlock;
+	return coolingSideBlock;
 }//end ::coolingSideBlock
 
 
 G4Tubs* DetectionSystemGriffin::StructureMatColdFinger() {
-    G4double innerRadius = 0.0*cm;
-    G4double outerRadius = fStructureMatColdFingerRadius;
-    G4double halfLengthZ = fStructureMatColdFingerThickness/2.0;
-    G4double startAngle = 0.0*M_PI;
-    G4double finalAngle = 2.0*M_PI;
+	G4double innerRadius = 0.0*cm;
+	G4double outerRadius = fStructureMatColdFingerRadius;
+	G4double halfLengthZ = fStructureMatColdFingerThickness/2.0;
+	G4double startAngle = 0.0*M_PI;
+	G4double finalAngle = 2.0*M_PI;
 
-    G4Tubs* structureMatColdFinger= new G4Tubs("structureMatColdFinger",
-                                                 innerRadius, outerRadius, halfLengthZ, startAngle, finalAngle);
+	G4Tubs* structureMatColdFinger= new G4Tubs("structureMatColdFinger",
+			innerRadius, outerRadius, halfLengthZ, startAngle, finalAngle);
 
-    return structureMatColdFinger;
+	return structureMatColdFinger;
 }//end ::structureMatColdFinger
 
 
@@ -1653,417 +1653,417 @@ G4Tubs* DetectionSystemGriffin::StructureMatColdFinger() {
 // of structureMat that surrounds the physical pieces.
 ///////////////////////////////////////////////////////////////////////
 void DetectionSystemGriffin::ConstructNewSuppressorCasingWithShells() {
-    G4int i;
-    G4double x0, y0, z0, x, y, z;
-
-    G4Material* structureMat = G4Material::GetMaterial(fStructureMaterial);
-    if(!structureMat) {
-        G4cout<<" ----> Structure material "<<fStructureMaterial<<" not found, cannot build the detector shell! "<<G4endl;
-        exit(1);
-    }
-    G4Material* materialBGO = G4Material::GetMaterial(fBGOMaterial);
-    if(!materialBGO) {
-        G4cout<<" ----> BGO material "<<fBGOMaterial<<" not found, cannot build the detector shell! "<<G4endl;
-        exit(1);
-    }
+	G4int i;
+	G4double x0, y0, z0, x, y, z;
+
+	G4Material* structureMat = G4Material::GetMaterial(fStructureMaterial);
+	if(!structureMat) {
+		G4cout<<" ----> Structure material "<<fStructureMaterial<<" not found, cannot build the detector shell! "<<G4endl;
+		exit(1);
+	}
+	G4Material* materialBGO = G4Material::GetMaterial(fBGOMaterial);
+	if(!materialBGO) {
+		G4cout<<" ----> BGO material "<<fBGOMaterial<<" not found, cannot build the detector shell! "<<G4endl;
+		exit(1);
+	}
 
-    // Change some values to accomodate the shells
-    // Replacement for sideSuppressorLength
-    G4double shellSideSuppressorLength = fSideSuppressorLength
-            + (fSuppressorShellThickness*2.0);
+	// Change some values to accomodate the shells
+	// Replacement for sideSuppressorLength
+	G4double shellSideSuppressorLength = fSideSuppressorLength
+		+ (fSuppressorShellThickness*2.0);
 
-    // Replacement for suppressorExtensionLength
-    G4double shellSuppressorExtensionLength = fSuppressorExtensionLength
-            + (fSuppressorShellThickness*2.0)*(1.0/tan(fBentEndAngle)
-                                                      - tan(fBentEndAngle));
+	// Replacement for suppressorExtensionLength
+	G4double shellSuppressorExtensionLength = fSuppressorExtensionLength
+		+ (fSuppressorShellThickness*2.0)*(1.0/tan(fBentEndAngle)
+				- tan(fBentEndAngle));
 
-    // Replacement for suppressorExtensionAngle: must totally recalculate
-    G4double shellSuppressorExtensionAngle = atan(((fSuppressorBackRadius
-                                                       + fBentEndLength +(fBGOCanSeperation
-                                                                                 + fSideBGOThickness + fSuppressorShellThickness*2.0)
-                                                       / tan(fBentEndAngle)
-                                                       - (fSuppressorExtensionThickness + fSuppressorShellThickness*2.0)
-                                                       * sin(fBentEndAngle))
-                                                      * tan(fBentEndAngle) -(fSuppressorForwardRadius +fHevimetTipThickness)
-                                                      * sin(fBentEndAngle))/(shellSuppressorExtensionLength));
+	// Replacement for suppressorExtensionAngle: must totally recalculate
+	G4double shellSuppressorExtensionAngle = atan(((fSuppressorBackRadius
+					+ fBentEndLength +(fBGOCanSeperation
+						+ fSideBGOThickness + fSuppressorShellThickness*2.0)
+					/ tan(fBentEndAngle)
+					- (fSuppressorExtensionThickness + fSuppressorShellThickness*2.0)
+					* sin(fBentEndAngle))
+				* tan(fBentEndAngle) -(fSuppressorForwardRadius +fHevimetTipThickness)
+				* sin(fBentEndAngle))/(shellSuppressorExtensionLength));
 
-    G4VisAttributes* SuppressorVisAtt = new G4VisAttributes(G4Colour(0.75,0.75,0.75));
-    SuppressorVisAtt->SetVisibility(true);
-    G4VisAttributes* innardsVisAtt = new G4VisAttributes(G4Colour(0.75, 0.75, 0.75));
-    innardsVisAtt->SetVisibility(true);
-    G4VisAttributes* backInnardsVisAtt = new G4VisAttributes(G4Colour(0.0, 1.0, 0.0));
-    backInnardsVisAtt->SetVisibility(true);
+	G4VisAttributes* SuppressorVisAtt = new G4VisAttributes(G4Colour(0.75,0.75,0.75));
+	SuppressorVisAtt->SetVisibility(true);
+	G4VisAttributes* innardsVisAtt = new G4VisAttributes(G4Colour(0.75, 0.75, 0.75));
+	innardsVisAtt->SetVisibility(true);
+	G4VisAttributes* backInnardsVisAtt = new G4VisAttributes(G4Colour(0.0, 1.0, 0.0));
+	backInnardsVisAtt->SetVisibility(true);
 
-    // first we add the four pieces of back suppressor, and their shells
+	// first we add the four pieces of back suppressor, and their shells
 
-    G4SubtractionSolid* backQuarterSuppressor = BackSuppressorQuarter();
+	G4SubtractionSolid* backQuarterSuppressor = BackSuppressorQuarter();
 
-    G4SubtractionSolid* backQuarterSuppressorShell = ShellForBackSuppressorQuarter();
+	G4SubtractionSolid* backQuarterSuppressorShell = ShellForBackSuppressorQuarter();
 
-    // Insert the structureMat shell first.  The shells must be given numbers, rather than
-    // the suppressor pieces themselves.  As an error checking method, the suppressor
-    // pieces are given a copy number value far out of range of any useful copy number.
-    if(fIncludeBackSuppressors) {
-        fBackQuarterSuppressorShellLog = new G4LogicalVolume(
-                    backQuarterSuppressorShell, structureMat,
-                    "backQuarterSuppressorLog", 0, 0, 0);
+	// Insert the structureMat shell first.  The shells must be given numbers, rather than
+	// the suppressor pieces themselves.  As an error checking method, the suppressor
+	// pieces are given a copy number value far out of range of any useful copy number.
+	if(fIncludeBackSuppressors) {
+		fBackQuarterSuppressorShellLog = new G4LogicalVolume(
+				backQuarterSuppressorShell, structureMat,
+				"backQuarterSuppressorLog", 0, 0, 0);
 
-        fBackQuarterSuppressorShellLog->SetVisAttributes(SuppressorVisAtt);
+		fBackQuarterSuppressorShellLog->SetVisAttributes(SuppressorVisAtt);
 
-        G4Material* backMaterial = G4Material::GetMaterial(fBackSuppressorMaterial);
-        if(!backMaterial) {
-            G4cout<<" ----> Back suppressor material "<<fBackSuppressorMaterial<<" not found, cannot build the detector shell! "<<G4endl;
-            exit(1);
-        }
+		G4Material* backMaterial = G4Material::GetMaterial(fBackSuppressorMaterial);
+		if(!backMaterial) {
+			G4cout<<" ----> Back suppressor material "<<fBackSuppressorMaterial<<" not found, cannot build the detector shell! "<<G4endl;
+			exit(1);
+		}
 
-        fBackQuarterSuppressorLog = new G4LogicalVolume(backQuarterSuppressor, backMaterial,
-                                                          "backQuarterSuppressorLog", 0, 0, 0);
-        fBackQuarterSuppressorLog->SetVisAttributes(backInnardsVisAtt);
+		fBackQuarterSuppressorLog = new G4LogicalVolume(backQuarterSuppressor, backMaterial,
+				"backQuarterSuppressorLog", 0, 0, 0);
+		fBackQuarterSuppressorLog->SetVisAttributes(backInnardsVisAtt);
 
-        fSuppressorBackAssembly->AddPlacedVolume(fBackQuarterSuppressorLog, fMoveNull, fRotateNull);
+		fSuppressorBackAssembly->AddPlacedVolume(fBackQuarterSuppressorLog, fMoveNull, fRotateNull);
 
-        x0 = 	(fBackBGOThickness -fCanFaceThickness)/2.0 + fSuppressorShellThickness
-                + fDetectorTotalLength +fBGOCanSeperation
-                + fShift + fAppliedBackShift ;
+		x0 = 	(fBackBGOThickness -fCanFaceThickness)/2.0 + fSuppressorShellThickness
+			+ fDetectorTotalLength +fBGOCanSeperation
+			+ fShift + fAppliedBackShift ;
 
-        y0 = fDetectorTotalWidth/4.0 ;
+		y0 = fDetectorTotalWidth/4.0 ;
 
-        z0 = fDetectorTotalWidth/4.0 ;
+		z0 = fDetectorTotalWidth/4.0 ;
 
-        G4RotationMatrix* rotateBackSuppressorShells[4] ;
-        G4ThreeVector moveBackQuarterSuppressor[4] ;
+		G4RotationMatrix* rotateBackSuppressorShells[4] ;
+		G4ThreeVector moveBackQuarterSuppressor[4] ;
 
-        for(i = 0 ; i < 4 ; i++) {
-            rotateBackSuppressorShells[i] = new G4RotationMatrix ;
-            rotateBackSuppressorShells[i]->rotateX(-M_PI / 2.0 + i * M_PI / 2.0) ;
+		for(i = 0 ; i < 4 ; i++) {
+			rotateBackSuppressorShells[i] = new G4RotationMatrix ;
+			rotateBackSuppressorShells[i]->rotateX(-M_PI / 2.0 + i * M_PI / 2.0) ;
 
-            x = x0 ;
+			x = x0 ;
 
-            y = y0 * (sin(i * M_PI/2.0) - cos(i * M_PI/2.0)) ;
-            z = -z0 * (sin(i * M_PI/2.0) + cos(i * M_PI/2.0)) ;
+			y = y0 * (sin(i * M_PI/2.0) - cos(i * M_PI/2.0)) ;
+			z = -z0 * (sin(i * M_PI/2.0) + cos(i * M_PI/2.0)) ;
 
-            moveBackQuarterSuppressor[i] = G4ThreeVector(x, y, z) ;
+			moveBackQuarterSuppressor[i] = G4ThreeVector(x, y, z) ;
 
-            fBackAndSideSuppressorShellAssembly->AddPlacedVolume(fBackQuarterSuppressorShellLog, moveBackQuarterSuppressor[i], rotateBackSuppressorShells[i]) ;
-        }
-    }
+			fBackAndSideSuppressorShellAssembly->AddPlacedVolume(fBackQuarterSuppressorShellLog, moveBackQuarterSuppressor[i], rotateBackSuppressorShells[i]) ;
+		}
+	}
 
-    // now we add the side pieces of suppressor that taper off towards the front of the can
+	// now we add the side pieces of suppressor that taper off towards the front of the can
 
-    // Define the structureMat shell logical volume
-    G4SubtractionSolid* rightSuppressorShell = ShellForFrontSlantSuppressor("right");
+	// Define the structureMat shell logical volume
+	G4SubtractionSolid* rightSuppressorShell = ShellForFrontSlantSuppressor("right");
 
-    fRightSuppressorShellLog = new G4LogicalVolume(rightSuppressorShell, structureMat,
-                                                     "rightSuppressorShellLog", 0,0,0);
-    fRightSuppressorShellLog->SetVisAttributes(SuppressorVisAtt);
+	fRightSuppressorShellLog = new G4LogicalVolume(rightSuppressorShell, structureMat,
+			"rightSuppressorShellLog", 0,0,0);
+	fRightSuppressorShellLog->SetVisAttributes(SuppressorVisAtt);
 
-    G4SubtractionSolid* leftSuppressorShell = ShellForFrontSlantSuppressor("left");
+	G4SubtractionSolid* leftSuppressorShell = ShellForFrontSlantSuppressor("left");
 
-    fLeftSuppressorShellLog = new G4LogicalVolume(leftSuppressorShell, structureMat,
-                                                    "leftSuppressorShellLog", 0,0,0);
-    fLeftSuppressorShellLog->SetVisAttributes(SuppressorVisAtt);
+	fLeftSuppressorShellLog = new G4LogicalVolume(leftSuppressorShell, structureMat,
+			"leftSuppressorShellLog", 0,0,0);
+	fLeftSuppressorShellLog->SetVisAttributes(SuppressorVisAtt);
 
-    G4SubtractionSolid* rightSuppressor = FrontSlantSuppressor("right", false); // Right, non-chopping.
+	G4SubtractionSolid* rightSuppressor = FrontSlantSuppressor("right", false); // Right, non-chopping.
 
-    fRightSuppressorLog = new G4LogicalVolume(rightSuppressor, materialBGO, "rightSuppressorCasingLog", 0, 0, 0);
-    fRightSuppressorLog->SetVisAttributes(innardsVisAtt);
+	fRightSuppressorLog = new G4LogicalVolume(rightSuppressor, materialBGO, "rightSuppressorCasingLog", 0, 0, 0);
+	fRightSuppressorLog->SetVisAttributes(innardsVisAtt);
 
-    G4SubtractionSolid* leftSuppressor = FrontSlantSuppressor("left", false); // Left, non-chopping.
+	G4SubtractionSolid* leftSuppressor = FrontSlantSuppressor("left", false); // Left, non-chopping.
 
-    fLeftSuppressorLog = new G4LogicalVolume(leftSuppressor, materialBGO, "leftSuppressorCasingLog", 0, 0, 0);
-    fLeftSuppressorLog->SetVisAttributes(innardsVisAtt);
+	fLeftSuppressorLog = new G4LogicalVolume(leftSuppressor, materialBGO, "leftSuppressorCasingLog", 0, 0, 0);
+	fLeftSuppressorLog->SetVisAttributes(innardsVisAtt);
 
-    fRightSuppressorCasingAssembly->AddPlacedVolume(fRightSuppressorLog, fMoveNull, fRotateNull);
-    fLeftSuppressorCasingAssembly->AddPlacedVolume(fLeftSuppressorLog, fMoveNull, fRotateNull);
+	fRightSuppressorCasingAssembly->AddPlacedVolume(fRightSuppressorLog, fMoveNull, fRotateNull);
+	fLeftSuppressorCasingAssembly->AddPlacedVolume(fLeftSuppressorLog, fMoveNull, fRotateNull);
 
 
-    /////////////////////////////////////////////////////////////////////
-    // Note : Left and Right are read from the BACK of the detector
-    // Suppressors 1 and 2 cover germanium 1
-    // Suppressors 3 and 4 cover germanium 2
-    // Suppressors 5 and 6 cover germanium 3
-    // Suppressors 7 and 8 cover germanium 4
-    /////////////////////////////////////////////////////////////////////
+	/////////////////////////////////////////////////////////////////////
+	// Note : Left and Right are read from the BACK of the detector
+	// Suppressors 1 and 2 cover germanium 1
+	// Suppressors 3 and 4 cover germanium 2
+	// Suppressors 5 and 6 cover germanium 3
+	// Suppressors 7 and 8 cover germanium 4
+	/////////////////////////////////////////////////////////////////////
 
-    x0 =    shellSideSuppressorLength/2.0 -fCanFaceThickness/2.0
-            + fBentEndLength + (fBGOCanSeperation
-                                       + fBGOChoppedTip) / tan(fBentEndAngle)
-            + fShift + fAppliedBackShift ;
+	x0 =    shellSideSuppressorLength/2.0 -fCanFaceThickness/2.0
+		+ fBentEndLength + (fBGOCanSeperation
+				+ fBGOChoppedTip) / tan(fBentEndAngle)
+		+ fShift + fAppliedBackShift ;
 
-    y0 =    fSideBGOThickness/2.0 + fSuppressorShellThickness
-            + fDetectorTotalWidth/2.0 + fBGOCanSeperation ;
+	y0 =    fSideBGOThickness/2.0 + fSuppressorShellThickness
+		+ fDetectorTotalWidth/2.0 + fBGOCanSeperation ;
 
-    z0 =    fSideBGOThickness/2.0 + fSuppressorShellThickness
-            + fDetectorTotalWidth/2.0 + fBGOCanSeperation ;
+	z0 =    fSideBGOThickness/2.0 + fSuppressorShellThickness
+		+ fDetectorTotalWidth/2.0 + fBGOCanSeperation ;
 
-    G4RotationMatrix* rotateSuppressorExtensionShell[8] ;
-    G4ThreeVector moveSuppressorExtensionShell[8] ;
+	G4RotationMatrix* rotateSuppressorExtensionShell[8] ;
+	G4ThreeVector moveSuppressorExtensionShell[8] ;
 
-    for(i = 0 ; i < 4 ; i++)
-    {
-        //********************** RIGHT **********************//
-        rotateSuppressorExtensionShell[2*i] = new G4RotationMatrix ;
-        rotateSuppressorExtensionShell[2*i]->rotateZ(M_PI/2.0) ;
-        rotateSuppressorExtensionShell[2*i]->rotateY(M_PI/2.0) ;
-        rotateSuppressorExtensionShell[2*i]->rotateX(M_PI * (1 - i/2.0)) ;
+	for(i = 0 ; i < 4 ; i++)
+	{
+		//********************** RIGHT **********************//
+		rotateSuppressorExtensionShell[2*i] = new G4RotationMatrix ;
+		rotateSuppressorExtensionShell[2*i]->rotateZ(M_PI/2.0) ;
+		rotateSuppressorExtensionShell[2*i]->rotateY(M_PI/2.0) ;
+		rotateSuppressorExtensionShell[2*i]->rotateX(M_PI * (1 - i/2.0)) ;
 
-        x = x0 ;
+		x = x0 ;
 
-        y = y0 * (-cos(i * M_PI/2.0) + sin(i * M_PI/2.0)) / (1 + (i + 1) % 2) ; // -y/2, y, y/2, -y
+		y = y0 * (-cos(i * M_PI/2.0) + sin(i * M_PI/2.0)) / (1 + (i + 1) % 2) ; // -y/2, y, y/2, -y
 
-        z = z0 * (cos(i * M_PI/2.0) + sin(i * M_PI/2.0)) / (1 + i % 2) ;  // z, z/2, -z, -z/2
+		z = z0 * (cos(i * M_PI/2.0) + sin(i * M_PI/2.0)) / (1 + i % 2) ;  // z, z/2, -z, -z/2
 
-        moveSuppressorExtensionShell[2*i] = G4ThreeVector(x, y, z) ;
+		moveSuppressorExtensionShell[2*i] = G4ThreeVector(x, y, z) ;
 
-        fBackAndSideSuppressorShellAssembly->AddPlacedVolume(fRightSuppressorShellLog, moveSuppressorExtensionShell[2*i], rotateSuppressorExtensionShell[2*i]) ;
+		fBackAndSideSuppressorShellAssembly->AddPlacedVolume(fRightSuppressorShellLog, moveSuppressorExtensionShell[2*i], rotateSuppressorExtensionShell[2*i]) ;
 
-        //*********************** LEFT ***********************//
-        rotateSuppressorExtensionShell[2*i+1] = new G4RotationMatrix ;
-        rotateSuppressorExtensionShell[2*i+1]->rotateY(-M_PI/2.0) ;
-        rotateSuppressorExtensionShell[2*i+1]->rotateX(M_PI * (1 - i/2.0)) ;
+		//*********************** LEFT ***********************//
+		rotateSuppressorExtensionShell[2*i+1] = new G4RotationMatrix ;
+		rotateSuppressorExtensionShell[2*i+1]->rotateY(-M_PI/2.0) ;
+		rotateSuppressorExtensionShell[2*i+1]->rotateX(M_PI * (1 - i/2.0)) ;
 
-        x = x0 ;
+		x = x0 ;
 
-        y = y0 * (cos(i * M_PI/2.0) - sin(i * M_PI/2.0)) / (1 + i % 2) ; // y, -y/2, -y, y/2
+		y = y0 * (cos(i * M_PI/2.0) - sin(i * M_PI/2.0)) / (1 + i % 2) ; // y, -y/2, -y, y/2
 
-        z = -z0 * (cos(i * M_PI/2.0) + sin(i * M_PI/2.0)) / (1 + (i + 1) % 2) ; // -z/2, -z, z/2, z
+		z = -z0 * (cos(i * M_PI/2.0) + sin(i * M_PI/2.0)) / (1 + (i + 1) % 2) ; // -z/2, -z, z/2, z
 
-        moveSuppressorExtensionShell[2*i+1] = G4ThreeVector(x, y, z) ;
+		moveSuppressorExtensionShell[2*i+1] = G4ThreeVector(x, y, z) ;
 
-        fBackAndSideSuppressorShellAssembly->AddPlacedVolume(fLeftSuppressorShellLog, moveSuppressorExtensionShell[2*i+1], rotateSuppressorExtensionShell[2*i+1]) ;
+		fBackAndSideSuppressorShellAssembly->AddPlacedVolume(fLeftSuppressorShellLog, moveSuppressorExtensionShell[2*i+1], rotateSuppressorExtensionShell[2*i+1]) ;
 
-    }
+	}
 
 
-    // now we add the side pieces of suppressor that extend out in front of the can when it's in the back position
+	// now we add the side pieces of suppressor that extend out in front of the can when it's in the back position
 
-    // Define the shell right logical volume
-    // G4SubtractionSolid* rightSuppressorShellExtension = ShellForRightSuppressorExtension();
-    G4SubtractionSolid* rightSuppressorShellExtension = ShellForSuppressorExtension("right");
+	// Define the shell right logical volume
+	// G4SubtractionSolid* rightSuppressorShellExtension = ShellForRightSuppressorExtension();
+	G4SubtractionSolid* rightSuppressorShellExtension = ShellForSuppressorExtension("right");
 
-    fRightSuppressorShellExtensionLog = new G4LogicalVolume(rightSuppressorShellExtension,
-                                                               materialBGO, "rightSuppressorShellExtensionLog", 0, 0, 0);
-    fRightSuppressorShellExtensionLog->SetVisAttributes(SuppressorVisAtt);
+	fRightSuppressorShellExtensionLog = new G4LogicalVolume(rightSuppressorShellExtension,
+			materialBGO, "rightSuppressorShellExtensionLog", 0, 0, 0);
+	fRightSuppressorShellExtensionLog->SetVisAttributes(SuppressorVisAtt);
 
-    G4SubtractionSolid* rightSuppressorExtension = SideSuppressorExtension("right", false); // Right, non-chopping // CALLED
+	G4SubtractionSolid* rightSuppressorExtension = SideSuppressorExtension("right", false); // Right, non-chopping // CALLED
 
-    fRightSuppressorExtensionLog = new G4LogicalVolume(rightSuppressorExtension, materialBGO,
-                                                         "rightSuppressorExtensionLog", 0, 0, 0);
-    fRightSuppressorExtensionLog->SetVisAttributes(innardsVisAtt);
+	fRightSuppressorExtensionLog = new G4LogicalVolume(rightSuppressorExtension, materialBGO,
+			"rightSuppressorExtensionLog", 0, 0, 0);
+	fRightSuppressorExtensionLog->SetVisAttributes(innardsVisAtt);
 
-    // Define the left shell logical volume
-    // G4SubtractionSolid* leftSuppressorShellExtension = ShellForLeftSuppressorExtension();
-    G4SubtractionSolid* leftSuppressorShellExtension = ShellForSuppressorExtension("left");
+	// Define the left shell logical volume
+	// G4SubtractionSolid* leftSuppressorShellExtension = ShellForLeftSuppressorExtension();
+	G4SubtractionSolid* leftSuppressorShellExtension = ShellForSuppressorExtension("left");
 
 
-    fLeftSuppressorShellExtensionLog = new G4LogicalVolume(leftSuppressorShellExtension,
-                                                              materialBGO, "leftSuppressorShellExtensionLog", 0, 0, 0);
-    fLeftSuppressorShellExtensionLog->SetVisAttributes(SuppressorVisAtt);
+	fLeftSuppressorShellExtensionLog = new G4LogicalVolume(leftSuppressorShellExtension,
+			materialBGO, "leftSuppressorShellExtensionLog", 0, 0, 0);
+	fLeftSuppressorShellExtensionLog->SetVisAttributes(SuppressorVisAtt);
 
-    G4SubtractionSolid* leftSuppressorExtension = SideSuppressorExtension("left", false); // Left, Non-chopping // CALLED
+	G4SubtractionSolid* leftSuppressorExtension = SideSuppressorExtension("left", false); // Left, Non-chopping // CALLED
 
-    fLeftSuppressorExtensionLog = new G4LogicalVolume(leftSuppressorExtension, materialBGO,
-                                                        "leftSuppressorExtensionLog", 0, 0, 0);
-    fLeftSuppressorExtensionLog->SetVisAttributes(innardsVisAtt);
+	fLeftSuppressorExtensionLog = new G4LogicalVolume(leftSuppressorExtension, materialBGO,
+			"leftSuppressorExtensionLog", 0, 0, 0);
+	fLeftSuppressorExtensionLog->SetVisAttributes(innardsVisAtt);
 
-    fRightSuppressorExtensionAssembly->AddPlacedVolume(fRightSuppressorExtensionLog, fMoveNull, fRotateNull);
-    fLeftSuppressorExtensionAssembly->AddPlacedVolume(fLeftSuppressorExtensionLog, fMoveNull, fRotateNull);
+	fRightSuppressorExtensionAssembly->AddPlacedVolume(fRightSuppressorExtensionLog, fMoveNull, fRotateNull);
+	fLeftSuppressorExtensionAssembly->AddPlacedVolume(fLeftSuppressorExtensionLog, fMoveNull, fRotateNull);
 
-    //geometry objects for the following:
-    G4RotationMatrix* rotateExtension[8];
-    G4ThreeVector moveExtension[8];
+	//geometry objects for the following:
+	G4RotationMatrix* rotateExtension[8];
+	G4ThreeVector moveExtension[8];
 
-    x0 =  - fCanFaceThickness/2.0 -(shellSuppressorExtensionLength/2.0
-                                           - (fSuppressorExtensionThickness + fSuppressorShellThickness*2.0)
-                                           * tan(fBentEndAngle)/2.0)
-            * cos(fBentEndAngle) +fBentEndLength +(fBGOCanSeperation
-                                                                 + fSideBGOThickness
-                                                                 + fSuppressorShellThickness*2.0)/tan(fBentEndAngle)
-            - (fSuppressorExtensionThickness + fSuppressorShellThickness*2.0)
-            * sin(fBentEndAngle) +fSuppShift +fSuppressorBackRadius
-            - fSuppressorForwardRadius ;
+	x0 =  - fCanFaceThickness/2.0 -(shellSuppressorExtensionLength/2.0
+			- (fSuppressorExtensionThickness + fSuppressorShellThickness*2.0)
+			* tan(fBentEndAngle)/2.0)
+		* cos(fBentEndAngle) +fBentEndLength +(fBGOCanSeperation
+				+ fSideBGOThickness
+				+ fSuppressorShellThickness*2.0)/tan(fBentEndAngle)
+		- (fSuppressorExtensionThickness + fSuppressorShellThickness*2.0)
+		* sin(fBentEndAngle) +fSuppShift +fSuppressorBackRadius
+		- fSuppressorForwardRadius ;
 
-    y0 =  - (shellSuppressorExtensionLength * tan(shellSuppressorExtensionAngle) / 2.0
-              + (fSuppressorForwardRadius + fHevimetTipThickness)
-              * sin(fBentEndAngle))/2.0;
+	y0 =  - (shellSuppressorExtensionLength * tan(shellSuppressorExtensionAngle) / 2.0
+			+ (fSuppressorForwardRadius + fHevimetTipThickness)
+			* sin(fBentEndAngle))/2.0;
 
-    z0 =  - ((fSuppressorExtensionThickness/2.0 + fSuppressorShellThickness)
-             / cos(fBentEndAngle)
-             + (shellSuppressorExtensionLength/2.0 -(fSuppressorExtensionThickness
-                                                        + fSuppressorShellThickness*2.0)
-                * tan(fBentEndAngle)/2.0)*sin(fBentEndAngle) -(fSuppressorBackRadius
-                                                                             + fBentEndLength +(fBGOCanSeperation
-                                                                                                       + fSideBGOThickness + fSuppressorShellThickness*2.0)
-                                                                             / tan(fBentEndAngle) -(fSuppressorExtensionThickness
-                                                                                                           + fSuppressorShellThickness*2.0)
-                                                                             * sin(fBentEndAngle)) * tan(fBentEndAngle)) ;
+	z0 =  - ((fSuppressorExtensionThickness/2.0 + fSuppressorShellThickness)
+			/ cos(fBentEndAngle)
+			+ (shellSuppressorExtensionLength/2.0 -(fSuppressorExtensionThickness
+					+ fSuppressorShellThickness*2.0)
+				* tan(fBentEndAngle)/2.0)*sin(fBentEndAngle) -(fSuppressorBackRadius
+				+ fBentEndLength +(fBGOCanSeperation
+					+ fSideBGOThickness + fSuppressorShellThickness*2.0)
+				/ tan(fBentEndAngle) -(fSuppressorExtensionThickness
+					+ fSuppressorShellThickness*2.0)
+				* sin(fBentEndAngle)) * tan(fBentEndAngle)) ;
 
-    if(fSuppressorPositionSelector == 0 && fIncludeExtensionSuppressors)
-    {
+	if(fSuppressorPositionSelector == 0 && fIncludeExtensionSuppressors)
+	{
 
-        // these two parameters are for shifting the extensions back and out when in their BACK position
-        G4double extensionBackShift =   fAirBoxFrontLength
-                - (fHevimetTipThickness +shellSuppressorExtensionLength
-                   + (fSuppressorExtensionThickness + fSuppressorShellThickness*2.0)
-                   * tan(fBentEndAngle)) * cos(fBentEndAngle) ;
+		// these two parameters are for shifting the extensions back and out when in their BACK position
+		G4double extensionBackShift =   fAirBoxFrontLength
+			- (fHevimetTipThickness +shellSuppressorExtensionLength
+					+ (fSuppressorExtensionThickness + fSuppressorShellThickness*2.0)
+					* tan(fBentEndAngle)) * cos(fBentEndAngle) ;
 
-        G4double extensionRadialShift = extensionBackShift * tan(fBentEndAngle) ;
+		G4double extensionRadialShift = extensionBackShift * tan(fBentEndAngle) ;
 
-        // The suppressors are put into the back position
+		// The suppressors are put into the back position
 
-        x0 += extensionBackShift ;
+		x0 += extensionBackShift ;
 
-        z0 += extensionRadialShift ;
+		z0 += extensionRadialShift ;
 
-        for(i=0; i<4; i++)
-        {
-            rotateExtension[i*2] = new G4RotationMatrix;
-            rotateExtension[i*2]->rotateZ(M_PI/2.0);
-            rotateExtension[i*2]->rotateY(fBentEndAngle);
-            rotateExtension[i*2]->rotateX(M_PI - M_PI/2.0*i);
+		for(i=0; i<4; i++)
+		{
+			rotateExtension[i*2] = new G4RotationMatrix;
+			rotateExtension[i*2]->rotateZ(M_PI/2.0);
+			rotateExtension[i*2]->rotateY(fBentEndAngle);
+			rotateExtension[i*2]->rotateX(M_PI - M_PI/2.0*i);
 
-            x = x0;
-            y = y0*cos(i*M_PI/2) + z0*sin(i*M_PI/2);
-            z = z0*cos(i*M_PI/2) - y0*sin(i*M_PI/2);
+			x = x0;
+			y = y0*cos(i*M_PI/2) + z0*sin(i*M_PI/2);
+			z = z0*cos(i*M_PI/2) - y0*sin(i*M_PI/2);
 
-            moveExtension[i*2] = G4ThreeVector(x, y, z);
+			moveExtension[i*2] = G4ThreeVector(x, y, z);
 
-            fExtensionSuppressorShellAssembly->AddPlacedVolume(fRightSuppressorShellExtensionLog, moveExtension[i*2], rotateExtension[i*2]);
+			fExtensionSuppressorShellAssembly->AddPlacedVolume(fRightSuppressorShellExtensionLog, moveExtension[i*2], rotateExtension[i*2]);
 
-            rotateExtension[i*2+1] = new G4RotationMatrix;
-            rotateExtension[i*2+1]->rotateY(M_PI/2.0);
-            rotateExtension[i*2+1]->rotateZ(M_PI/2.0 + fBentEndAngle);
-            rotateExtension[i*2+1]->rotateX(M_PI - M_PI/2.0*i);
+			rotateExtension[i*2+1] = new G4RotationMatrix;
+			rotateExtension[i*2+1]->rotateY(M_PI/2.0);
+			rotateExtension[i*2+1]->rotateZ(M_PI/2.0 + fBentEndAngle);
+			rotateExtension[i*2+1]->rotateX(M_PI - M_PI/2.0*i);
 
-            x = x0;
-            y = -z0*cos(i*M_PI/2) - y0*sin(i*M_PI/2);
-            z = -y0*cos(i*M_PI/2) + z0*sin(i*M_PI/2);
+			x = x0;
+			y = -z0*cos(i*M_PI/2) - y0*sin(i*M_PI/2);
+			z = -y0*cos(i*M_PI/2) + z0*sin(i*M_PI/2);
 
-            moveExtension[i*2+1] = G4ThreeVector(x, y, z);
+			moveExtension[i*2+1] = G4ThreeVector(x, y, z);
 
-            fExtensionSuppressorShellAssembly->AddPlacedVolume(fLeftSuppressorShellExtensionLog, moveExtension[i*2+1], rotateExtension[i*2+1]);
-        }
+			fExtensionSuppressorShellAssembly->AddPlacedVolume(fLeftSuppressorShellExtensionLog, moveExtension[i*2+1], rotateExtension[i*2+1]);
+		}
 
 
-    }//end if(detectors forward) statement
+	}//end if(detectors forward) statement
 
-    // Otherwise, put them forward
-    else if(fSuppressorPositionSelector == 1 && fIncludeExtensionSuppressors)
-    {
+	// Otherwise, put them forward
+	else if(fSuppressorPositionSelector == 1 && fIncludeExtensionSuppressors)
+	{
 
-        for(i = 0 ; i < 4 ; i++){
-            rotateExtension[2*i] = new G4RotationMatrix;
-            rotateExtension[2*i]->rotateZ(M_PI/2.0);
-            rotateExtension[2*i]->rotateY(fBentEndAngle);
-            rotateExtension[2*i]->rotateX(M_PI - i*M_PI/2.0);
+		for(i = 0 ; i < 4 ; i++){
+			rotateExtension[2*i] = new G4RotationMatrix;
+			rotateExtension[2*i]->rotateZ(M_PI/2.0);
+			rotateExtension[2*i]->rotateY(fBentEndAngle);
+			rotateExtension[2*i]->rotateX(M_PI - i*M_PI/2.0);
 
-            x = x0;
-            y = y0*cos(i*M_PI/2) + z0*sin(i*M_PI/2);
-            z = z0*cos(i*M_PI/2) - y0*sin(i*M_PI/2);
+			x = x0;
+			y = y0*cos(i*M_PI/2) + z0*sin(i*M_PI/2);
+			z = z0*cos(i*M_PI/2) - y0*sin(i*M_PI/2);
 
-            moveExtension[i*2] = G4ThreeVector(x, y, z);
+			moveExtension[i*2] = G4ThreeVector(x, y, z);
 
-            fExtensionSuppressorShellAssembly->AddPlacedVolume(fRightSuppressorShellExtensionLog, moveExtension[2*i], rotateExtension[2*i]);
+			fExtensionSuppressorShellAssembly->AddPlacedVolume(fRightSuppressorShellExtensionLog, moveExtension[2*i], rotateExtension[2*i]);
 
-            rotateExtension[2*i+1] = new G4RotationMatrix;
-            rotateExtension[2*i+1]->rotateY(M_PI/2.0);
-            rotateExtension[2*i+1]->rotateZ(M_PI/2.0 + fBentEndAngle);
-            rotateExtension[2*i+1]->rotateX(M_PI - i*M_PI/2);
+			rotateExtension[2*i+1] = new G4RotationMatrix;
+			rotateExtension[2*i+1]->rotateY(M_PI/2.0);
+			rotateExtension[2*i+1]->rotateZ(M_PI/2.0 + fBentEndAngle);
+			rotateExtension[2*i+1]->rotateX(M_PI - i*M_PI/2);
 
-            x =  x0;
-            y =  -z0 * cos(i*M_PI/2) - y0 * sin(i*M_PI/2);
-            z =  -y0 * cos(i*M_PI/2) + z0 * sin(i*M_PI/2);
+			x =  x0;
+			y =  -z0 * cos(i*M_PI/2) - y0 * sin(i*M_PI/2);
+			z =  -y0 * cos(i*M_PI/2) + z0 * sin(i*M_PI/2);
 
-            moveExtension[i*2+1] = G4ThreeVector(x, y, z);
+			moveExtension[i*2+1] = G4ThreeVector(x, y, z);
 
-            fExtensionSuppressorShellAssembly->AddPlacedVolume(fLeftSuppressorShellExtensionLog, moveExtension[2*i+1], rotateExtension[2*i+1]);
-        }
+			fExtensionSuppressorShellAssembly->AddPlacedVolume(fLeftSuppressorShellExtensionLog, moveExtension[2*i+1], rotateExtension[2*i+1]);
+		}
 
-    }//end if(detectors back) statement
+	}//end if(detectors back) statement
 
 }//end ::ConstructNewSuppressorCasingWithShells
 
 
 void DetectionSystemGriffin::ConstructNewSuppressorCasingDetectorSpecificDeadLayer(G4int det, G4int cry) {
-    G4String strdet = G4UIcommand::ConvertToString(det);
-    G4String strcry = G4UIcommand::ConvertToString(cry);
+	G4String strdet = G4UIcommand::ConvertToString(det);
+	G4String strcry = G4UIcommand::ConvertToString(cry);
 
-    G4Material* materialBGO = G4Material::GetMaterial(fBGOMaterial);
-    if(!materialBGO) {
-        G4cout<<" ----> BGO material "<<fBGOMaterial<<" not found, cannot build the detector shell! "<<G4endl;
-        exit(1);
-    }
+	G4Material* materialBGO = G4Material::GetMaterial(fBGOMaterial);
+	if(!materialBGO) {
+		G4cout<<" ----> BGO material "<<fBGOMaterial<<" not found, cannot build the detector shell! "<<G4endl;
+		exit(1);
+	}
 
-    G4VisAttributes* SuppressorVisAtt = new G4VisAttributes(G4Colour(0.75,0.75,0.75));
-    SuppressorVisAtt->SetVisibility(true);
-    G4VisAttributes* innardsVisAtt = new G4VisAttributes(G4Colour(0.75, 0.75, 0.75));
-    innardsVisAtt->SetVisibility(true);
-    G4VisAttributes* backInnardsVisAtt = new G4VisAttributes(G4Colour(0.0, 1.0, 0.0));
-    backInnardsVisAtt->SetVisibility(true);
+	G4VisAttributes* SuppressorVisAtt = new G4VisAttributes(G4Colour(0.75,0.75,0.75));
+	SuppressorVisAtt->SetVisibility(true);
+	G4VisAttributes* innardsVisAtt = new G4VisAttributes(G4Colour(0.75, 0.75, 0.75));
+	innardsVisAtt->SetVisibility(true);
+	G4VisAttributes* backInnardsVisAtt = new G4VisAttributes(G4Colour(0.0, 1.0, 0.0));
+	backInnardsVisAtt->SetVisibility(true);
 
-    // first we add the four pieces of back suppressor, and their shells
+	// first we add the four pieces of back suppressor, and their shells
 
-    G4SubtractionSolid* backQuarterSuppressor = BackSuppressorQuarter();
+	G4SubtractionSolid* backQuarterSuppressor = BackSuppressorQuarter();
 
-    // Insert the structureMat shell first.  The shells must be given numbers, rather than
-    // the suppressor pieces themselves.  As an error checking method, the suppressor
-    // pieces are given a copy number value far out of range of any useful copy number.
-    if(fIncludeBackSuppressors) {
-        G4Material* backMaterial = G4Material::GetMaterial(fBackSuppressorMaterial);
+	// Insert the structureMat shell first.  The shells must be given numbers, rather than
+	// the suppressor pieces themselves.  As an error checking method, the suppressor
+	// pieces are given a copy number value far out of range of any useful copy number.
+	if(fIncludeBackSuppressors) {
+		G4Material* backMaterial = G4Material::GetMaterial(fBackSuppressorMaterial);
 
-        if(!backMaterial) {
-            G4cout<<" ----> Back suppressor material "<<fBackSuppressorMaterial<<" not found, cannot build the detector shell! "<<G4endl;
-            exit(1);
-        }
+		if(!backMaterial) {
+			G4cout<<" ----> Back suppressor material "<<fBackSuppressorMaterial<<" not found, cannot build the detector shell! "<<G4endl;
+			exit(1);
+		}
 
-        G4String backQuarterSuppressorName = "backDlsQuarterSuppressor_" + strdet + "_" + strcry + "_log" ;
+		G4String backQuarterSuppressorName = "backDlsQuarterSuppressor_" + strdet + "_" + strcry + "_log" ;
 
-        fBackQuarterSuppressorLog = new G4LogicalVolume(backQuarterSuppressor, backMaterial,
-                                                          backQuarterSuppressorName, 0, 0, 0);
+		fBackQuarterSuppressorLog = new G4LogicalVolume(backQuarterSuppressor, backMaterial,
+				backQuarterSuppressorName, 0, 0, 0);
 
-        fBackQuarterSuppressorLog->SetVisAttributes(backInnardsVisAtt);
+		fBackQuarterSuppressorLog->SetVisAttributes(backInnardsVisAtt);
 
-        fSuppressorBackAssemblyCry[cry]->AddPlacedVolume(fBackQuarterSuppressorLog, fMoveNull, fRotateNull);
+		fSuppressorBackAssemblyCry[cry]->AddPlacedVolume(fBackQuarterSuppressorLog, fMoveNull, fRotateNull);
 
-    }
+	}
 
-    // now we add the side pieces of suppressor that taper off towards the front of the can
+	// now we add the side pieces of suppressor that taper off towards the front of the can
 
-    G4String rightSuppressorCasingName = "rightDlsSuppressorCasing_" + strdet + "_" + strcry + "_log" ;
-    G4String leftSuppressorCasingName = "leftDlsSuppressorCasing_" + strdet + "_" + strcry + "_log" ;
+	G4String rightSuppressorCasingName = "rightDlsSuppressorCasing_" + strdet + "_" + strcry + "_log" ;
+	G4String leftSuppressorCasingName = "leftDlsSuppressorCasing_" + strdet + "_" + strcry + "_log" ;
 
-    G4SubtractionSolid* rightSuppressor = FrontSlantSuppressor("right", false); // Right, non-chopping. // CALLED
+	G4SubtractionSolid* rightSuppressor = FrontSlantSuppressor("right", false); // Right, non-chopping. // CALLED
 
-    fRightSuppressorLog = new G4LogicalVolume(rightSuppressor, materialBGO, rightSuppressorCasingName, 0, 0, 0);
-    fRightSuppressorLog->SetVisAttributes(innardsVisAtt);
+	fRightSuppressorLog = new G4LogicalVolume(rightSuppressor, materialBGO, rightSuppressorCasingName, 0, 0, 0);
+	fRightSuppressorLog->SetVisAttributes(innardsVisAtt);
 
-    G4SubtractionSolid* leftSuppressor = FrontSlantSuppressor("left", false); // Left, non-chopping. // CALLED
+	G4SubtractionSolid* leftSuppressor = FrontSlantSuppressor("left", false); // Left, non-chopping. // CALLED
 
-    fLeftSuppressorLog = new G4LogicalVolume(leftSuppressor, materialBGO, leftSuppressorCasingName, 0, 0, 0);
-    fLeftSuppressorLog->SetVisAttributes(innardsVisAtt);
+	fLeftSuppressorLog = new G4LogicalVolume(leftSuppressor, materialBGO, leftSuppressorCasingName, 0, 0, 0);
+	fLeftSuppressorLog->SetVisAttributes(innardsVisAtt);
 
-    fRightSuppressorCasingAssemblyCry[cry]->AddPlacedVolume(fRightSuppressorLog, fMoveNull, fRotateNull);
-    fLeftSuppressorCasingAssemblyCry[cry]->AddPlacedVolume(fLeftSuppressorLog, fMoveNull, fRotateNull);
+	fRightSuppressorCasingAssemblyCry[cry]->AddPlacedVolume(fRightSuppressorLog, fMoveNull, fRotateNull);
+	fLeftSuppressorCasingAssemblyCry[cry]->AddPlacedVolume(fLeftSuppressorLog, fMoveNull, fRotateNull);
 
-    G4String rightSuppressorExtensionName = "rightDlsSuppressorExtension_" + strdet + "_" + strcry + "_log" ;
-    G4String leftSuppressorExtensionName = "leftDlsSuppressorExtension_" + strdet + "_" + strcry + "_log" ;
+	G4String rightSuppressorExtensionName = "rightDlsSuppressorExtension_" + strdet + "_" + strcry + "_log" ;
+	G4String leftSuppressorExtensionName = "leftDlsSuppressorExtension_" + strdet + "_" + strcry + "_log" ;
 
-    // now we add the side pieces of suppressor that extend out in front of the can when it's in the back position
+	// now we add the side pieces of suppressor that extend out in front of the can when it's in the back position
 
-    G4SubtractionSolid* rightSuppressorExtension = SideSuppressorExtension("right", false); // Right, non-chopping // CALLED
+	G4SubtractionSolid* rightSuppressorExtension = SideSuppressorExtension("right", false); // Right, non-chopping // CALLED
 
-    fRightSuppressorExtensionLog = new G4LogicalVolume(rightSuppressorExtension, materialBGO,
-                                                            rightSuppressorExtensionName, 0, 0, 0);
-    fRightSuppressorExtensionLog->SetVisAttributes(innardsVisAtt);
+	fRightSuppressorExtensionLog = new G4LogicalVolume(rightSuppressorExtension, materialBGO,
+			rightSuppressorExtensionName, 0, 0, 0);
+	fRightSuppressorExtensionLog->SetVisAttributes(innardsVisAtt);
 
-    G4SubtractionSolid* leftSuppressorExtension = SideSuppressorExtension("left", false); // Left, Non-chopping // CALLED
+	G4SubtractionSolid* leftSuppressorExtension = SideSuppressorExtension("left", false); // Left, Non-chopping // CALLED
 
-    fLeftSuppressorExtensionLog = new G4LogicalVolume(leftSuppressorExtension, materialBGO,
-                                                        leftSuppressorExtensionName, 0, 0, 0);
-    fLeftSuppressorExtensionLog->SetVisAttributes(innardsVisAtt);
+	fLeftSuppressorExtensionLog = new G4LogicalVolume(leftSuppressorExtension, materialBGO,
+			leftSuppressorExtensionName, 0, 0, 0);
+	fLeftSuppressorExtensionLog->SetVisAttributes(innardsVisAtt);
 
-    fRightSuppressorExtensionAssemblyCry[cry]->AddPlacedVolume(fRightSuppressorExtensionLog, fMoveNull, fRotateNull);
-    fLeftSuppressorExtensionAssemblyCry[cry]->AddPlacedVolume(fLeftSuppressorExtensionLog, fMoveNull, fRotateNull);
+	fRightSuppressorExtensionAssemblyCry[cry]->AddPlacedVolume(fRightSuppressorExtensionLog, fMoveNull, fRotateNull);
+	fLeftSuppressorExtensionAssemblyCry[cry]->AddPlacedVolume(fLeftSuppressorExtensionLog, fMoveNull, fRotateNull);
 
 
 }//end ::ConstructNewSuppressorCasingDetectorSpecificDeadLayer
@@ -2074,69 +2074,69 @@ void DetectionSystemGriffin::ConstructNewSuppressorCasingDetectorSpecificDeadLay
 // the electrodeMat layers between the crystals
 ///////////////////////////////////////////////////////////////////////
 G4UnionSolid* DetectionSystemGriffin::InterCrystalelectrodeMatBack() {
-    G4double distanceOfTheTriangleTips = fGermaniumSeparation/2.0
-            + (fGermaniumWidth/2.0 - fGermaniumShift) //centre of the middle hole
-            + sqrt(pow((fGermaniumOuterRadius
-                         + fTrianglePostsDistanceFromCrystals), 2.0)
-                    - pow(fGermaniumWidth/2.0 - fGermaniumShift, 2.0));
+	G4double distanceOfTheTriangleTips = fGermaniumSeparation/2.0
+		+ (fGermaniumWidth/2.0 - fGermaniumShift) //centre of the middle hole
+		+ sqrt(pow((fGermaniumOuterRadius
+						+ fTrianglePostsDistanceFromCrystals), 2.0)
+				- pow(fGermaniumWidth/2.0 - fGermaniumShift, 2.0));
 
-    G4double extentOfTheElectrodeMatPieces = distanceOfTheTriangleTips
-            - fTrianglePostsDistanceFromCrystals;
+	G4double extentOfTheElectrodeMatPieces = distanceOfTheTriangleTips
+		- fTrianglePostsDistanceFromCrystals;
 
-    G4Box* electrodeMatPiece1 = new G4Box("electrodeMatPiece1", extentOfTheElectrodeMatPieces,
-                                            (fGermaniumLength-fGermaniumBentLength)/2.0,
-                                            fInterCrystalElectrodeMatThickness/2.0);
+	G4Box* electrodeMatPiece1 = new G4Box("electrodeMatPiece1", extentOfTheElectrodeMatPieces,
+			(fGermaniumLength-fGermaniumBentLength)/2.0,
+			fInterCrystalElectrodeMatThickness/2.0);
 
-    G4Box* electrodeMatPiece2 = new G4Box("electrodeMatPiece2", extentOfTheElectrodeMatPieces,
-                                            (fGermaniumLength-fGermaniumBentLength)/2.0,
-                                            fInterCrystalElectrodeMatThickness/2.0);
+	G4Box* electrodeMatPiece2 = new G4Box("electrodeMatPiece2", extentOfTheElectrodeMatPieces,
+			(fGermaniumLength-fGermaniumBentLength)/2.0,
+			fInterCrystalElectrodeMatThickness/2.0);
 
-    G4RotationMatrix* rotatePiece2 = new G4RotationMatrix;
-    rotatePiece2->rotateY(M_PI/2.0);
+	G4RotationMatrix* rotatePiece2 = new G4RotationMatrix;
+	rotatePiece2->rotateY(M_PI/2.0);
 
-    G4ThreeVector moveZero(0,0,0);
+	G4ThreeVector moveZero(0,0,0);
 
-    G4UnionSolid* interCrystalElectrodeMatBack = new G4UnionSolid(
-                "interCrystalElectrodeMatBack", electrodeMatPiece1, electrodeMatPiece2,
-                rotatePiece2, moveZero);
+	G4UnionSolid* interCrystalElectrodeMatBack = new G4UnionSolid(
+			"interCrystalElectrodeMatBack", electrodeMatPiece1, electrodeMatPiece2,
+			rotatePiece2, moveZero);
 
-    return interCrystalElectrodeMatBack;
+	return interCrystalElectrodeMatBack;
 } //end ::interCrystalelectrodeMatBack
 
 G4UnionSolid* DetectionSystemGriffin::InterCrystalelectrodeMatFront() {
 
-    G4double distanceOfTheTriangleTips = fGermaniumSeparation/2.0
-            + (fGermaniumWidth/2.0 - fGermaniumShift) //centre of the middle hole
-            + sqrt(pow((fGermaniumOuterRadius
-                         + fTrianglePostsDistanceFromCrystals), 2.0)
-                    - pow(fGermaniumWidth/2.0 - fGermaniumShift, 2.0));
+	G4double distanceOfTheTriangleTips = fGermaniumSeparation/2.0
+		+ (fGermaniumWidth/2.0 - fGermaniumShift) //centre of the middle hole
+		+ sqrt(pow((fGermaniumOuterRadius
+						+ fTrianglePostsDistanceFromCrystals), 2.0)
+				- pow(fGermaniumWidth/2.0 - fGermaniumShift, 2.0));
 
-    G4Trd* electrodeMatPiece1 = new G4Trd("electrodeMatPiece1", distanceOfTheTriangleTips
-                                           - fTrianglePostsDistanceFromCrystals,
-                                           fGermaniumWidth - fGermaniumBentLength
-                                           *tan(fBentEndAngle),
-                                           fGermaniumSeparation/2.0,
-                                           fGermaniumSeparation/2.0, (fGermaniumBentLength
-                                                                            - fElectrodeMatStartingDepth)/2.0);
+	G4Trd* electrodeMatPiece1 = new G4Trd("electrodeMatPiece1", distanceOfTheTriangleTips
+			- fTrianglePostsDistanceFromCrystals,
+			fGermaniumWidth - fGermaniumBentLength
+			*tan(fBentEndAngle),
+			fGermaniumSeparation/2.0,
+			fGermaniumSeparation/2.0, (fGermaniumBentLength
+				- fElectrodeMatStartingDepth)/2.0);
 
-    G4Trd* electrodeMatPiece2 = new G4Trd("electrodeMatPiece2", distanceOfTheTriangleTips
-                                           - fTrianglePostsDistanceFromCrystals,
-                                           fGermaniumWidth - fGermaniumBentLength
-                                           *tan(fBentEndAngle),
-                                           fGermaniumSeparation/2.0,
-                                           fGermaniumSeparation/2.0, (fGermaniumBentLength
-                                                                            - fElectrodeMatStartingDepth)/2.0);
+	G4Trd* electrodeMatPiece2 = new G4Trd("electrodeMatPiece2", distanceOfTheTriangleTips
+			- fTrianglePostsDistanceFromCrystals,
+			fGermaniumWidth - fGermaniumBentLength
+			*tan(fBentEndAngle),
+			fGermaniumSeparation/2.0,
+			fGermaniumSeparation/2.0, (fGermaniumBentLength
+				- fElectrodeMatStartingDepth)/2.0);
 
-    G4RotationMatrix* rotatePiece2 = new G4RotationMatrix;
-    rotatePiece2->rotateZ(M_PI/2.0);
+	G4RotationMatrix* rotatePiece2 = new G4RotationMatrix;
+	rotatePiece2->rotateZ(M_PI/2.0);
 
-    G4ThreeVector moveZero(0,0,0);
+	G4ThreeVector moveZero(0,0,0);
 
-    G4UnionSolid* interCrystalElectrodeMatFront = new G4UnionSolid(
-                "interCrystalElectrodeMatFront", electrodeMatPiece1, electrodeMatPiece2,
-                rotatePiece2, moveZero);
+	G4UnionSolid* interCrystalElectrodeMatFront = new G4UnionSolid(
+			"interCrystalElectrodeMatFront", electrodeMatPiece1, electrodeMatPiece2,
+			rotatePiece2, moveZero);
 
-    return interCrystalElectrodeMatFront;
+	return interCrystalElectrodeMatFront;
 } //end ::interCrystalelectrodeMatFront
 
 ///////////////////////////////////////////////////////////////////////
@@ -2145,33 +2145,33 @@ G4UnionSolid* DetectionSystemGriffin::InterCrystalelectrodeMatFront() {
 // forward position   
 ///////////////////////////////////////////////////////////////////////
 void DetectionSystemGriffin::ConstructNewHeavyMet() {
-    G4Material* materialHevimetal = G4Material::GetMaterial("Hevimetal");
-    if(!materialHevimetal) {
-        G4cout<<" ----> Material Hevimetal not found, cannot build the detector shell! "<<G4endl;
-        exit(1);
-    }
+	G4Material* materialHevimetal = G4Material::GetMaterial("Hevimetal");
+	if(!materialHevimetal) {
+		G4cout<<" ----> Material Hevimetal not found, cannot build the detector shell! "<<G4endl;
+		exit(1);
+	}
 
-    G4VisAttributes* heviMetVisAtt = new G4VisAttributes(G4Colour(0.5,0.5,0.5));
-    heviMetVisAtt->SetVisibility(true);
+	G4VisAttributes* heviMetVisAtt = new G4VisAttributes(G4Colour(0.5,0.5,0.5));
+	heviMetVisAtt->SetVisibility(true);
 
-    G4SubtractionSolid* hevimet = NewHeavyMet();
-    
-    G4RotationMatrix* rotateHevimet = new G4RotationMatrix;
-    rotateHevimet->rotateY(-1.0*M_PI/2.0);
+	G4SubtractionSolid* hevimet = NewHeavyMet();
 
-    G4ThreeVector moveHevimet(((fHevimetTipThickness / cos(fHevimetTipAngle)) * cos(fBentEndAngle -fHevimetTipAngle)
-                                 + fSuppressorForwardRadius* tan(fHevimetTipAngle)*sin(fBentEndAngle))/2.0
-                                - fAirBoxBackLength/2.0 -fAirBoxFrontLength, 0.0, 0.0);
+	G4RotationMatrix* rotateHevimet = new G4RotationMatrix;
+	rotateHevimet->rotateY(-1.0*M_PI/2.0);
 
-    // NOTE** The hevimet does not require the "shift" parameter, as the airBox has been designed
-    // so that the hevimet sits right at the front, and has been moved accordingly. Also, the
-    // "appliedBackShift" parameter is missing, as the hevimet only goes on in the "detector back" position
+	G4ThreeVector moveHevimet(((fHevimetTipThickness / cos(fHevimetTipAngle)) * cos(fBentEndAngle -fHevimetTipAngle)
+				+ fSuppressorForwardRadius* tan(fHevimetTipAngle)*sin(fBentEndAngle))/2.0
+			- fAirBoxBackLength/2.0 -fAirBoxFrontLength, 0.0, 0.0);
 
-    fHevimetLog = new G4LogicalVolume(hevimet, materialHevimetal, "hevimetLog", 0, 0, 0);
+	// NOTE** The hevimet does not require the "shift" parameter, as the airBox has been designed
+	// so that the hevimet sits right at the front, and has been moved accordingly. Also, the
+	// "appliedBackShift" parameter is missing, as the hevimet only goes on in the "detector back" position
 
-    fHevimetLog->SetVisAttributes(heviMetVisAtt);
+	fHevimetLog = new G4LogicalVolume(hevimet, materialHevimetal, "hevimetLog", 0, 0, 0);
 
-    fHevimetAssembly->AddPlacedVolume(fHevimetLog, moveHevimet, rotateHevimet);
+	fHevimetLog->SetVisAttributes(heviMetVisAtt);
+
+	fHevimetAssembly->AddPlacedVolume(fHevimetLog, moveHevimet, rotateHevimet);
 
 
 }//end ::ConstructHeavyMet
@@ -2182,30 +2182,30 @@ void DetectionSystemGriffin::ConstructNewHeavyMet() {
 ///////////////////////////////////////////////////////////////////////
 G4Box* DetectionSystemGriffin::SquareFrontFace() {
 
-    G4double fixOverlap = 250*nm;
+	G4double fixOverlap = 250*nm;
 
-    G4double halfThicknessX = fCanFaceThickness/2.0;
-    
-    G4double halfLengthY = ((fDetectorTotalWidth/2.0) -(fBentEndLength
-                                                                *tan(fBentEndAngle)))-fixOverlap;
-    
-    G4double halfLengthZ = halfLengthY;
+	G4double halfThicknessX = fCanFaceThickness/2.0;
 
-    G4Box* frontFace = new G4Box("frontFace", halfThicknessX, halfLengthY, halfLengthZ);
+	G4double halfLengthY = ((fDetectorTotalWidth/2.0) -(fBentEndLength
+				*tan(fBentEndAngle)))-fixOverlap;
 
-    return frontFace;
+	G4double halfLengthZ = halfLengthY;
+
+	G4Box* frontFace = new G4Box("frontFace", halfThicknessX, halfLengthY, halfLengthZ);
+
+	return frontFace;
 
 }//end ::squareFrontFace
 
 
 G4Trap* DetectionSystemGriffin::CornerWedge() {
-    G4double heightY = fCanFaceThickness;
-    G4double lengthZ = fDetectorTotalWidth -2.0*(fBentEndLength *tan(fBentEndAngle));
-    G4double extensionLengthX = heightY *tan(fBentEndAngle);
+	G4double heightY = fCanFaceThickness;
+	G4double lengthZ = fDetectorTotalWidth -2.0*(fBentEndLength *tan(fBentEndAngle));
+	G4double extensionLengthX = heightY *tan(fBentEndAngle);
 
-    G4Trap* wedge = new G4Trap("wedge", lengthZ, heightY, extensionLengthX, fWedgeDim);
+	G4Trap* wedge = new G4Trap("wedge", lengthZ, heightY, extensionLengthX, fWedgeDim);
 
-    return wedge;
+	return wedge;
 }//end ::cornerWedge
 
 
@@ -2216,149 +2216,149 @@ G4Trap* DetectionSystemGriffin::CornerWedge() {
 ///////////////////////////////////////////////////////////////////////
 G4Para* DetectionSystemGriffin::BentSidePiece() {
 
-    G4double halfLengthX = ((fBentEndLength -fCanFaceThickness)
-                              /cos(fBentEndAngle))/2.0;
+	G4double halfLengthX = ((fBentEndLength -fCanFaceThickness)
+			/cos(fBentEndAngle))/2.0;
 
-    G4double halfLengthY = (fDetectorTotalWidth/2.0) -(fBentEndLength
-                                                                *tan(fBentEndAngle)) -fCanFaceThickness
-            *(1.0 -tan(fBentEndAngle));
+	G4double halfLengthY = (fDetectorTotalWidth/2.0) -(fBentEndLength
+			*tan(fBentEndAngle)) -fCanFaceThickness
+		*(1.0 -tan(fBentEndAngle));
 
-    // Last two operations in "halfLengthY" are correction
-    // factor to keep the bent pieces from overlapping
-    G4double halfLengthZ = fCanFaceThickness *cos(fBentEndAngle)/2.0;
-    G4double alphaAngle = 0.0*M_PI;
-    G4double polarAngle = fBentEndAngle;
-    G4double azimuthalAngle = 0.0*M_PI;
+	// Last two operations in "halfLengthY" are correction
+	// factor to keep the bent pieces from overlapping
+	G4double halfLengthZ = fCanFaceThickness *cos(fBentEndAngle)/2.0;
+	G4double alphaAngle = 0.0*M_PI;
+	G4double polarAngle = fBentEndAngle;
+	G4double azimuthalAngle = 0.0*M_PI;
 
-    G4Para* bentSidePiece = new G4Para("bentSidePiece", halfLengthX,
-                                         halfLengthY, halfLengthZ, alphaAngle, polarAngle, azimuthalAngle);
+	G4Para* bentSidePiece = new G4Para("bentSidePiece", halfLengthX,
+			halfLengthY, halfLengthZ, alphaAngle, polarAngle, azimuthalAngle);
 
-    return bentSidePiece;
+	return bentSidePiece;
 
 }//end ::bentSidePiece
 
 
 // this is a conic piece that attaches two bent end pieces
 G4Cons* DetectionSystemGriffin::RoundedEndEdge() {
-    G4double holeEliminator = fCanFaceThickness *(1.0 -tan(fBentEndAngle));
+	G4double holeEliminator = fCanFaceThickness *(1.0 -tan(fBentEndAngle));
 
-    // this is correction factor to avoid holes caused by bent pieces
-    G4double halfLengthZ = (fBentEndLength -fCanFaceThickness)/2.0;
-    G4double insideRadiusAtApex = 0.0;
-    G4double outsideRadiusAtApex = fCanFaceThickness *tan(fBentEndAngle) +holeEliminator;
-    G4double outsideRadiusAtBase = fBentEndLength *tan(fBentEndAngle) +holeEliminator;
-    G4double insideRadiusAtBase = outsideRadiusAtBase -fCanFaceThickness;
-    G4double startAngle = 0.0*M_PI;
-    G4double finalAngle = 0.5*M_PI;
+	// this is correction factor to avoid holes caused by bent pieces
+	G4double halfLengthZ = (fBentEndLength -fCanFaceThickness)/2.0;
+	G4double insideRadiusAtApex = 0.0;
+	G4double outsideRadiusAtApex = fCanFaceThickness *tan(fBentEndAngle) +holeEliminator;
+	G4double outsideRadiusAtBase = fBentEndLength *tan(fBentEndAngle) +holeEliminator;
+	G4double insideRadiusAtBase = outsideRadiusAtBase -fCanFaceThickness;
+	G4double startAngle = 0.0*M_PI;
+	G4double finalAngle = 0.5*M_PI;
 
-    G4Cons* roundedEndEdge = new G4Cons("roundedEndEdge", insideRadiusAtApex,
-                                          outsideRadiusAtApex, insideRadiusAtBase, outsideRadiusAtBase,
-                                          halfLengthZ, startAngle, finalAngle);
+	G4Cons* roundedEndEdge = new G4Cons("roundedEndEdge", insideRadiusAtApex,
+			outsideRadiusAtApex, insideRadiusAtBase, outsideRadiusAtBase,
+			halfLengthZ, startAngle, finalAngle);
 
-    return roundedEndEdge;
+	return roundedEndEdge;
 
 }//end ::roundedEndEdge
 
 
 G4Tubs* DetectionSystemGriffin::CornerTube() {
-    G4double outerRadius 	= fBentEndLength *tan(fBentEndAngle);
-    G4double innerRadius 	= outerRadius - fCanSideThickness;
-    G4double halfHeightZ 	= (fDetectorTotalLength -fBentEndLength
-                               -fRearPlateThickness)/2.0;
+	G4double outerRadius 	= fBentEndLength *tan(fBentEndAngle);
+	G4double innerRadius 	= outerRadius - fCanSideThickness;
+	G4double halfHeightZ 	= (fDetectorTotalLength -fBentEndLength
+			-fRearPlateThickness)/2.0;
 
-    G4double startAngle = 0.0*M_PI;
-    G4double finalAngle = 0.5*M_PI;
+	G4double startAngle = 0.0*M_PI;
+	G4double finalAngle = 0.5*M_PI;
 
-    G4Tubs* cornerTube = new G4Tubs("cornerTube", innerRadius, outerRadius, halfHeightZ, startAngle, finalAngle);
+	G4Tubs* cornerTube = new G4Tubs("cornerTube", innerRadius, outerRadius, halfHeightZ, startAngle, finalAngle);
 
-    return cornerTube;
+	return cornerTube;
 }//end ::cornerTube
 
 
 G4Box* DetectionSystemGriffin::SidePanel() {
-    G4double halfLengthX = (fDetectorTotalLength -fBentEndLength -fRearPlateThickness)/2.0;
-    G4double halfThicknessY = (fCanSideThickness)/2.0;
-    G4double halfWidthZ = (fDetectorTotalWidth)/2.0 -(fBentEndLength *tan(fBentEndAngle));
+	G4double halfLengthX = (fDetectorTotalLength -fBentEndLength -fRearPlateThickness)/2.0;
+	G4double halfThicknessY = (fCanSideThickness)/2.0;
+	G4double halfWidthZ = (fDetectorTotalWidth)/2.0 -(fBentEndLength *tan(fBentEndAngle));
 
-    G4Box* sidePanel = new G4Box("sidePanel", halfLengthX, halfThicknessY, halfWidthZ);
+	G4Box* sidePanel = new G4Box("sidePanel", halfLengthX, halfThicknessY, halfWidthZ);
 
-    return sidePanel;
+	return sidePanel;
 }//end ::sidePanel
 
 
 G4SubtractionSolid* DetectionSystemGriffin::RearPlate() {
 
-    G4double halfWidthX = fDetectorTotalWidth/2.0;
-    G4double halfWidthY = halfWidthX;
-    G4double halfThicknessZ = fRearPlateThickness/2.0;
+	G4double halfWidthX = fDetectorTotalWidth/2.0;
+	G4double halfWidthY = halfWidthX;
+	G4double halfThicknessZ = fRearPlateThickness/2.0;
 
-    G4Box* plate = new G4Box("plate", halfWidthX, halfWidthY, halfThicknessZ);
+	G4Box* plate = new G4Box("plate", halfWidthX, halfWidthY, halfThicknessZ);
 
-    G4double innerRadius = 0.0;
-    G4double outerRadius = fColdFingerOuterShellRadius;
-    G4double halfHeightZ = halfThicknessZ +1.0*cm;  // +1.0*cm just to make sure the hole goes completely through the plate
-    G4double startAngle = 0.0*M_PI;
-    G4double finalAngle = 2.0*M_PI;
+	G4double innerRadius = 0.0;
+	G4double outerRadius = fColdFingerOuterShellRadius;
+	G4double halfHeightZ = halfThicknessZ +1.0*cm;  // +1.0*cm just to make sure the hole goes completely through the plate
+	G4double startAngle = 0.0*M_PI;
+	G4double finalAngle = 2.0*M_PI;
 
-    G4Tubs* hole = new G4Tubs("hole", innerRadius, outerRadius, halfHeightZ, startAngle, finalAngle);
+	G4Tubs* hole = new G4Tubs("hole", innerRadius, outerRadius, halfHeightZ, startAngle, finalAngle);
 
-    G4SubtractionSolid* rearPlate = new G4SubtractionSolid("rearPlate", plate, hole);
+	G4SubtractionSolid* rearPlate = new G4SubtractionSolid("rearPlate", plate, hole);
 
-    return rearPlate;
+	return rearPlate;
 }//end ::rearPlate
 
 
 G4Tubs* DetectionSystemGriffin::ColdFingerShell() {
-    G4double outerRadius = fColdFingerOuterShellRadius;
-    G4double innerRadius = outerRadius - fColdFingerShellThickness;
-    G4double halfLengthZ = fColdFingerShellLength/2.0;
-    G4double startAngle = 0.0*M_PI;
-    G4double finalAngle = 2.0*M_PI;
+	G4double outerRadius = fColdFingerOuterShellRadius;
+	G4double innerRadius = outerRadius - fColdFingerShellThickness;
+	G4double halfLengthZ = fColdFingerShellLength/2.0;
+	G4double startAngle = 0.0*M_PI;
+	G4double finalAngle = 2.0*M_PI;
 
-    G4Tubs* coldFingerShell = new G4Tubs("coldFingerShell", innerRadius,
-                                           outerRadius, halfLengthZ, startAngle, finalAngle);
+	G4Tubs* coldFingerShell = new G4Tubs("coldFingerShell", innerRadius,
+			outerRadius, halfLengthZ, startAngle, finalAngle);
 
-    return coldFingerShell;
+	return coldFingerShell;
 
 }//end ::coldFingerShell
 
 
 G4Tubs* DetectionSystemGriffin::LiquidNitrogenTank() {
-    G4double innerRadius = fCoolantRadius - fCoolantThickness;
-    G4double outerRadius = fCoolantRadius;
-    G4double halfLengthZ = (fCoolantLength - 2.0*fCoolantThickness)/2.0;
-    G4double startAngle = 0.0*M_PI;
-    G4double finalAngle = 2.0*M_PI;
+	G4double innerRadius = fCoolantRadius - fCoolantThickness;
+	G4double outerRadius = fCoolantRadius;
+	G4double halfLengthZ = (fCoolantLength - 2.0*fCoolantThickness)/2.0;
+	G4double startAngle = 0.0*M_PI;
+	G4double finalAngle = 2.0*M_PI;
 
-    G4Tubs* tank = new G4Tubs("tank", innerRadius, outerRadius, halfLengthZ, startAngle, finalAngle);
+	G4Tubs* tank = new G4Tubs("tank", innerRadius, outerRadius, halfLengthZ, startAngle, finalAngle);
 
-    return tank;
+	return tank;
 
 }//end ::liquidNitrogenTank
 
 G4Tubs* DetectionSystemGriffin::LiquidNitrogenTankLid() {
-    G4double innerRadius = 0.0*mm;
-    G4double outerRadius = fCoolantRadius;
-    G4double halfLengthZ = (fCoolantThickness)/2.0;
-    G4double startAngle = 0.0*M_PI;
-    G4double finalAngle = 2.0*M_PI;
+	G4double innerRadius = 0.0*mm;
+	G4double outerRadius = fCoolantRadius;
+	G4double halfLengthZ = (fCoolantThickness)/2.0;
+	G4double startAngle = 0.0*M_PI;
+	G4double finalAngle = 2.0*M_PI;
 
-    G4Tubs* tank = new G4Tubs("tank", innerRadius, outerRadius, halfLengthZ, startAngle, finalAngle);
+	G4Tubs* tank = new G4Tubs("tank", innerRadius, outerRadius, halfLengthZ, startAngle, finalAngle);
 
-    return tank;
+	return tank;
 
 }//end ::liquidNitrogenTankLid
 
 G4Tubs* DetectionSystemGriffin::LiquidNitrogen() {
-    G4double innerRadius = 0.0*mm;
-    G4double outerRadius = fCoolantRadius - fCoolantThickness;
-    G4double halfLengthZ = (fCoolantLength - 2.0*fCoolantThickness)/2.0;
-    G4double startAngle = 0.0*M_PI;
-    G4double finalAngle = 2.0*M_PI;
+	G4double innerRadius = 0.0*mm;
+	G4double outerRadius = fCoolantRadius - fCoolantThickness;
+	G4double halfLengthZ = (fCoolantLength - 2.0*fCoolantThickness)/2.0;
+	G4double startAngle = 0.0*M_PI;
+	G4double finalAngle = 2.0*M_PI;
 
-    G4Tubs* tank = new G4Tubs("tank", innerRadius, outerRadius, halfLengthZ, startAngle, finalAngle);
+	G4Tubs* tank = new G4Tubs("tank", innerRadius, outerRadius, halfLengthZ, startAngle, finalAngle);
 
-    return tank;
+	return tank;
 
 }//end ::liquidNitrogen
 
@@ -2368,28 +2368,28 @@ G4Tubs* DetectionSystemGriffin::LiquidNitrogen() {
 // to form a UnionSolid
 ///////////////////////////////////////////////////////////////////////
 G4Box* DetectionSystemGriffin::RectangularSegment() {
-    G4double halfLengthX = fDetectorBlockHeight/2.0;
-    G4double halfLengthY = fDetectorBlockLength/2.0;
-    G4double halfLengthZ = halfLengthY; 	// Since it is symmetric
+	G4double halfLengthX = fDetectorBlockHeight/2.0;
+	G4double halfLengthY = fDetectorBlockLength/2.0;
+	G4double halfLengthZ = halfLengthY; 	// Since it is symmetric
 
-    G4Box* rectangularSegment = new G4Box("rectangularSegment", halfLengthX, halfLengthY, halfLengthZ);
+	G4Box* rectangularSegment = new G4Box("rectangularSegment", halfLengthX, halfLengthY, halfLengthZ);
 
-    return rectangularSegment;
+	return rectangularSegment;
 
 }// end ::rectangularSegment
 
 
 G4Trd* DetectionSystemGriffin::TrapezoidalSegment() {
-    G4double halfBaseX 		= fDetectorBlockLength/2.0;
-    G4double halfTopX 		= halfBaseX - (fDetectorBlockTrapezoidalHeight *tan(fBentEndAngle));
-    G4double halfBaseY 		= halfBaseX; 	// Since it is symmetric
-    G4double halfTopY 		= halfTopX;
-    G4double halfHeightZ 	= fDetectorBlockTrapezoidalHeight/2.0;
+	G4double halfBaseX 		= fDetectorBlockLength/2.0;
+	G4double halfTopX 		= halfBaseX - (fDetectorBlockTrapezoidalHeight *tan(fBentEndAngle));
+	G4double halfBaseY 		= halfBaseX; 	// Since it is symmetric
+	G4double halfTopY 		= halfTopX;
+	G4double halfHeightZ 	= fDetectorBlockTrapezoidalHeight/2.0;
 
-    G4Trd* trapezoidalSegment = new G4Trd("trapezoidalSegment",
-                                           halfBaseX, halfTopX, halfBaseY, halfTopY, halfHeightZ);
+	G4Trd* trapezoidalSegment = new G4Trd("trapezoidalSegment",
+			halfBaseX, halfTopX, halfBaseY, halfTopY, halfHeightZ);
 
-    return trapezoidalSegment;
+	return trapezoidalSegment;
 
 }//end ::trapezoidalSegment
 
@@ -2400,248 +2400,248 @@ G4Trd* DetectionSystemGriffin::TrapezoidalSegment() {
 ///////////////////////////////////////////////////////////////////////
 G4SubtractionSolid* DetectionSystemGriffin::QuarterDetector() {
 
-    G4double halfWidthX 	= fGermaniumWidth/2.0;
-    G4double halfWidthY 	= halfWidthX;
-    G4double halfLengthZ 	= fGermaniumLength/2.0;
+	G4double halfWidthX 	= fGermaniumWidth/2.0;
+	G4double halfWidthY 	= halfWidthX;
+	G4double halfLengthZ 	= fGermaniumLength/2.0;
 
-    G4Box* rectangularGermanium 	= new G4Box("rectangularGermanium", halfWidthX, halfWidthY, halfLengthZ);
+	G4Box* rectangularGermanium 	= new G4Box("rectangularGermanium", halfWidthX, halfWidthY, halfLengthZ);
 
-    G4double outerRadius = ((fGermaniumWidth +fGermaniumShift)*1.5)/2.0;
+	G4double outerRadius = ((fGermaniumWidth +fGermaniumShift)*1.5)/2.0;
 
-    // 1.5 is almost root 2, so this makes sure the corners are chopped off
+	// 1.5 is almost root 2, so this makes sure the corners are chopped off
 
-    G4double innerRadius = fGermaniumOuterRadius;
-    G4double startAngle = 0.0*M_PI;
-    G4double finalAngle = 2.0*M_PI;
+	G4double innerRadius = fGermaniumOuterRadius;
+	G4double startAngle = 0.0*M_PI;
+	G4double finalAngle = 2.0*M_PI;
 
-    G4ThreeVector moveChoppingCylinder(fGermaniumShift, -(fGermaniumShift), 0);
-    G4Tubs* choppingCylinder = new G4Tubs("choppingCylinder", innerRadius,
-                                           outerRadius, halfLengthZ+1.0*cm, startAngle, finalAngle);
+	G4ThreeVector moveChoppingCylinder(fGermaniumShift, -(fGermaniumShift), 0);
+	G4Tubs* choppingCylinder = new G4Tubs("choppingCylinder", innerRadius,
+			outerRadius, halfLengthZ+1.0*cm, startAngle, finalAngle);
 
-    G4SubtractionSolid* germaniumRoundedCorners = new G4SubtractionSolid("germaniumRoundedCorners",
-                                                                           rectangularGermanium, choppingCylinder, 0, moveChoppingCylinder);
+	G4SubtractionSolid* germaniumRoundedCorners = new G4SubtractionSolid("germaniumRoundedCorners",
+			rectangularGermanium, choppingCylinder, 0, moveChoppingCylinder);
 
-    G4double baseInnerRadius = fGermaniumOuterRadius;
-    G4double baseOuterRadius = 2.0*baseInnerRadius;
+	G4double baseInnerRadius = fGermaniumOuterRadius;
+	G4double baseOuterRadius = 2.0*baseInnerRadius;
 
-    // G4double tipInnerRadius = baseInnerRadius - fGermaniumBentLength*tan(fBentEndAngle);
-    G4double tipInnerRadius = baseInnerRadius
-            - fGermaniumCornerConeEndLength*tan(fBentEndAngle);
-    G4double tipOuterRadius = baseOuterRadius;
+	// G4double tipInnerRadius = baseInnerRadius - fGermaniumBentLength*tan(fBentEndAngle);
+	G4double tipInnerRadius = baseInnerRadius
+		- fGermaniumCornerConeEndLength*tan(fBentEndAngle);
+	G4double tipOuterRadius = baseOuterRadius;
 
-    // G4double conHalfLengthZ = fGermaniumBentLength/2.0;
-    G4double conHalfLengthZ = fGermaniumCornerConeEndLength/2.0 + fQuarterDetectorCxn;
+	// G4double conHalfLengthZ = fGermaniumBentLength/2.0;
+	G4double conHalfLengthZ = fGermaniumCornerConeEndLength/2.0 + fQuarterDetectorCxn;
 
-    G4double initialAngle = acos((fGermaniumWidth/2.0 +fGermaniumShift)
-                                  /fGermaniumOuterRadius);
-    G4double totalAngle = M_PI/2.0 -2.0*initialAngle;
+	G4double initialAngle = acos((fGermaniumWidth/2.0 +fGermaniumShift)
+			/fGermaniumOuterRadius);
+	G4double totalAngle = M_PI/2.0 -2.0*initialAngle;
 
-    G4Cons* roundedEdge = new G4Cons("roundedEdge", baseInnerRadius,
-                                      baseOuterRadius, tipInnerRadius, tipOuterRadius,
-                                      conHalfLengthZ, initialAngle, totalAngle);
-
-
-    G4RotationMatrix* rotateRoundedEdge = new G4RotationMatrix;
-    rotateRoundedEdge->rotateZ(-M_PI/2.0);
-
-    G4ThreeVector moveRoundedEdge(fGermaniumShift, -fGermaniumShift,
-                                    fGermaniumLength/2.0 -fGermaniumCornerConeEndLength/2.0
-                                    + fQuarterDetectorCxnB);
-
-    G4SubtractionSolid* germaniumRoundedEdge = new G4SubtractionSolid("germaniumRoundedEdge",
-                                                                        germaniumRoundedCorners, roundedEdge, rotateRoundedEdge,
-                                                                        moveRoundedEdge);
-
-    // now we make the diagonal slices
-    G4double halfChopPieceWidthX 	= fGermaniumWidth/2.0;
-    G4double halfChopPieceWidthY 	= fGermaniumWidth/2.0;
-    G4double halfChopPieceLengthZ 	= (fGermaniumBentLength/cos(fBentEndAngle))/2.0;
-    G4Box* chopPiece = new G4Box("chopPiece", halfChopPieceWidthX,
-                                  halfChopPieceWidthY, halfChopPieceLengthZ);
-
-    G4RotationMatrix* rotateChopPiece1 = new G4RotationMatrix;
-    rotateChopPiece1->rotateX(-(fBentEndAngle));
-
-    G4ThreeVector moveChopPiece1(0, fGermaniumWidth/2.0 +(fGermaniumBentLength
-                                                                  /tan(fBentEndAngle) +fGermaniumWidth
-                                                                  *cos(fBentEndAngle))/2.0 -((fGermaniumBentLength
-                                                                                                     /cos(fBentEndAngle))/2.0) /sin(fBentEndAngle),
-                                   fGermaniumLength/2.0 -fGermaniumBentLength
-                                   +(fGermaniumBentLength +fGermaniumWidth
-                                     *sin(fBentEndAngle))/2.0);
-
-    G4SubtractionSolid* choppedGermanium1 = new G4SubtractionSolid("choppedGermanium1",
-                                                                    germaniumRoundedEdge, chopPiece, rotateChopPiece1, moveChopPiece1);
+	G4Cons* roundedEdge = new G4Cons("roundedEdge", baseInnerRadius,
+			baseOuterRadius, tipInnerRadius, tipOuterRadius,
+			conHalfLengthZ, initialAngle, totalAngle);
 
 
-    G4RotationMatrix* rotateChopPiece2 = new G4RotationMatrix;
-    rotateChopPiece2->rotateY(-(fBentEndAngle));
+	G4RotationMatrix* rotateRoundedEdge = new G4RotationMatrix;
+	rotateRoundedEdge->rotateZ(-M_PI/2.0);
 
-    G4ThreeVector moveChopPiece2(-(fGermaniumWidth/2.0 +(fGermaniumBentLength
-                                                                 /tan(fBentEndAngle) +fGermaniumWidth
-                                                                 *cos(fBentEndAngle))/2.0 -((fGermaniumBentLength
-                                                                                                    /cos(fBentEndAngle))/2.0) /sin(fBentEndAngle)), 0,
-                                   fGermaniumLength/2.0 -fGermaniumBentLength
-                                   +(fGermaniumBentLength +fGermaniumWidth
-                                     *sin(fBentEndAngle))/2.0);
+	G4ThreeVector moveRoundedEdge(fGermaniumShift, -fGermaniumShift,
+			fGermaniumLength/2.0 -fGermaniumCornerConeEndLength/2.0
+			+ fQuarterDetectorCxnB);
 
-    G4SubtractionSolid* choppedGermanium2 = new G4SubtractionSolid("choppedGermanium2",
-                                                                    choppedGermanium1, chopPiece, rotateChopPiece2, moveChopPiece2);
+	G4SubtractionSolid* germaniumRoundedEdge = new G4SubtractionSolid("germaniumRoundedEdge",
+			germaniumRoundedCorners, roundedEdge, rotateRoundedEdge,
+			moveRoundedEdge);
+
+	// now we make the diagonal slices
+	G4double halfChopPieceWidthX 	= fGermaniumWidth/2.0;
+	G4double halfChopPieceWidthY 	= fGermaniumWidth/2.0;
+	G4double halfChopPieceLengthZ 	= (fGermaniumBentLength/cos(fBentEndAngle))/2.0;
+	G4Box* chopPiece = new G4Box("chopPiece", halfChopPieceWidthX,
+			halfChopPieceWidthY, halfChopPieceLengthZ);
+
+	G4RotationMatrix* rotateChopPiece1 = new G4RotationMatrix;
+	rotateChopPiece1->rotateX(-(fBentEndAngle));
+
+	G4ThreeVector moveChopPiece1(0, fGermaniumWidth/2.0 +(fGermaniumBentLength
+				/tan(fBentEndAngle) +fGermaniumWidth
+				*cos(fBentEndAngle))/2.0 -((fGermaniumBentLength
+					/cos(fBentEndAngle))/2.0) /sin(fBentEndAngle),
+			fGermaniumLength/2.0 -fGermaniumBentLength
+			+(fGermaniumBentLength +fGermaniumWidth
+				*sin(fBentEndAngle))/2.0);
+
+	G4SubtractionSolid* choppedGermanium1 = new G4SubtractionSolid("choppedGermanium1",
+			germaniumRoundedEdge, chopPiece, rotateChopPiece1, moveChopPiece1);
 
 
-    // now we make the hole that will go in the back of each quarter detector, /////////////////////////////////////////////////////////
-    startAngle = 0.0*M_PI;
-    finalAngle = 2.0*M_PI;
-    G4double holeRadius = fGermaniumHoleRadius;
-    G4double holeHalfLengthZ = (fGermaniumLength -fGermaniumHoleDistFromFace)/2.0;
+	G4RotationMatrix* rotateChopPiece2 = new G4RotationMatrix;
+	rotateChopPiece2->rotateY(-(fBentEndAngle));
 
-    G4Tubs* holeTubs = new G4Tubs("holeTubs", 0.0, holeRadius, holeHalfLengthZ, startAngle, finalAngle);
-    G4ThreeVector moveHole(fGermaniumShift, -(fGermaniumShift),-((fGermaniumHoleDistFromFace)));
+	G4ThreeVector moveChopPiece2(-(fGermaniumWidth/2.0 +(fGermaniumBentLength
+					/tan(fBentEndAngle) +fGermaniumWidth
+					*cos(fBentEndAngle))/2.0 -((fGermaniumBentLength
+						/cos(fBentEndAngle))/2.0) /sin(fBentEndAngle)), 0,
+			fGermaniumLength/2.0 -fGermaniumBentLength
+			+(fGermaniumBentLength +fGermaniumWidth
+				*sin(fBentEndAngle))/2.0);
 
-    G4SubtractionSolid* choppedGermanium3 = new G4SubtractionSolid("choppedGermanium3",
-                                                                    choppedGermanium2, holeTubs, 0, moveHole);
+	G4SubtractionSolid* choppedGermanium2 = new G4SubtractionSolid("choppedGermanium2",
+			choppedGermanium1, chopPiece, rotateChopPiece2, moveChopPiece2);
 
-    startAngle = 0.0*M_PI;
-    finalAngle = 2.0*M_PI;
-    G4double deadLayerRadius = fGermaniumHoleRadius + fInnerDeadLayerThickness;
-    G4double deadLayerHalfLengthZ = (fGermaniumLength
-                                         - fGermaniumHoleDistFromFace
-                                         + fInnerDeadLayerThickness)/2.0;
 
-    // now dead layer
-    G4Tubs* deadLayerTubs = new G4Tubs("deadLayerTubs", 0.0,
-                                         deadLayerRadius, deadLayerHalfLengthZ, startAngle,finalAngle);
+	// now we make the hole that will go in the back of each quarter detector, /////////////////////////////////////////////////////////
+	startAngle = 0.0*M_PI;
+	finalAngle = 2.0*M_PI;
+	G4double holeRadius = fGermaniumHoleRadius;
+	G4double holeHalfLengthZ = (fGermaniumLength -fGermaniumHoleDistFromFace)/2.0;
 
-    G4ThreeVector moveDeadLayer(fGermaniumShift, -(fGermaniumShift),
-                                  -((fGermaniumHoleDistFromFace
-                                     - fInnerDeadLayerThickness)/2.0));
+	G4Tubs* holeTubs = new G4Tubs("holeTubs", 0.0, holeRadius, holeHalfLengthZ, startAngle, finalAngle);
+	G4ThreeVector moveHole(fGermaniumShift, -(fGermaniumShift),-((fGermaniumHoleDistFromFace)));
 
-    G4SubtractionSolid* choppedGermanium4 = new G4SubtractionSolid("choppedGermanium4",
-                                                                    choppedGermanium3, deadLayerTubs, 0, moveDeadLayer);
+	G4SubtractionSolid* choppedGermanium3 = new G4SubtractionSolid("choppedGermanium3",
+			choppedGermanium2, holeTubs, 0, moveHole);
 
-    return choppedGermanium4;
+	startAngle = 0.0*M_PI;
+	finalAngle = 2.0*M_PI;
+	G4double deadLayerRadius = fGermaniumHoleRadius + fInnerDeadLayerThickness;
+	G4double deadLayerHalfLengthZ = (fGermaniumLength
+			- fGermaniumHoleDistFromFace
+			+ fInnerDeadLayerThickness)/2.0;
+
+	// now dead layer
+	G4Tubs* deadLayerTubs = new G4Tubs("deadLayerTubs", 0.0,
+			deadLayerRadius, deadLayerHalfLengthZ, startAngle,finalAngle);
+
+	G4ThreeVector moveDeadLayer(fGermaniumShift, -(fGermaniumShift),
+			-((fGermaniumHoleDistFromFace
+					- fInnerDeadLayerThickness)/2.0));
+
+	G4SubtractionSolid* choppedGermanium4 = new G4SubtractionSolid("choppedGermanium4",
+			choppedGermanium3, deadLayerTubs, 0, moveDeadLayer);
+
+	return choppedGermanium4;
 
 }//end ::quarterDetector
 
 
 G4SubtractionSolid* DetectionSystemGriffin::QuarterSpecificDeadLayerDetector(G4int det, G4int cry) {
 
-    G4double halfWidthX 	= fGermaniumWidth/2.0;
-    G4double halfWidthY 	= halfWidthX;
-    G4double halfLengthZ 	= fGermaniumLength/2.0;
+	G4double halfWidthX 	= fGermaniumWidth/2.0;
+	G4double halfWidthY 	= halfWidthX;
+	G4double halfLengthZ 	= fGermaniumLength/2.0;
 
-    G4Box* rectangularGermanium 	= new G4Box("rectangularGermanium", halfWidthX, halfWidthY, halfLengthZ);
+	G4Box* rectangularGermanium 	= new G4Box("rectangularGermanium", halfWidthX, halfWidthY, halfLengthZ);
 
-    G4double outerRadius = ((fGermaniumWidth +fGermaniumShift)*1.5)/2.0;
+	G4double outerRadius = ((fGermaniumWidth +fGermaniumShift)*1.5)/2.0;
 
-    // 1.5 is almost root 2, so this makes sure the corners are chopped off
+	// 1.5 is almost root 2, so this makes sure the corners are chopped off
 
-    G4double innerRadius = fGermaniumOuterRadius;
-    G4double startAngle = 0.0*M_PI;
-    G4double finalAngle = 2.0*M_PI;
+	G4double innerRadius = fGermaniumOuterRadius;
+	G4double startAngle = 0.0*M_PI;
+	G4double finalAngle = 2.0*M_PI;
 
-    G4ThreeVector moveChoppingCylinder(fGermaniumShift, -(fGermaniumShift), 0);
-    G4Tubs* choppingCylinder = new G4Tubs("choppingCylinder", innerRadius,
-                                           outerRadius, halfLengthZ+1.0*cm, startAngle, finalAngle);
+	G4ThreeVector moveChoppingCylinder(fGermaniumShift, -(fGermaniumShift), 0);
+	G4Tubs* choppingCylinder = new G4Tubs("choppingCylinder", innerRadius,
+			outerRadius, halfLengthZ+1.0*cm, startAngle, finalAngle);
 
-    G4SubtractionSolid* germaniumRoundedCorners = new G4SubtractionSolid("germaniumRoundedCorners",
-                                                                           rectangularGermanium, choppingCylinder, 0, moveChoppingCylinder);
+	G4SubtractionSolid* germaniumRoundedCorners = new G4SubtractionSolid("germaniumRoundedCorners",
+			rectangularGermanium, choppingCylinder, 0, moveChoppingCylinder);
 
-    G4double baseInnerRadius = fGermaniumOuterRadius;
-    G4double baseOuterRadius = 2.0*baseInnerRadius;
+	G4double baseInnerRadius = fGermaniumOuterRadius;
+	G4double baseOuterRadius = 2.0*baseInnerRadius;
 
-    G4double tipInnerRadius = baseInnerRadius - fGermaniumCornerConeEndLength*tan(fBentEndAngle);
-    G4double tipOuterRadius = baseOuterRadius;
+	G4double tipInnerRadius = baseInnerRadius - fGermaniumCornerConeEndLength*tan(fBentEndAngle);
+	G4double tipOuterRadius = baseOuterRadius;
 
-    G4double conHalfLengthZ = fGermaniumCornerConeEndLength/2.0 + fQuarterDetectorCxn;
+	G4double conHalfLengthZ = fGermaniumCornerConeEndLength/2.0 + fQuarterDetectorCxn;
 
-    G4double initialAngle = acos((fGermaniumWidth/2.0 +fGermaniumShift)
-                                  /fGermaniumOuterRadius);
-    G4double totalAngle = M_PI/2.0 -2.0*initialAngle;
+	G4double initialAngle = acos((fGermaniumWidth/2.0 +fGermaniumShift)
+			/fGermaniumOuterRadius);
+	G4double totalAngle = M_PI/2.0 -2.0*initialAngle;
 
-    G4Cons* roundedEdge = new G4Cons("roundedEdge", baseInnerRadius,
-                                      baseOuterRadius, tipInnerRadius, tipOuterRadius,
-                                      conHalfLengthZ, initialAngle, totalAngle);
+	G4Cons* roundedEdge = new G4Cons("roundedEdge", baseInnerRadius,
+			baseOuterRadius, tipInnerRadius, tipOuterRadius,
+			conHalfLengthZ, initialAngle, totalAngle);
 
-    G4RotationMatrix* rotateRoundedEdge = new G4RotationMatrix;
-    rotateRoundedEdge->rotateZ(-M_PI/2.0);
+	G4RotationMatrix* rotateRoundedEdge = new G4RotationMatrix;
+	rotateRoundedEdge->rotateZ(-M_PI/2.0);
 
-    G4ThreeVector moveRoundedEdge(fGermaniumShift, -fGermaniumShift,
-                                    fGermaniumLength/2.0 -fGermaniumCornerConeEndLength/2.0
-                                    + fQuarterDetectorCxnB);
+	G4ThreeVector moveRoundedEdge(fGermaniumShift, -fGermaniumShift,
+			fGermaniumLength/2.0 -fGermaniumCornerConeEndLength/2.0
+			+ fQuarterDetectorCxnB);
 
-    G4SubtractionSolid* germaniumRoundedEdge = new G4SubtractionSolid("germaniumRoundedEdge",
-                                                                        germaniumRoundedCorners, roundedEdge, rotateRoundedEdge,
-                                                                        moveRoundedEdge);
+	G4SubtractionSolid* germaniumRoundedEdge = new G4SubtractionSolid("germaniumRoundedEdge",
+			germaniumRoundedCorners, roundedEdge, rotateRoundedEdge,
+			moveRoundedEdge);
 
-    // now we make the diagonal slices
-    G4double halfChopPieceWidthX 	= fGermaniumWidth/2.0;
-    G4double halfChopPieceWidthY 	= fGermaniumWidth/2.0;
-    G4double halfChopPieceLengthZ 	= (fGermaniumBentLength/cos(fBentEndAngle))/2.0;
-    G4Box* chopPiece = new G4Box("chopPiece", halfChopPieceWidthX,
-                                  halfChopPieceWidthY, halfChopPieceLengthZ);
+	// now we make the diagonal slices
+	G4double halfChopPieceWidthX 	= fGermaniumWidth/2.0;
+	G4double halfChopPieceWidthY 	= fGermaniumWidth/2.0;
+	G4double halfChopPieceLengthZ 	= (fGermaniumBentLength/cos(fBentEndAngle))/2.0;
+	G4Box* chopPiece = new G4Box("chopPiece", halfChopPieceWidthX,
+			halfChopPieceWidthY, halfChopPieceLengthZ);
 
-    G4RotationMatrix* rotateChopPiece1 = new G4RotationMatrix;
-    rotateChopPiece1->rotateX(-(fBentEndAngle));
+	G4RotationMatrix* rotateChopPiece1 = new G4RotationMatrix;
+	rotateChopPiece1->rotateX(-(fBentEndAngle));
 
-    G4ThreeVector moveChopPiece1(0, fGermaniumWidth/2.0 +(fGermaniumBentLength
-                                                                  /tan(fBentEndAngle) +fGermaniumWidth
-                                                                  *cos(fBentEndAngle))/2.0 -((fGermaniumBentLength
-                                                                                                     /cos(fBentEndAngle))/2.0) /sin(fBentEndAngle),
-                                   fGermaniumLength/2.0 -fGermaniumBentLength
-                                   +(fGermaniumBentLength +fGermaniumWidth
-                                     *sin(fBentEndAngle))/2.0);
+	G4ThreeVector moveChopPiece1(0, fGermaniumWidth/2.0 +(fGermaniumBentLength
+				/tan(fBentEndAngle) +fGermaniumWidth
+				*cos(fBentEndAngle))/2.0 -((fGermaniumBentLength
+					/cos(fBentEndAngle))/2.0) /sin(fBentEndAngle),
+			fGermaniumLength/2.0 -fGermaniumBentLength
+			+(fGermaniumBentLength +fGermaniumWidth
+				*sin(fBentEndAngle))/2.0);
 
-    G4SubtractionSolid* choppedGermanium1 = new G4SubtractionSolid("choppedGermanium1",
-                                                                    germaniumRoundedEdge, chopPiece, rotateChopPiece1, moveChopPiece1);
-
-
-    G4RotationMatrix* rotateChopPiece2 = new G4RotationMatrix;
-    rotateChopPiece2->rotateY(-(fBentEndAngle));
-
-    G4ThreeVector moveChopPiece2(-(fGermaniumWidth/2.0 +(fGermaniumBentLength
-                                                                 /tan(fBentEndAngle) +fGermaniumWidth
-                                                                 *cos(fBentEndAngle))/2.0 -((fGermaniumBentLength
-                                                                                                    /cos(fBentEndAngle))/2.0) /sin(fBentEndAngle)), 0,
-                                   fGermaniumLength/2.0 -fGermaniumBentLength
-                                   +(fGermaniumBentLength +fGermaniumWidth
-                                     *sin(fBentEndAngle))/2.0);
-
-    G4SubtractionSolid* choppedGermanium2 = new G4SubtractionSolid("choppedGermanium2",
-                                                                    choppedGermanium1, chopPiece, rotateChopPiece2, moveChopPiece2);
+	G4SubtractionSolid* choppedGermanium1 = new G4SubtractionSolid("choppedGermanium1",
+			germaniumRoundedEdge, chopPiece, rotateChopPiece1, moveChopPiece1);
 
 
-    // now we make the hole that will go in the back of each quarter detector, /////////////////////////////////////////////////////////
-    startAngle = 0.0*M_PI;
-    finalAngle = 2.0*M_PI;
-    G4double holeRadius = fGermaniumHoleRadius;
-    G4double holeHalfLengthZ = (fGermaniumLength -fGermaniumHoleDistFromFace)/2.0;
+	G4RotationMatrix* rotateChopPiece2 = new G4RotationMatrix;
+	rotateChopPiece2->rotateY(-(fBentEndAngle));
 
-    G4Tubs* holeTubs = new G4Tubs("holeTubs", 0.0, holeRadius, holeHalfLengthZ, startAngle, finalAngle);
-    G4ThreeVector moveHole(fGermaniumShift, -(fGermaniumShift),-((fGermaniumHoleDistFromFace)));
+	G4ThreeVector moveChopPiece2(-(fGermaniumWidth/2.0 +(fGermaniumBentLength
+					/tan(fBentEndAngle) +fGermaniumWidth
+					*cos(fBentEndAngle))/2.0 -((fGermaniumBentLength
+						/cos(fBentEndAngle))/2.0) /sin(fBentEndAngle)), 0,
+			fGermaniumLength/2.0 -fGermaniumBentLength
+			+(fGermaniumBentLength +fGermaniumWidth
+				*sin(fBentEndAngle))/2.0);
 
-    G4SubtractionSolid* choppedGermanium3 = new G4SubtractionSolid("choppedGermanium3",
-                                                                    choppedGermanium2, holeTubs, 0, moveHole);
+	G4SubtractionSolid* choppedGermanium2 = new G4SubtractionSolid("choppedGermanium2",
+			choppedGermanium1, chopPiece, rotateChopPiece2, moveChopPiece2);
 
-    startAngle = 0.0*M_PI;
-    finalAngle = 2.0*M_PI;
-    G4double deadLayerRadius = fGermaniumHoleRadius + fGriffinDeadLayers[det][cry];
-    G4double deadLayerHalfLengthZ = (fGermaniumLength
-                                         - fGermaniumHoleDistFromFace
-                                         + fGriffinDeadLayers[det][cry])/2.0;
 
-    // now dead layer
-    G4Tubs* deadLayerTubs = new G4Tubs("deadLayerTubs", 0.0,
-                                         deadLayerRadius, deadLayerHalfLengthZ, startAngle,finalAngle);
+	// now we make the hole that will go in the back of each quarter detector, /////////////////////////////////////////////////////////
+	startAngle = 0.0*M_PI;
+	finalAngle = 2.0*M_PI;
+	G4double holeRadius = fGermaniumHoleRadius;
+	G4double holeHalfLengthZ = (fGermaniumLength -fGermaniumHoleDistFromFace)/2.0;
 
-    G4ThreeVector moveDeadLayer(fGermaniumShift, -(fGermaniumShift),
-                                  -((fGermaniumHoleDistFromFace
-                                     - fGriffinDeadLayers[det][cry])/2.0));
+	G4Tubs* holeTubs = new G4Tubs("holeTubs", 0.0, holeRadius, holeHalfLengthZ, startAngle, finalAngle);
+	G4ThreeVector moveHole(fGermaniumShift, -(fGermaniumShift),-((fGermaniumHoleDistFromFace)));
 
-    G4SubtractionSolid* choppedGermanium4 = new G4SubtractionSolid("choppedGermanium4",
-                                                                    choppedGermanium3, deadLayerTubs, 0, moveDeadLayer);
+	G4SubtractionSolid* choppedGermanium3 = new G4SubtractionSolid("choppedGermanium3",
+			choppedGermanium2, holeTubs, 0, moveHole);
 
-    return choppedGermanium4;
+	startAngle = 0.0*M_PI;
+	finalAngle = 2.0*M_PI;
+	G4double deadLayerRadius = fGermaniumHoleRadius + fGriffinDeadLayers[det][cry];
+	G4double deadLayerHalfLengthZ = (fGermaniumLength
+			- fGermaniumHoleDistFromFace
+			+ fGriffinDeadLayers[det][cry])/2.0;
+
+	// now dead layer
+	G4Tubs* deadLayerTubs = new G4Tubs("deadLayerTubs", 0.0,
+			deadLayerRadius, deadLayerHalfLengthZ, startAngle,finalAngle);
+
+	G4ThreeVector moveDeadLayer(fGermaniumShift, -(fGermaniumShift),
+			-((fGermaniumHoleDistFromFace
+					- fGriffinDeadLayers[det][cry])/2.0));
+
+	G4SubtractionSolid* choppedGermanium4 = new G4SubtractionSolid("choppedGermanium4",
+			choppedGermanium3, deadLayerTubs, 0, moveDeadLayer);
+
+	return choppedGermanium4;
 
 }//end ::quarterSpecificDeadLayerDetector
 
@@ -2650,330 +2650,330 @@ G4SubtractionSolid* DetectionSystemGriffin::QuarterSpecificDeadLayerDetector(G4i
 ///////////////////////////////////////////////////////////////////////
 
 G4SubtractionSolid* DetectionSystemGriffin::ShellForBackSuppressorQuarter() {
-    G4double halfThicknessX = fBackBGOThickness/2.0 + fSuppressorShellThickness;
-    G4double halfLengthY = fDetectorTotalWidth/4.0;
-    G4double halfLengthZ = halfLengthY;
-    G4Box* quarterSuppressorShell = new G4Box("quarterSuppressorShell", halfThicknessX, halfLengthY, halfLengthZ);
+	G4double halfThicknessX = fBackBGOThickness/2.0 + fSuppressorShellThickness;
+	G4double halfLengthY = fDetectorTotalWidth/4.0;
+	G4double halfLengthZ = halfLengthY;
+	G4Box* quarterSuppressorShell = new G4Box("quarterSuppressorShell", halfThicknessX, halfLengthY, halfLengthZ);
 
-    G4double shellHoleRadius = fColdFingerOuterShellRadius;
-    G4Tubs* shellHole = new G4Tubs("shellHole", 0, shellHoleRadius, halfThicknessX +1.0*cm, 0.0*M_PI, 2.0*M_PI);
+	G4double shellHoleRadius = fColdFingerOuterShellRadius;
+	G4Tubs* shellHole = new G4Tubs("shellHole", 0, shellHoleRadius, halfThicknessX +1.0*cm, 0.0*M_PI, 2.0*M_PI);
 
-    G4RotationMatrix* rotateShellHole = new G4RotationMatrix;
-    rotateShellHole->rotateY(M_PI/2.0);
-    G4ThreeVector moveShellHole(0, -halfLengthY, halfLengthZ);
+	G4RotationMatrix* rotateShellHole = new G4RotationMatrix;
+	rotateShellHole->rotateY(M_PI/2.0);
+	G4ThreeVector moveShellHole(0, -halfLengthY, halfLengthZ);
 
-    G4SubtractionSolid* quarterSuppressorShellWithHole = new G4SubtractionSolid("quarterSuppressorShellWithHole",
-                                                                                    quarterSuppressorShell, shellHole, rotateShellHole, moveShellHole);
+	G4SubtractionSolid* quarterSuppressorShellWithHole = new G4SubtractionSolid("quarterSuppressorShellWithHole",
+			quarterSuppressorShell, shellHole, rotateShellHole, moveShellHole);
 
-    //now we need to cut out inner cavity, first we define the cavity
-    halfThicknessX = fBackBGOThickness/2.0;
-    halfLengthY = fDetectorTotalWidth/4.0 - fSuppressorShellThickness;
-    halfLengthZ = halfLengthY;
-    G4Box* quarterSuppressor = new G4Box("quarterSuppressor", halfThicknessX, halfLengthY, halfLengthZ);
+	//now we need to cut out inner cavity, first we define the cavity
+	halfThicknessX = fBackBGOThickness/2.0;
+	halfLengthY = fDetectorTotalWidth/4.0 - fSuppressorShellThickness;
+	halfLengthZ = halfLengthY;
+	G4Box* quarterSuppressor = new G4Box("quarterSuppressor", halfThicknessX, halfLengthY, halfLengthZ);
 
-    G4ThreeVector moveCut(0,0,0);
+	G4ThreeVector moveCut(0,0,0);
 
-    // cut
-    G4SubtractionSolid* quarterSuppressorShellWithHoleAndCavity = new G4SubtractionSolid("quarterSuppressorShellWithHoleAndCavity",
-                                                                                               quarterSuppressorShellWithHole, quarterSuppressor, 0, moveCut);
+	// cut
+	G4SubtractionSolid* quarterSuppressorShellWithHoleAndCavity = new G4SubtractionSolid("quarterSuppressorShellWithHoleAndCavity",
+			quarterSuppressorShellWithHole, quarterSuppressor, 0, moveCut);
 
-    return quarterSuppressorShellWithHoleAndCavity;
+	return quarterSuppressorShellWithHoleAndCavity;
 
 }//end ::shellForBackSuppressorQuarter
 
 
 G4SubtractionSolid* DetectionSystemGriffin::ShellForFrontSlantSuppressor(G4String sidePosition) {
-    // Change some values to accomodate the shells
-    // Replacement for sideSuppressorLength
-    G4double shellSideSuppressorShellLength = fSideSuppressorLength + (fSuppressorShellThickness*2.0);
+	// Change some values to accomodate the shells
+	// Replacement for sideSuppressorLength
+	G4double shellSideSuppressorShellLength = fSideSuppressorLength + (fSuppressorShellThickness*2.0);
 
-    G4double lengthZ         = shellSideSuppressorShellLength;
-    G4double lengthY         = fSideBGOThickness + fSuppressorShellThickness*2.0;
-    G4double lengthLongerX  = fDetectorTotalWidth/2.0 +fBGOCanSeperation
-            + fSideBGOThickness + fSuppressorShellThickness*2.0;
-    G4double lengthShorterX = lengthLongerX -fSideBGOThickness
-            - fSuppressorShellThickness*2.0;
+	G4double lengthZ         = shellSideSuppressorShellLength;
+	G4double lengthY         = fSideBGOThickness + fSuppressorShellThickness*2.0;
+	G4double lengthLongerX  = fDetectorTotalWidth/2.0 +fBGOCanSeperation
+		+ fSideBGOThickness + fSuppressorShellThickness*2.0;
+	G4double lengthShorterX = lengthLongerX -fSideBGOThickness
+		- fSuppressorShellThickness*2.0;
 
-    G4Trap* suppressorShell = new G4Trap("suppressorShell", lengthZ, lengthY, lengthLongerX, lengthShorterX);
+	G4Trap* suppressorShell = new G4Trap("suppressorShell", lengthZ, lengthY, lengthLongerX, lengthShorterX);
 
-    G4double halfLengthX      = lengthLongerX/2.0 +1.0*cm;
-    G4double halfThicknessY   = fSideBGOThickness/2.0 + fSuppressorShellThickness;
-    G4double halfLengthZ      = ((fSideBGOThickness + fSuppressorShellThickness*2.0
-                                    - fBGOChoppedTip)/sin(fBentEndAngle))/2.0;
+	G4double halfLengthX      = lengthLongerX/2.0 +1.0*cm;
+	G4double halfThicknessY   = fSideBGOThickness/2.0 + fSuppressorShellThickness;
+	G4double halfLengthZ      = ((fSideBGOThickness + fSuppressorShellThickness*2.0
+				- fBGOChoppedTip)/sin(fBentEndAngle))/2.0;
 
-    G4Box* choppingShellBox = new G4Box("choppingShellBox", halfLengthX, halfThicknessY, halfLengthZ);
+	G4Box* choppingShellBox = new G4Box("choppingShellBox", halfLengthX, halfThicknessY, halfLengthZ);
 
-    G4RotationMatrix* rotateChoppingShellBox = new G4RotationMatrix;
+	G4RotationMatrix* rotateChoppingShellBox = new G4RotationMatrix;
 
-    G4double y0 = fSideBGOThickness/2.0 - fSuppressorShellThickness * sin(fBentEndAngle)
-            - fBGOChoppedTip - 0.5 * sqrt(pow((2.0 * halfLengthZ), 2.0)
-                                                 + pow((2.0 * halfThicknessY), 2.0)) * cos(M_PI/2.0 - fBentEndAngle - atan(halfThicknessY/halfLengthZ)) ;
+	G4double y0 = fSideBGOThickness/2.0 - fSuppressorShellThickness * sin(fBentEndAngle)
+		- fBGOChoppedTip - 0.5 * sqrt(pow((2.0 * halfLengthZ), 2.0)
+				+ pow((2.0 * halfThicknessY), 2.0)) * cos(M_PI/2.0 - fBentEndAngle - atan(halfThicknessY/halfLengthZ)) ;
 
-    G4double z0 = lengthZ/2.0 - 0.5 * sqrt(pow((2.0 * halfLengthZ), 2.0) + pow((2.0 * halfThicknessY), 2.0)) * sin(M_PI/2.0
-                                                                                                                        - fBentEndAngle - atan(halfThicknessY/halfLengthZ)) ;
-    G4ThreeVector moveChoppingShellBox ;
+	G4double z0 = lengthZ/2.0 - 0.5 * sqrt(pow((2.0 * halfLengthZ), 2.0) + pow((2.0 * halfThicknessY), 2.0)) * sin(M_PI/2.0
+			- fBentEndAngle - atan(halfThicknessY/halfLengthZ)) ;
+	G4ThreeVector moveChoppingShellBox ;
 
-    if(sidePosition == "left")
-    {
-        rotateChoppingShellBox->rotateX(fBentEndAngle);
-        moveChoppingShellBox = G4ThreeVector(0, y0, z0) ;
-    }
-    else if(sidePosition == "right")
-    {
-        rotateChoppingShellBox->rotateX(-fBentEndAngle);
-        moveChoppingShellBox = G4ThreeVector(0, y0, -z0) ;
-    }
+	if(sidePosition == "left")
+	{
+		rotateChoppingShellBox->rotateX(fBentEndAngle);
+		moveChoppingShellBox = G4ThreeVector(0, y0, z0) ;
+	}
+	else if(sidePosition == "right")
+	{
+		rotateChoppingShellBox->rotateX(-fBentEndAngle);
+		moveChoppingShellBox = G4ThreeVector(0, y0, -z0) ;
+	}
 
-    G4SubtractionSolid* sideSuppressorShell = new G4SubtractionSolid("sideSuppressorShell",
-                                                                       suppressorShell, choppingShellBox, rotateChoppingShellBox, moveChoppingShellBox);
+	G4SubtractionSolid* sideSuppressorShell = new G4SubtractionSolid("sideSuppressorShell",
+			suppressorShell, choppingShellBox, rotateChoppingShellBox, moveChoppingShellBox);
 
-    G4SubtractionSolid* sideSuppressorShellWithCavity = NULL;
+	G4SubtractionSolid* sideSuppressorShellWithCavity = nullptr;
 
-    // cut out cavity
-    if(sidePosition == "left")
-    {
-        G4ThreeVector moveCut(-(fSuppressorShellThickness + (fExtraCutLength/2.0 - fSuppressorShellThickness)/2.0), 0, (fSuppressorShellThickness/2.0));
+	// cut out cavity
+	if(sidePosition == "left")
+	{
+		G4ThreeVector moveCut(-(fSuppressorShellThickness + (fExtraCutLength/2.0 - fSuppressorShellThickness)/2.0), 0, (fSuppressorShellThickness/2.0));
 
-        sideSuppressorShellWithCavity = new G4SubtractionSolid("sideSuppressorShellWithCavity", sideSuppressorShell,
-                                                                    FrontSlantSuppressor("left", true), 0, moveCut); // chopping, left from frontSlantSuppressor.
-    }
-    else if(sidePosition == "right")
-    {
-        G4ThreeVector moveCut(-(fSuppressorShellThickness + (fExtraCutLength/2.0 - fSuppressorShellThickness)/2.0), 0, -(fSuppressorShellThickness/2.0));
+		sideSuppressorShellWithCavity = new G4SubtractionSolid("sideSuppressorShellWithCavity", sideSuppressorShell,
+				FrontSlantSuppressor("left", true), 0, moveCut); // chopping, left from frontSlantSuppressor.
+	}
+	else if(sidePosition == "right")
+	{
+		G4ThreeVector moveCut(-(fSuppressorShellThickness + (fExtraCutLength/2.0 - fSuppressorShellThickness)/2.0), 0, -(fSuppressorShellThickness/2.0));
 
-        sideSuppressorShellWithCavity = new G4SubtractionSolid("sideSuppressorShellWithCavity", sideSuppressorShell,
-                                                                    FrontSlantSuppressor("right", true), 0, moveCut); // chopping, right from frontSlantSuppressor.
-    }
+		sideSuppressorShellWithCavity = new G4SubtractionSolid("sideSuppressorShellWithCavity", sideSuppressorShell,
+				FrontSlantSuppressor("right", true), 0, moveCut); // chopping, right from frontSlantSuppressor.
+	}
 
-    return sideSuppressorShellWithCavity;
+	return sideSuppressorShellWithCavity;
 } // end ::shellForFrontSlantSuppressor
 
 
 G4SubtractionSolid* DetectionSystemGriffin::ShellForSuppressorExtension(G4String sidePosition) {
 
-    // Replacement for suppressorExtensionLength
-    G4double shellSuppressorShellExtensionLength = fSuppressorExtensionLength
-            + (fSuppressorShellThickness*2.0)*(1.0/tan(fBentEndAngle)
-                                                      - tan(fBentEndAngle));
+	// Replacement for suppressorExtensionLength
+	G4double shellSuppressorShellExtensionLength = fSuppressorExtensionLength
+		+ (fSuppressorShellThickness*2.0)*(1.0/tan(fBentEndAngle)
+				- tan(fBentEndAngle));
 
-    G4double thicknessZ = fSuppressorExtensionThickness + fSuppressorShellThickness*2.0;
-    G4double lengthY = shellSuppressorShellExtensionLength;
+	G4double thicknessZ = fSuppressorExtensionThickness + fSuppressorShellThickness*2.0;
+	G4double lengthY = shellSuppressorShellExtensionLength;
 
-    G4double longerLengthX =  (fSuppressorBackRadius +fBentEndLength +(fBGOCanSeperation
-                                                                                        + fSideBGOThickness
-                                                                                        + fSuppressorShellThickness*2.0)
-                                  / tan(fBentEndAngle)
-                                  - (fSuppressorExtensionThickness
-                                     + fSuppressorShellThickness*2.0)
-                                  * sin(fBentEndAngle))*tan(fBentEndAngle);
+	G4double longerLengthX =  (fSuppressorBackRadius +fBentEndLength +(fBGOCanSeperation
+				+ fSideBGOThickness
+				+ fSuppressorShellThickness*2.0)
+			/ tan(fBentEndAngle)
+			- (fSuppressorExtensionThickness
+				+ fSuppressorShellThickness*2.0)
+			* sin(fBentEndAngle))*tan(fBentEndAngle);
 
-    G4double shorterLengthX = (fSuppressorForwardRadius + fHevimetTipThickness) * sin(fBentEndAngle) ;
+	G4double shorterLengthX = (fSuppressorForwardRadius + fHevimetTipThickness) * sin(fBentEndAngle) ;
 
-    G4Trap* uncutExtensionShell = new G4Trap("uncutExtensionShell", thicknessZ, lengthY, longerLengthX, shorterLengthX);
+	G4Trap* uncutExtensionShell = new G4Trap("uncutExtensionShell", thicknessZ, lengthY, longerLengthX, shorterLengthX);
 
-    // because these pieces are rotated in two planes, there are multiple angles that need to be calculated to make sure
-    // all of the extensions join up
+	// because these pieces are rotated in two planes, there are multiple angles that need to be calculated to make sure
+	// all of the extensions join up
 
-    G4double beta = atan((longerLengthX -shorterLengthX)/(lengthY));
-    G4double phi  = atan(1/cos(fBentEndAngle));
+	G4double beta = atan((longerLengthX -shorterLengthX)/(lengthY));
+	G4double phi  = atan(1/cos(fBentEndAngle));
 
-    G4double choppingHalfLengthX = (thicknessZ / sin(phi)) / 2.0;
-    G4double choppingHalfLengthY = lengthY / (2.0 * cos(beta));
-    G4double choppingHalfLengthZ = choppingHalfLengthX;
-    G4double yAngle = -beta;
-    G4double xAngle = 0.0;
-    G4double zAngle = 0.;
+	G4double choppingHalfLengthX = (thicknessZ / sin(phi)) / 2.0;
+	G4double choppingHalfLengthY = lengthY / (2.0 * cos(beta));
+	G4double choppingHalfLengthZ = choppingHalfLengthX;
+	G4double yAngle = -beta;
+	G4double xAngle = 0.0;
+	G4double zAngle = 0.;
 
-    if(sidePosition == "left")
-        zAngle = M_PI/2.0 - phi ;
-    else if(sidePosition == "right")
-        zAngle = phi - M_PI/2.0 ;
+	if(sidePosition == "left")
+		zAngle = M_PI/2.0 - phi ;
+	else if(sidePosition == "right")
+		zAngle = phi - M_PI/2.0 ;
 
 
-    G4Para* choppingParaShell = new G4Para("choppingParaShell", choppingHalfLengthX,
-                                             choppingHalfLengthY, choppingHalfLengthZ, yAngle, zAngle, xAngle);
+	G4Para* choppingParaShell = new G4Para("choppingParaShell", choppingHalfLengthX,
+			choppingHalfLengthY, choppingHalfLengthZ, yAngle, zAngle, xAngle);
 
-    G4ThreeVector moveParaShell(((longerLengthX -shorterLengthX)/2.0 +shorterLengthX)/2.0
-                                  + choppingHalfLengthX -choppingHalfLengthX*cos(phi), 0.0, 0.0);
+	G4ThreeVector moveParaShell(((longerLengthX -shorterLengthX)/2.0 +shorterLengthX)/2.0
+			+ choppingHalfLengthX -choppingHalfLengthX*cos(phi), 0.0, 0.0);
 
-    G4SubtractionSolid* extensionShell = new G4SubtractionSolid("extensionShell",
-                                                                 uncutExtensionShell, choppingParaShell, 0, moveParaShell);
+	G4SubtractionSolid* extensionShell = new G4SubtractionSolid("extensionShell",
+			uncutExtensionShell, choppingParaShell, 0, moveParaShell);
 
-    G4ThreeVector moveCut ;
-    G4SubtractionSolid* extensionSuppressorShellWithCavity = NULL;
-    G4SubtractionSolid* extensionSuppressorShellWithCavityPre = NULL;
+	G4ThreeVector moveCut ;
+	G4SubtractionSolid* extensionSuppressorShellWithCavity = nullptr;
+	G4SubtractionSolid* extensionSuppressorShellWithCavityPre = nullptr;
 
-    // cut out cavity ----
-    // We make two cuts, one "crude" one from a G4Trap, and a more refined cut using a G4SubtractionSolid. There are two reasons why we make two cuts.
-    // Firstly, the shape of these suppressors are strange. To make the inside cut large enough to have an opening such that the left and right suppressors touch would
-    // require some clever math, and that's a pain. The second (less lazy) reason is Geant4 doesn't like to make a G4SubtractionSolid out of two G4SubtractionSolids.
-    // My experience is that the visulization will fail if two sides of the G4SubtractionSolids are close, that is do not have a LARGE (>~10mm) overlap. To get around this,
-    // I simply make a "crude" first cut using a G4Trap.
-    // The cuts are slightly larger than suppressor to allow for small gaps between the shell and the suppressor.
-    if(sidePosition == "left")
-    {
-        moveCut = G4ThreeVector(-30.0*mm,0.40*mm,0.25*mm);
-        extensionSuppressorShellWithCavityPre = new G4SubtractionSolid("extensionSuppressorShellWithCavityPre", extensionShell, SideSuppressorExtensionUncut(), 0, (moveCut)/2.0); // Left, Chopping sideSuppressorExtension
+	// cut out cavity ----
+	// We make two cuts, one "crude" one from a G4Trap, and a more refined cut using a G4SubtractionSolid. There are two reasons why we make two cuts.
+	// Firstly, the shape of these suppressors are strange. To make the inside cut large enough to have an opening such that the left and right suppressors touch would
+	// require some clever math, and that's a pain. The second (less lazy) reason is Geant4 doesn't like to make a G4SubtractionSolid out of two G4SubtractionSolids.
+	// My experience is that the visulization will fail if two sides of the G4SubtractionSolids are close, that is do not have a LARGE (>~10mm) overlap. To get around this,
+	// I simply make a "crude" first cut using a G4Trap.
+	// The cuts are slightly larger than suppressor to allow for small gaps between the shell and the suppressor.
+	if(sidePosition == "left")
+	{
+		moveCut = G4ThreeVector(-30.0*mm,0.40*mm,0.25*mm);
+		extensionSuppressorShellWithCavityPre = new G4SubtractionSolid("extensionSuppressorShellWithCavityPre", extensionShell, SideSuppressorExtensionUncut(), 0, (moveCut)/2.0); // Left, Chopping sideSuppressorExtension
 
-        moveCut = G4ThreeVector(-1.15*mm,0.40*mm,0.25*mm);
-        extensionSuppressorShellWithCavity = new G4SubtractionSolid("extensionSuppressorShellWithCavity", extensionSuppressorShellWithCavityPre, SideSuppressorExtension("left", true), 0, (moveCut)/2.0);
-    }
-    else if(sidePosition == "right")
-    {
-        moveCut = G4ThreeVector(-30.0*mm,0.40*mm,-0.25*mm);
-        extensionSuppressorShellWithCavityPre = new G4SubtractionSolid("extensionSuppressorShellWithCavityPre", extensionShell, SideSuppressorExtensionUncut(), 0, (moveCut)/2.0); // Left, Chopping sideSuppressorExtension
+		moveCut = G4ThreeVector(-1.15*mm,0.40*mm,0.25*mm);
+		extensionSuppressorShellWithCavity = new G4SubtractionSolid("extensionSuppressorShellWithCavity", extensionSuppressorShellWithCavityPre, SideSuppressorExtension("left", true), 0, (moveCut)/2.0);
+	}
+	else if(sidePosition == "right")
+	{
+		moveCut = G4ThreeVector(-30.0*mm,0.40*mm,-0.25*mm);
+		extensionSuppressorShellWithCavityPre = new G4SubtractionSolid("extensionSuppressorShellWithCavityPre", extensionShell, SideSuppressorExtensionUncut(), 0, (moveCut)/2.0); // Left, Chopping sideSuppressorExtension
 
-        moveCut = G4ThreeVector(-1.15*mm,0.40*mm,-0.25*mm);
-        extensionSuppressorShellWithCavity = new G4SubtractionSolid("extensionSuppressorShellWithCavity", extensionSuppressorShellWithCavityPre, SideSuppressorExtension("right", true), 0, (moveCut)/2.0);
-    }
+		moveCut = G4ThreeVector(-1.15*mm,0.40*mm,-0.25*mm);
+		extensionSuppressorShellWithCavity = new G4SubtractionSolid("extensionSuppressorShellWithCavity", extensionSuppressorShellWithCavityPre, SideSuppressorExtension("right", true), 0, (moveCut)/2.0);
+	}
 
-    return extensionSuppressorShellWithCavity;
+	return extensionSuppressorShellWithCavity;
 } // end ::shellForSuppressorExtension
 
 
 // Back to making the suppressor volumes themselves
 G4SubtractionSolid* DetectionSystemGriffin::BackSuppressorQuarter() {
-    G4double halfThicknessX = fBackBGOThickness/2.0;
-    G4double halfLengthY = fDetectorTotalWidth/4.0 - fSuppressorShellThickness;
-    G4double halfLengthZ = halfLengthY;
-    G4Box* quarterSuppressor = new G4Box("quarterSuppressor", halfThicknessX, halfLengthY, halfLengthZ);
+	G4double halfThicknessX = fBackBGOThickness/2.0;
+	G4double halfLengthY = fDetectorTotalWidth/4.0 - fSuppressorShellThickness;
+	G4double halfLengthZ = halfLengthY;
+	G4Box* quarterSuppressor = new G4Box("quarterSuppressor", halfThicknessX, halfLengthY, halfLengthZ);
 
-    G4double holeRadius = fColdFingerOuterShellRadius;
-    G4Tubs* hole = new G4Tubs("hole", 0, holeRadius, halfThicknessX +1.0*cm, 0.0*M_PI, 2.0*M_PI);
+	G4double holeRadius = fColdFingerOuterShellRadius;
+	G4Tubs* hole = new G4Tubs("hole", 0, holeRadius, halfThicknessX +1.0*cm, 0.0*M_PI, 2.0*M_PI);
 
-    G4RotationMatrix* rotateHole = new G4RotationMatrix;
-    rotateHole->rotateY(M_PI/2.0);
-    G4ThreeVector moveHole(0, -halfLengthY, halfLengthZ);
+	G4RotationMatrix* rotateHole = new G4RotationMatrix;
+	rotateHole->rotateY(M_PI/2.0);
+	G4ThreeVector moveHole(0, -halfLengthY, halfLengthZ);
 
-    G4SubtractionSolid* quarterSuppressorWithHole = new G4SubtractionSolid("quarterSuppressorWithHole",
-                                                                              quarterSuppressor, hole, rotateHole, moveHole);
+	G4SubtractionSolid* quarterSuppressorWithHole = new G4SubtractionSolid("quarterSuppressorWithHole",
+			quarterSuppressor, hole, rotateHole, moveHole);
 
-    return quarterSuppressorWithHole;
+	return quarterSuppressorWithHole;
 
 }//end ::backSuppressorQuarter
 
 
 G4SubtractionSolid* DetectionSystemGriffin::FrontSlantSuppressor(G4String sidePosition, G4bool choppingSuppressor) {
-    // If chop is true, it will be a chopping suppressor.
+	// If chop is true, it will be a chopping suppressor.
 
-    G4double lengthZ     = fSideSuppressorLength ;
-    G4double lengthY     = fSideBGOThickness ;
-    G4double lengthLongerX  = 0 ;
+	G4double lengthZ     = fSideSuppressorLength ;
+	G4double lengthY     = fSideBGOThickness ;
+	G4double lengthLongerX  = 0 ;
 
-    if(choppingSuppressor)
-        lengthLongerX  = fDetectorTotalWidth / 2.0 + fBGOCanSeperation + fSideBGOThickness + fExtraCutLength / 2.0 ;
-    else
-        lengthLongerX  = fDetectorTotalWidth / 2.0 + fBGOCanSeperation + fSideBGOThickness;
-    
-    G4double lengthShorterX   = lengthLongerX - fSideBGOThickness;
+	if(choppingSuppressor)
+		lengthLongerX  = fDetectorTotalWidth / 2.0 + fBGOCanSeperation + fSideBGOThickness + fExtraCutLength / 2.0 ;
+	else
+		lengthLongerX  = fDetectorTotalWidth / 2.0 + fBGOCanSeperation + fSideBGOThickness;
 
-    G4Trap* suppressor = new G4Trap("suppressor", lengthZ, lengthY, lengthLongerX, lengthShorterX) ;
+	G4double lengthShorterX   = lengthLongerX - fSideBGOThickness;
 
-    G4double halfLengthX  = lengthLongerX / 2.0 + 1.0*cm ;
-    G4double halfThicknessY   = fSideBGOThickness / 2.0;
-    G4double halfLengthZ  = ((fSideBGOThickness - fBGOChoppedTip) / sin(fBentEndAngle)) / 2.0;
+	G4Trap* suppressor = new G4Trap("suppressor", lengthZ, lengthY, lengthLongerX, lengthShorterX) ;
 
-    G4Box* choppingBox = new G4Box("choppingBox", halfLengthX, halfThicknessY, halfLengthZ);
+	G4double halfLengthX  = lengthLongerX / 2.0 + 1.0*cm ;
+	G4double halfThicknessY   = fSideBGOThickness / 2.0;
+	G4double halfLengthZ  = ((fSideBGOThickness - fBGOChoppedTip) / sin(fBentEndAngle)) / 2.0;
 
-    G4RotationMatrix* rotateChoppingBox = new G4RotationMatrix;
-    G4ThreeVector moveChoppingBox ;
-    G4double y0, z0 ;
+	G4Box* choppingBox = new G4Box("choppingBox", halfLengthX, halfThicknessY, halfLengthZ);
 
-    y0 =  fSideBGOThickness / 2.0 - fBGOChoppedTip - 0.5 * sqrt(pow((2.0 * halfLengthZ), 2.0)
-                                                                               + pow((2.0 * halfThicknessY), 2.0)) * cos(M_PI/2.0 - fBentEndAngle - atan(halfThicknessY / halfLengthZ)) ;
+	G4RotationMatrix* rotateChoppingBox = new G4RotationMatrix;
+	G4ThreeVector moveChoppingBox ;
+	G4double y0, z0 ;
 
-    z0 =  lengthZ / 2.0 - 0.5 * sqrt(pow((2.0 * halfLengthZ), 2.0) + pow((2.0 * halfThicknessY), 2.0))
-            * sin(M_PI/2.0 - fBentEndAngle - atan(halfThicknessY / halfLengthZ)) ;
+	y0 =  fSideBGOThickness / 2.0 - fBGOChoppedTip - 0.5 * sqrt(pow((2.0 * halfLengthZ), 2.0)
+			+ pow((2.0 * halfThicknessY), 2.0)) * cos(M_PI/2.0 - fBentEndAngle - atan(halfThicknessY / halfLengthZ)) ;
 
-    if(sidePosition == "left") {
-        rotateChoppingBox->rotateX(fBentEndAngle) ;
-        moveChoppingBox = G4ThreeVector(0, y0, z0) ;
-    } else if(sidePosition == "right") {
-        rotateChoppingBox->rotateX(-fBentEndAngle) ;
-        moveChoppingBox = G4ThreeVector(0, y0, -z0) ;
-    }
-    
-    G4SubtractionSolid* sideSuppressor = new G4SubtractionSolid("sideSuppressor",
-                                                                 suppressor, choppingBox, rotateChoppingBox, moveChoppingBox);
+	z0 =  lengthZ / 2.0 - 0.5 * sqrt(pow((2.0 * halfLengthZ), 2.0) + pow((2.0 * halfThicknessY), 2.0))
+		* sin(M_PI/2.0 - fBentEndAngle - atan(halfThicknessY / halfLengthZ)) ;
 
-    return sideSuppressor;
+	if(sidePosition == "left") {
+		rotateChoppingBox->rotateX(fBentEndAngle) ;
+		moveChoppingBox = G4ThreeVector(0, y0, z0) ;
+	} else if(sidePosition == "right") {
+		rotateChoppingBox->rotateX(-fBentEndAngle) ;
+		moveChoppingBox = G4ThreeVector(0, y0, -z0) ;
+	}
+
+	G4SubtractionSolid* sideSuppressor = new G4SubtractionSolid("sideSuppressor",
+			suppressor, choppingBox, rotateChoppingBox, moveChoppingBox);
+
+	return sideSuppressor;
 
 }// end ::frontSlantSuppressor
 
 
 G4SubtractionSolid* DetectionSystemGriffin::SideSuppressorExtension(G4String sidePosition, G4bool choppingSuppressor) {
 
-    G4double thicknessZ      =   fSuppressorExtensionThickness ;
-    G4double lengthY         =   fSuppressorExtensionLength ;
+	G4double thicknessZ      =   fSuppressorExtensionThickness ;
+	G4double lengthY         =   fSuppressorExtensionLength ;
 
-    G4double longerLengthX  =   ((fSuppressorBackRadius + fBentEndLength
-                                    + (fBGOCanSeperation
-                                       + fSideBGOThickness) / tan(fBentEndAngle)
-                                    - fSuppressorExtensionThickness
-                                    * sin(fBentEndAngle)) * tan(fBentEndAngle) - fBGOCanSeperation * 2.0) ;  // - fBGOCanSeperation
+	G4double longerLengthX  =   ((fSuppressorBackRadius + fBentEndLength
+				+ (fBGOCanSeperation
+					+ fSideBGOThickness) / tan(fBentEndAngle)
+				- fSuppressorExtensionThickness
+				* sin(fBentEndAngle)) * tan(fBentEndAngle) - fBGOCanSeperation * 2.0) ;  // - fBGOCanSeperation
 
-    G4double shorterLengthX =   ((fSuppressorForwardRadius + fHevimetTipThickness)
-            * sin(fBentEndAngle) - fBGOCanSeperation * 2.0) ; // - fBGOCanSeperation
+	G4double shorterLengthX =   ((fSuppressorForwardRadius + fHevimetTipThickness)
+			* sin(fBentEndAngle) - fBGOCanSeperation * 2.0) ; // - fBGOCanSeperation
 
-    if(choppingSuppressor) {
-        thicknessZ += 0.1*mm;
-        lengthY += 0.1*mm;
-    }
+	if(choppingSuppressor) {
+		thicknessZ += 0.1*mm;
+		lengthY += 0.1*mm;
+	}
 
-    G4Trap* uncutExtension   = new G4Trap("uncutExtension", thicknessZ, lengthY, longerLengthX, shorterLengthX);
+	G4Trap* uncutExtension   = new G4Trap("uncutExtension", thicknessZ, lengthY, longerLengthX, shorterLengthX);
 
-    // because these pieces are rotated in two planes, there are multiple angles that need to be calculated to make sure
-    // all of the extensions join up
-    G4double beta = atan((longerLengthX - shorterLengthX) / (lengthY)) ;
-    G4double phi  = atan(1 / cos(fBentEndAngle)) ;
+	// because these pieces are rotated in two planes, there are multiple angles that need to be calculated to make sure
+	// all of the extensions join up
+	G4double beta = atan((longerLengthX - shorterLengthX) / (lengthY)) ;
+	G4double phi  = atan(1 / cos(fBentEndAngle)) ;
 
-    G4double choppingHalfLengthX = thicknessZ / (2.0 * sin(phi)) ;
-    G4double choppingHalfLengthY = lengthY / (2.0 * cos(beta)) ;
-    G4double choppingHalfLengthZ = choppingHalfLengthX ;
+	G4double choppingHalfLengthX = thicknessZ / (2.0 * sin(phi)) ;
+	G4double choppingHalfLengthY = lengthY / (2.0 * cos(beta)) ;
+	G4double choppingHalfLengthZ = choppingHalfLengthX ;
 
-    G4double xAngle = 0.0 ;
-    G4double yAngle = -beta ;
-    G4double zAngle = phi - M_PI/2.0 ;
+	G4double xAngle = 0.0 ;
+	G4double yAngle = -beta ;
+	G4double zAngle = phi - M_PI/2.0 ;
 
-    if(sidePosition == "left")
-        zAngle *= -1 ;
+	if(sidePosition == "left")
+		zAngle *= -1 ;
 
-    G4Para* choppingPara = new G4Para("choppingPara", choppingHalfLengthX,
-                                       choppingHalfLengthY, choppingHalfLengthZ,
-                                       yAngle, zAngle, xAngle);
+	G4Para* choppingPara = new G4Para("choppingPara", choppingHalfLengthX,
+			choppingHalfLengthY, choppingHalfLengthZ,
+			yAngle, zAngle, xAngle);
 
-    G4ThreeVector movePara(((longerLengthX - shorterLengthX) / 2.0
-                             + shorterLengthX) / 2.0 + choppingHalfLengthX
-                            - choppingHalfLengthX * cos(phi), 0.0, 0.0);
+	G4ThreeVector movePara(((longerLengthX - shorterLengthX) / 2.0
+				+ shorterLengthX) / 2.0 + choppingHalfLengthX
+			- choppingHalfLengthX * cos(phi), 0.0, 0.0);
 
-    G4SubtractionSolid* rightExtension = new G4SubtractionSolid("rightExtension", uncutExtension, choppingPara, 0, movePara);
+	G4SubtractionSolid* rightExtension = new G4SubtractionSolid("rightExtension", uncutExtension, choppingPara, 0, movePara);
 
-    return rightExtension;
+	return rightExtension;
 
 }// end ::sideSuppressorExtension()
 
 
 G4Trap* DetectionSystemGriffin::SideSuppressorExtensionUncut() {
 
-    G4double thicknessZ      =   fSuppressorExtensionThickness ;
-    G4double lengthY         =   fSuppressorExtensionLength ;
+	G4double thicknessZ      =   fSuppressorExtensionThickness ;
+	G4double lengthY         =   fSuppressorExtensionLength ;
 
-    G4double longerLengthX  =   ((fSuppressorBackRadius + fBentEndLength
-                                    + (fBGOCanSeperation
-                                       + fSideBGOThickness) / tan(fBentEndAngle)
-                                    - fSuppressorExtensionThickness
-                                    * sin(fBentEndAngle)) * tan(fBentEndAngle) - fBGOCanSeperation * 2.0) ;  // - fBGOCanSeperation
+	G4double longerLengthX  =   ((fSuppressorBackRadius + fBentEndLength
+				+ (fBGOCanSeperation
+					+ fSideBGOThickness) / tan(fBentEndAngle)
+				- fSuppressorExtensionThickness
+				* sin(fBentEndAngle)) * tan(fBentEndAngle) - fBGOCanSeperation * 2.0) ;  // - fBGOCanSeperation
 
-    G4double shorterLengthX =   ((fSuppressorForwardRadius + fHevimetTipThickness)
-            * sin(fBentEndAngle) - fBGOCanSeperation * 2.0) ; // - fBGOCanSeperation
+	G4double shorterLengthX =   ((fSuppressorForwardRadius + fHevimetTipThickness)
+			* sin(fBentEndAngle) - fBGOCanSeperation * 2.0) ; // - fBGOCanSeperation
 
-    // Similar to the "true" choppingSuppressor, add a bit on the z and y lengths to give a bit of a gap.
-    thicknessZ += 0.1*mm;
-    lengthY += 0.1*mm;
+	// Similar to the "true" choppingSuppressor, add a bit on the z and y lengths to give a bit of a gap.
+	thicknessZ += 0.1*mm;
+	lengthY += 0.1*mm;
 
-    G4Trap* uncutExtension   = new G4Trap("uncutExtension", thicknessZ, lengthY, longerLengthX, shorterLengthX);
+	G4Trap* uncutExtension   = new G4Trap("uncutExtension", thicknessZ, lengthY, longerLengthX, shorterLengthX);
 
-    return uncutExtension;
+	return uncutExtension;
 }// end ::sideSuppressorExtensionUncut()
 
 
@@ -2982,62 +2982,62 @@ G4Trap* DetectionSystemGriffin::SideSuppressorExtensionUncut() {
 ///////////////////////////////////////////////////////////////////////
 G4SubtractionSolid* DetectionSystemGriffin::NewHeavyMet() {
 
-    G4double halfThicknessZ = ((fHevimetTipThickness/cos(fHevimetTipAngle))
-                                 * cos(fBentEndAngle -fHevimetTipAngle)
-                                 + fSuppressorForwardRadius * tan(fHevimetTipAngle)
-                                 * sin(fBentEndAngle))/2.0;
+	G4double halfThicknessZ = ((fHevimetTipThickness/cos(fHevimetTipAngle))
+			* cos(fBentEndAngle -fHevimetTipAngle)
+			+ fSuppressorForwardRadius * tan(fHevimetTipAngle)
+			* sin(fBentEndAngle))/2.0;
 
 
-    G4double halfLengthShorterX  = fSuppressorForwardRadius * sin(fBentEndAngle);
-    G4double halfLengthLongerX 	= halfLengthShorterX +2.0*halfThicknessZ*tan(fBentEndAngle);
-    G4double  halfLengthShorterY = halfLengthShorterX;
-    G4double halfLengthLongerY 	= halfLengthLongerX;
+	G4double halfLengthShorterX  = fSuppressorForwardRadius * sin(fBentEndAngle);
+	G4double halfLengthLongerX 	= halfLengthShorterX +2.0*halfThicknessZ*tan(fBentEndAngle);
+	G4double  halfLengthShorterY = halfLengthShorterX;
+	G4double halfLengthLongerY 	= halfLengthLongerX;
 
-    G4Trd* uncutHevimet = new G4Trd("uncutHevimet", halfLengthLongerX,
-                                     halfLengthShorterX, halfLengthLongerY, halfLengthShorterY, halfThicknessZ);
+	G4Trd* uncutHevimet = new G4Trd("uncutHevimet", halfLengthLongerX,
+			halfLengthShorterX, halfLengthLongerY, halfLengthShorterY, halfThicknessZ);
 
-    G4double halfShorterLengthX = halfLengthShorterX
-            - fSuppressorForwardRadius * tan(fHevimetTipAngle) * cos(fBentEndAngle);
+	G4double halfShorterLengthX = halfLengthShorterX
+		- fSuppressorForwardRadius * tan(fHevimetTipAngle) * cos(fBentEndAngle);
 
-    G4double halfHeightZ =  (2.0 * halfThicknessZ + (halfLengthLongerX
-                                                           - ((fSuppressorForwardRadius + fHevimetTipThickness)
-                                                               * tan(fHevimetTipAngle)) / cos(fBentEndAngle)
-                                                           - halfShorterLengthX)*tan(fBentEndAngle)) / 2.0;
+	G4double halfHeightZ =  (2.0 * halfThicknessZ + (halfLengthLongerX
+				- ((fSuppressorForwardRadius + fHevimetTipThickness)
+					* tan(fHevimetTipAngle)) / cos(fBentEndAngle)
+				- halfShorterLengthX)*tan(fBentEndAngle)) / 2.0;
 
-    G4double halfLongerLengthX 	= halfShorterLengthX + 2.0 * halfHeightZ/tan(fBentEndAngle) ;
-    G4double halfShorterLengthY 	= halfShorterLengthX;
-    G4double halfLongerLengthY 	= halfLongerLengthX;
+	G4double halfLongerLengthX 	= halfShorterLengthX + 2.0 * halfHeightZ/tan(fBentEndAngle) ;
+	G4double halfShorterLengthY 	= halfShorterLengthX;
+	G4double halfLongerLengthY 	= halfLongerLengthX;
 
-    G4Trd* intersector = new G4Trd("intersector", halfShorterLengthX,
-                                    halfLongerLengthX, halfShorterLengthY, halfLongerLengthY, halfHeightZ);
+	G4Trd* intersector = new G4Trd("intersector", halfShorterLengthX,
+			halfLongerLengthX, halfShorterLengthY, halfLongerLengthY, halfHeightZ);
 
-    G4Trd* chopper = new G4Trd("chopper", halfShorterLengthX, halfLongerLengthX,
-                                halfShorterLengthY, halfLongerLengthY, halfHeightZ);
+	G4Trd* chopper = new G4Trd("chopper", halfShorterLengthX, halfLongerLengthX,
+			halfShorterLengthY, halfLongerLengthY, halfHeightZ);
 
-    G4ThreeVector moveChopper(0.0, 0.0, halfHeightZ + halfThicknessZ
-                               - fSuppressorForwardRadius * tan(fHevimetTipAngle)
-                               * sin(fBentEndAngle)) ;
+	G4ThreeVector moveChopper(0.0, 0.0, halfHeightZ + halfThicknessZ
+			- fSuppressorForwardRadius * tan(fHevimetTipAngle)
+			* sin(fBentEndAngle)) ;
 
-    G4SubtractionSolid* choppedHevimet = new G4SubtractionSolid("choppedHevimet",
-                                                                 uncutHevimet, chopper, 0, moveChopper);
+	G4SubtractionSolid* choppedHevimet = new G4SubtractionSolid("choppedHevimet",
+			uncutHevimet, chopper, 0, moveChopper);
 
-    G4ThreeVector moveIntersector(0.0, 0.0, -halfHeightZ + halfThicknessZ);
+	G4ThreeVector moveIntersector(0.0, 0.0, -halfHeightZ + halfThicknessZ);
 
-    G4IntersectionSolid* intersectedHevimet = new G4IntersectionSolid("intersectedHevimet",
-                                                                       choppedHevimet, intersector, 0, moveIntersector);
+	G4IntersectionSolid* intersectedHevimet = new G4IntersectionSolid("intersectedHevimet",
+			choppedHevimet, intersector, 0, moveIntersector);
 
-    G4double longerHalfLength = halfLengthLongerX -((fSuppressorForwardRadius
-                                                          + fHevimetTipThickness)*tan(fHevimetTipAngle)) / cos(fBentEndAngle) ;
+	G4double longerHalfLength = halfLengthLongerX -((fSuppressorForwardRadius
+				+ fHevimetTipThickness)*tan(fHevimetTipAngle)) / cos(fBentEndAngle) ;
 
-    G4double shorterHalfLength = longerHalfLength -2.0*(halfThicknessZ +0.1*mm)
-            * tan(fBentEndAngle -fHevimetTipAngle);
+	G4double shorterHalfLength = longerHalfLength -2.0*(halfThicknessZ +0.1*mm)
+		* tan(fBentEndAngle -fHevimetTipAngle);
 
-    G4Trd* middleChopper = new G4Trd("middleChopper", longerHalfLength, shorterHalfLength,
-                                      longerHalfLength, shorterHalfLength, halfThicknessZ +0.1*mm);
+	G4Trd* middleChopper = new G4Trd("middleChopper", longerHalfLength, shorterHalfLength,
+			longerHalfLength, shorterHalfLength, halfThicknessZ +0.1*mm);
 
-    G4SubtractionSolid* hevimet = new G4SubtractionSolid("hevimet", intersectedHevimet, middleChopper);
+	G4SubtractionSolid* hevimet = new G4SubtractionSolid("hevimet", intersectedHevimet, middleChopper);
 
-    return hevimet;
+	return hevimet;
 }//end ::newHeavyMet
 
 

--- a/src/DetectionSystemGriffin.cc
+++ b/src/DetectionSystemGriffin.cc
@@ -529,7 +529,7 @@ void DetectionSystemGriffin::BuildOneDetector() {
     if(fBGOSelector == 1) {
         ConstructNewSuppressorCasingWithShells() ;
     } else if(fBGOSelector == 0) {
-        G4cout<<"Not building BGO "<<G4endl ;
+        //G4cout<<"Not building BGO "<<G4endl ;
     } else {
         G4cout<<"Error 234235"<<G4endl ;
         exit(1);
@@ -568,7 +568,7 @@ void DetectionSystemGriffin::BuildEverythingButCrystals() {
     if(fBGOSelector == 1) {
         ConstructNewSuppressorCasingWithShells();
     } else if(fBGOSelector == 0) {
-        G4cout<<"Not building BGO "<<G4endl;
+        //G4cout<<"Not building BGO "<<G4endl;
     } else {
         G4cout<<"Error 234235"<<G4endl;
         exit(1);

--- a/src/DetectionSystemLanthanumBromide.cc
+++ b/src/DetectionSystemLanthanumBromide.cc
@@ -26,592 +26,592 @@
 
 
 DetectionSystemLanthanumBromide::DetectionSystemLanthanumBromide() :
-    // LogicalVolumes
-    fDetectorVolumeLog(0),
-    fCrystalBlockLog(0),
-    fCanCylinderLog(0),
-    fCanFrontLidLog(0),
-    fCanBackLidLog(0),
-    fSealFrontLidLog(0),
-    fDiscFrontLidLog(0),
-    fPackingCylinderLog(0),
-    fPackingFrontLidLog(0)
+	// LogicalVolumes
+	fDetectorVolumeLog(0),
+	fCrystalBlockLog(0),
+	fCanCylinderLog(0),
+	fCanFrontLidLog(0),
+	fCanBackLidLog(0),
+	fSealFrontLidLog(0),
+	fDiscFrontLidLog(0),
+	fPackingCylinderLog(0),
+	fPackingFrontLidLog(0)
 {
 
-    // NaI Crystal and Can Physical Properties
-    // From: Scintillation Spectrometry gamma-ray catalogue - R. L. Heath, 1964
+	// NaI Crystal and Can Physical Properties
+	// From: Scintillation Spectrometry gamma-ray catalogue - R. L. Heath, 1964
 
-    /////////////////////////////////////////////////////////////////////
-    //  0.019"
-    //  "can" - Al Container
-    //
-    //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-    //% 0.040"
-    //% "seal" - Compressed Neoprene Rubber
-    //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-    //-------------------------------------------------------------------
-    //- 0.006"
-    //- "disc" - Polyethylene Disc
-    //-------------------------------------------------------------------
-    /////////////////////////////////////////////////////////////////////
-    //- 0.0625"
-    //- "packing" - Packed Aluminum Oxide
-    /////////////////////////////////////////////////////////////////////
-    //
-    //
-    //  NaI Crystal - Used as first-order estimate of Lanthanum Bromide Crystal
-    //
-    //
-    //
-    //
-    //
-
-
-    fDetailViewEndAngle	      = 360.0*deg;
-    fCrystalMaterial            = "CeriumDopedLanthanumBromide";
-
-    fCanMaterial                = "G4_Al";
-    fSealMaterial               = "G4_RUBBER_NEOPRENE";
-    fDiscMaterial               = "G4_POLYETHYLENE";
-    fPackingMaterial            = "G4_ALUMINUM_OXIDE";
-
-    fCrystalLengthZ            = 2.0*inchtocm*cm;
-    fCrystalInnerRadius 		  = 0.0*cm;
-    fCrystalOuterRadius 		  = 1.0*inchtocm*cm;
-
-    fPackingLengthZ            = fCrystalLengthZ;
-    fPackingInnerRadius 		  = fCrystalOuterRadius;
-    fPackingOuterRadius 		  = 0.0625*inchtocm*cm + fCrystalOuterRadius;
-
-    fPackingLidInnerRadius    = 0.0*cm;
-    fPackingLidOuterRadius 	  = fPackingOuterRadius;
-    fPackingFrontLidThickness = 0.0625*inchtocm*cm;
-
-    fDiscLidInnerRadius       = 0.0*cm;
-    fDiscLidOuterRadius       = fPackingLidOuterRadius;
-    fDiscFrontLidThickness	= 0.006*inchtocm*cm;
-
-    fSealLidInnerRadius       = 0.0*cm;
-    fSealLidOuterRadius       = fPackingLidOuterRadius;
-    fSealFrontLidThickness	  = 0.04*inchtocm*cm;
-
-    fCanLengthZ                = fCrystalLengthZ + fPackingFrontLidThickness + fDiscFrontLidThickness + fSealFrontLidThickness;
-    fCanInnerRadius            = fPackingOuterRadius;
-    fCanOuterRadius            = 0.019*inchtocm*cm + fPackingOuterRadius;
-
-    fCanLidInnerRadius        = 0.0*cm;
-    fCanLidOuterRadius        = fCanOuterRadius;
-    fCanFrontLidThickness     = 0.019*inchtocm*cm;
-    fCanBackLidThickness      = 0.019*inchtocm*cm;
+	/////////////////////////////////////////////////////////////////////
+	//  0.019"
+	//  "can" - Al Container
+	//
+	//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+	//% 0.040"
+	//% "seal" - Compressed Neoprene Rubber
+	//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+	//-------------------------------------------------------------------
+	//- 0.006"
+	//- "disc" - Polyethylene Disc
+	//-------------------------------------------------------------------
+	/////////////////////////////////////////////////////////////////////
+	//- 0.0625"
+	//- "packing" - Packed Aluminum Oxide
+	/////////////////////////////////////////////////////////////////////
+	//
+	//
+	//  NaI Crystal - Used as first-order estimate of Lanthanum Bromide Crystal
+	//
+	//
+	//
+	//
+	//
 
 
-    fDetectorLengthZ           = fCrystalLengthZ +
-            fPackingFrontLidThickness +
-            fDiscFrontLidThickness +
-            fSealFrontLidThickness +
-            fCanFrontLidThickness +
-            fCanBackLidThickness;
-	  //G4double triangleThetaAngle = (180/M_PI)*(atan((1/sqrt(3))/sqrt((11/12) + (1/sqrt(2))) )+atan((sqrt(2))/(1+sqrt(2))))*deg;
-	  G4double triangleThetaAngle = 54.735610317245360*deg;
+	fDetailViewEndAngle	      = 360.0*deg;
+	fCrystalMaterial            = "CeriumDopedLanthanumBromide";
 
-	  // theta
-	  fDetectorAngles[0][0] 	= triangleThetaAngle;
-	  fDetectorAngles[1][0] 	= triangleThetaAngle;
-	  fDetectorAngles[2][0] 	= triangleThetaAngle;
-	  fDetectorAngles[3][0] 	= triangleThetaAngle;
-	  fDetectorAngles[4][0] 	= 180.0*deg - triangleThetaAngle;
-	  fDetectorAngles[5][0] 	= 180.0*deg - triangleThetaAngle;
-	  fDetectorAngles[6][0] 	= 180.0*deg - triangleThetaAngle;
-	  fDetectorAngles[7][0] 	= 180.0*deg - triangleThetaAngle;
-	  // phi
-	  fDetectorAngles[0][1] 	= 22.5*deg;
-	  fDetectorAngles[1][1] 	= 112.5*deg;
-	  fDetectorAngles[2][1] 	= 202.5*deg;
-	  fDetectorAngles[3][1] 	= 292.5*deg;
-	  fDetectorAngles[4][1] 	= 22.5*deg;
-	  fDetectorAngles[5][1] 	= 112.5*deg;
-	  fDetectorAngles[6][1] 	= 202.5*deg;
-	  fDetectorAngles[7][1] 	= 292.5*deg;
-	  // yaw (alpha)
-	  fDetectorAngles[0][2] 	= 0.0*deg;
-	  fDetectorAngles[1][2] 	= 0.0*deg;
-	  fDetectorAngles[2][2] 	= 0.0*deg;
-	  fDetectorAngles[3][2] 	= 0.0*deg;
-	  fDetectorAngles[4][2] 	= 0.0*deg;
-	  fDetectorAngles[5][2] 	= 0.0*deg;
-	  fDetectorAngles[6][2] 	= 0.0*deg;
-	  fDetectorAngles[7][2] 	= 0.0*deg;
-	  // pitch (beta)
-	  fDetectorAngles[0][3] 	= triangleThetaAngle;
-	  fDetectorAngles[1][3] 	= triangleThetaAngle;
-	  fDetectorAngles[2][3] 	= triangleThetaAngle;
-	  fDetectorAngles[3][3] 	= triangleThetaAngle;
-	  fDetectorAngles[4][3] 	= 180.0*deg - triangleThetaAngle;
-	  fDetectorAngles[5][3] 	= 180.0*deg - triangleThetaAngle;
-	  fDetectorAngles[6][3] 	= 180.0*deg - triangleThetaAngle;
-	  fDetectorAngles[7][3] 	= 180.0*deg - triangleThetaAngle;
-	  // roll (gamma)
-	  fDetectorAngles[0][4] 	= 22.5*deg;
-	  fDetectorAngles[1][4] 	= 112.5*deg;
-	  fDetectorAngles[2][4] 	= 202.5*deg;
-	  fDetectorAngles[3][4] 	= 292.5*deg;
-	  fDetectorAngles[4][4] 	= 22.5*deg;
-	  fDetectorAngles[5][4] 	= 112.5*deg;
-	  fDetectorAngles[6][4] 	= 202.5*deg;
-	  fDetectorAngles[7][4] 	= 292.5*deg;
+	fCanMaterial                = "G4_Al";
+	fSealMaterial               = "G4_RUBBER_NEOPRENE";
+	fDiscMaterial               = "G4_POLYETHYLENE";
+	fPackingMaterial            = "G4_ALUMINUM_OXIDE";
+
+	fCrystalLengthZ            = 2.0*inchtocm*cm;
+	fCrystalInnerRadius 		  = 0.0*cm;
+	fCrystalOuterRadius 		  = 1.0*inchtocm*cm;
+
+	fPackingLengthZ            = fCrystalLengthZ;
+	fPackingInnerRadius 		  = fCrystalOuterRadius;
+	fPackingOuterRadius 		  = 0.0625*inchtocm*cm + fCrystalOuterRadius;
+
+	fPackingLidInnerRadius    = 0.0*cm;
+	fPackingLidOuterRadius 	  = fPackingOuterRadius;
+	fPackingFrontLidThickness = 0.0625*inchtocm*cm;
+
+	fDiscLidInnerRadius       = 0.0*cm;
+	fDiscLidOuterRadius       = fPackingLidOuterRadius;
+	fDiscFrontLidThickness	= 0.006*inchtocm*cm;
+
+	fSealLidInnerRadius       = 0.0*cm;
+	fSealLidOuterRadius       = fPackingLidOuterRadius;
+	fSealFrontLidThickness	  = 0.04*inchtocm*cm;
+
+	fCanLengthZ                = fCrystalLengthZ + fPackingFrontLidThickness + fDiscFrontLidThickness + fSealFrontLidThickness;
+	fCanInnerRadius            = fPackingOuterRadius;
+	fCanOuterRadius            = 0.019*inchtocm*cm + fPackingOuterRadius;
+
+	fCanLidInnerRadius        = 0.0*cm;
+	fCanLidOuterRadius        = fCanOuterRadius;
+	fCanFrontLidThickness     = 0.019*inchtocm*cm;
+	fCanBackLidThickness      = 0.019*inchtocm*cm;
+
+
+	fDetectorLengthZ           = fCrystalLengthZ +
+		fPackingFrontLidThickness +
+		fDiscFrontLidThickness +
+		fSealFrontLidThickness +
+		fCanFrontLidThickness +
+		fCanBackLidThickness;
+	//G4double triangleThetaAngle = (180/M_PI)*(atan((1/sqrt(3))/sqrt((11/12) + (1/sqrt(2))))+atan((sqrt(2))/(1+sqrt(2))))*deg;
+	G4double triangleThetaAngle = 54.735610317245360*deg;
+
+	// theta
+	fDetectorAngles[0][0] 	= triangleThetaAngle;
+	fDetectorAngles[1][0] 	= triangleThetaAngle;
+	fDetectorAngles[2][0] 	= triangleThetaAngle;
+	fDetectorAngles[3][0] 	= triangleThetaAngle;
+	fDetectorAngles[4][0] 	= 180.0*deg - triangleThetaAngle;
+	fDetectorAngles[5][0] 	= 180.0*deg - triangleThetaAngle;
+	fDetectorAngles[6][0] 	= 180.0*deg - triangleThetaAngle;
+	fDetectorAngles[7][0] 	= 180.0*deg - triangleThetaAngle;
+	// phi
+	fDetectorAngles[0][1] 	= 22.5*deg;
+	fDetectorAngles[1][1] 	= 112.5*deg;
+	fDetectorAngles[2][1] 	= 202.5*deg;
+	fDetectorAngles[3][1] 	= 292.5*deg;
+	fDetectorAngles[4][1] 	= 22.5*deg;
+	fDetectorAngles[5][1] 	= 112.5*deg;
+	fDetectorAngles[6][1] 	= 202.5*deg;
+	fDetectorAngles[7][1] 	= 292.5*deg;
+	// yaw (alpha)
+	fDetectorAngles[0][2] 	= 0.0*deg;
+	fDetectorAngles[1][2] 	= 0.0*deg;
+	fDetectorAngles[2][2] 	= 0.0*deg;
+	fDetectorAngles[3][2] 	= 0.0*deg;
+	fDetectorAngles[4][2] 	= 0.0*deg;
+	fDetectorAngles[5][2] 	= 0.0*deg;
+	fDetectorAngles[6][2] 	= 0.0*deg;
+	fDetectorAngles[7][2] 	= 0.0*deg;
+	// pitch (beta)
+	fDetectorAngles[0][3] 	= triangleThetaAngle;
+	fDetectorAngles[1][3] 	= triangleThetaAngle;
+	fDetectorAngles[2][3] 	= triangleThetaAngle;
+	fDetectorAngles[3][3] 	= triangleThetaAngle;
+	fDetectorAngles[4][3] 	= 180.0*deg - triangleThetaAngle;
+	fDetectorAngles[5][3] 	= 180.0*deg - triangleThetaAngle;
+	fDetectorAngles[6][3] 	= 180.0*deg - triangleThetaAngle;
+	fDetectorAngles[7][3] 	= 180.0*deg - triangleThetaAngle;
+	// roll (gamma)
+	fDetectorAngles[0][4] 	= 22.5*deg;
+	fDetectorAngles[1][4] 	= 112.5*deg;
+	fDetectorAngles[2][4] 	= 202.5*deg;
+	fDetectorAngles[3][4] 	= 292.5*deg;
+	fDetectorAngles[4][4] 	= 22.5*deg;
+	fDetectorAngles[5][4] 	= 112.5*deg;
+	fDetectorAngles[6][4] 	= 202.5*deg;
+	fDetectorAngles[7][4] 	= 292.5*deg;
 }
 
 DetectionSystemLanthanumBromide::~DetectionSystemLanthanumBromide() {
-    // LogicalVolumes
-    delete fDetectorVolumeLog;
-    delete fCrystalBlockLog;
-    delete fCanCylinderLog;
-    delete fCanFrontLidLog;
-    delete fCanBackLidLog;
-    delete fSealFrontLidLog;
-    delete fDiscFrontLidLog;
-    delete fPackingCylinderLog;
-    delete fPackingFrontLidLog;
+	// LogicalVolumes
+	delete fDetectorVolumeLog;
+	delete fCrystalBlockLog;
+	delete fCanCylinderLog;
+	delete fCanFrontLidLog;
+	delete fCanBackLidLog;
+	delete fSealFrontLidLog;
+	delete fDiscFrontLidLog;
+	delete fPackingCylinderLog;
+	delete fPackingFrontLidLog;
 }
 
 
 G4int DetectionSystemLanthanumBromide::Build() {
 
-    // Build assembly volume
-    fAssembly = new G4AssemblyVolume();
+	// Build assembly volume
+	fAssembly = new G4AssemblyVolume();
 
-    G4cout << "BuildCrystalVolume" << G4endl;
-    BuildCrystalVolume();
-    G4cout << "BuildAluminumCanVolume" << G4endl;
-    BuildAluminumCanVolume();
-    G4cout << "BuildPackingVolume" << G4endl;
-    BuildPackingVolume();
-    G4cout << "BuildDiscVolume" << G4endl;
-    BuildDiscVolume();
-    G4cout << "BuildSealVolume" << G4endl;
-    BuildSealVolume();
+	G4cout<<"BuildCrystalVolume"<<G4endl;
+	BuildCrystalVolume();
+	G4cout<<"BuildAluminumCanVolume"<<G4endl;
+	BuildAluminumCanVolume();
+	G4cout<<"BuildPackingVolume"<<G4endl;
+	BuildPackingVolume();
+	G4cout<<"BuildDiscVolume"<<G4endl;
+	BuildDiscVolume();
+	G4cout<<"BuildSealVolume"<<G4endl;
+	BuildSealVolume();
 
-    return 1;
+	return 1;
 }
 
 G4double DetectionSystemLanthanumBromide::GetR() {
-    // to crystal face
+	// to crystal face
 
-    G4double position = fSetRadialPos - (fPackingFrontLidThickness + fDiscFrontLidThickness + fCanFrontLidThickness - fCanBackLidThickness);
-    return position;
+	G4double position = fSetRadialPos - (fPackingFrontLidThickness + fDiscFrontLidThickness + fCanFrontLidThickness - fCanBackLidThickness);
+	return position;
 }
 
 G4double DetectionSystemLanthanumBromide::GetTheta(G4int i) {
-    // to crystal face
+	// to crystal face
 
-    return fDetectorAngles[i][0]; //theta
+	return fDetectorAngles[i][0]; //theta
 }
 
 G4double DetectionSystemLanthanumBromide::GetPhi(G4int i) {
-    // to crystal face
+	// to crystal face
 
-    return fDetectorAngles[i][1]; //phi
+	return fDetectorAngles[i][1]; //phi
 }
 
 G4double DetectionSystemLanthanumBromide::GetYaw(G4int i) {
-    // to crystal face
+	// to crystal face
 
-    return fDetectorAngles[i][2]; //yaw
+	return fDetectorAngles[i][2]; //yaw
 }
 
 G4double DetectionSystemLanthanumBromide::GetPitch(G4int i) {
-    // to crystal face
+	// to crystal face
 
-    return fDetectorAngles[i][3]; //pitch
+	return fDetectorAngles[i][3]; //pitch
 }
 
 G4double DetectionSystemLanthanumBromide::GetRoll(G4int i) {
-    // to crystal face
+	// to crystal face
 
-    return fDetectorAngles[i][4]; //roll
+	return fDetectorAngles[i][4]; //roll
 }
 
 G4int DetectionSystemLanthanumBromide::PlaceDetector(G4LogicalVolume* expHallLog, G4int detectorNumber, G4double radialpos) {
-    G4int detectorCopyID = 0;
+	G4int detectorCopyID = 0;
 
-    G4cout << "LanthanumBromide Detector Number = " << detectorNumber << G4endl;
+	G4cout<<"LanthanumBromide Detector Number = "<<detectorNumber<<G4endl;
 
-    fCopyNumber = detectorCopyID + detectorNumber;
+	fCopyNumber = detectorCopyID + detectorNumber;
 
-    G4double position = radialpos + fCanFrontLidThickness +( fCanLengthZ / 2.0 ) ;
-    fSetRadialPos = radialpos;
+	G4double position = radialpos + fCanFrontLidThickness +(fCanLengthZ / 2.0) ;
+	fSetRadialPos = radialpos;
 
-    G4double theta  = fDetectorAngles[detectorNumber][0];
-    G4double phi    = fDetectorAngles[detectorNumber][1];
-    //G4double alpha  = fDetectorAngles[detectorNumber][2]; // yaw
-    G4double beta   = fDetectorAngles[detectorNumber][3]; // pitch
-    G4double gamma  = fDetectorAngles[detectorNumber][4]; // roll
+	G4double theta  = fDetectorAngles[detectorNumber][0];
+	G4double phi    = fDetectorAngles[detectorNumber][1];
+	//G4double alpha  = fDetectorAngles[detectorNumber][2]; // yaw
+	G4double beta   = fDetectorAngles[detectorNumber][3]; // pitch
+	G4double gamma  = fDetectorAngles[detectorNumber][4]; // roll
 
-    G4double x = 0;
-    G4double y = 0;
-    G4double z = position;
+	G4double x = 0;
+	G4double y = 0;
+	G4double z = position;
 
-    G4RotationMatrix* rotate = new G4RotationMatrix;    // rotation matrix corresponding to direction vector
-    rotate->rotateY(M_PI);
-    rotate->rotateY(M_PI+beta);
-    rotate->rotateZ(gamma);
+	G4RotationMatrix* rotate = new G4RotationMatrix;    // rotation matrix corresponding to direction vector
+	rotate->rotateY(M_PI);
+	rotate->rotateY(M_PI+beta);
+	rotate->rotateZ(gamma);
 
-    G4ThreeVector move(TransX(x,y,z,theta,phi), TransY(x,y,z,theta,phi), TransZ(x,y,z,theta));
+	G4ThreeVector move(TransX(x,y,z,theta,phi), TransY(x,y,z,theta,phi), TransZ(x,y,z,theta));
 
-    fAssembly->MakeImprint(expHallLog, move, rotate, fCopyNumber);
+	fAssembly->MakeImprint(expHallLog, move, rotate, fCopyNumber);
 
-    return 1;
+	return 1;
 }
 
 G4int DetectionSystemLanthanumBromide::BuildCrystalVolume() {
-    G4Material* material = G4Material::GetMaterial(fCrystalMaterial);
-    if( !material ) {
-        G4cout << " ----> Material " << fCrystalMaterial << " not found, cannot build the detector shell! " << G4endl;
-        return 0;
-    }
+	G4Material* material = G4Material::GetMaterial(fCrystalMaterial);
+	if(!material) {
+		G4cout<<" ----> Material "<<fCrystalMaterial<<" not found, cannot build the detector shell! "<<G4endl;
+		return 0;
+	}
 
-    // Set visualization attributes
-    G4VisAttributes* visAtt = new G4VisAttributes(G4Colour(0.2,1.0,0.3));
-    visAtt->SetVisibility(true);
+	// Set visualization attributes
+	G4VisAttributes* visAtt = new G4VisAttributes(G4Colour(0.2,1.0,0.3));
+	visAtt->SetVisibility(true);
 
-    G4Tubs* crystalBlock = BuildCrystal();
+	G4Tubs* crystalBlock = BuildCrystal();
 
-    // Define rotation and movement objects
-    G4ThreeVector direction 	= G4ThreeVector(0,0,1);
-    G4double zPosition		= ( (fCanFrontLidThickness + fSealFrontLidThickness + fDiscFrontLidThickness + fPackingFrontLidThickness) - (fCanBackLidThickness) )/2.0;
-    G4ThreeVector move 		= zPosition * direction;
-    G4RotationMatrix* rotate = new G4RotationMatrix;
+	// Define rotation and movement objects
+	G4ThreeVector direction 	= G4ThreeVector(0,0,1);
+	G4double zPosition		= ((fCanFrontLidThickness + fSealFrontLidThickness + fDiscFrontLidThickness + fPackingFrontLidThickness) - (fCanBackLidThickness))/2.0;
+	G4ThreeVector move 		= zPosition * direction;
+	G4RotationMatrix* rotate = new G4RotationMatrix;
 
-    //logical volume
-    if( fCrystalBlockLog == NULL ) {
-        fCrystalBlockLog = new G4LogicalVolume(crystalBlock, material, "lanthanumBromideCrystalBlockLog", 0, 0, 0);
-        fCrystalBlockLog->SetVisAttributes(visAtt);
-    }
+	//logical volume
+	if(fCrystalBlockLog == nullptr) {
+		fCrystalBlockLog = new G4LogicalVolume(crystalBlock, material, "lanthanumBromideCrystalBlockLog", 0, 0, 0);
+		fCrystalBlockLog->SetVisAttributes(visAtt);
+	}
 
-    fAssembly->AddPlacedVolume(fCrystalBlockLog, move, rotate);
+	fAssembly->AddPlacedVolume(fCrystalBlockLog, move, rotate);
 
-    return 1;
+	return 1;
 }
 
 G4int DetectionSystemLanthanumBromide::BuildAluminumCanVolume() {
-    G4Material* material = G4Material::GetMaterial(fCanMaterial);
-    if( !material ) {
-        G4cout << " ----> Material " << fCanMaterial << " not found, cannot build the detector shell! " << G4endl;
-        return 0;
-    }
+	G4Material* material = G4Material::GetMaterial(fCanMaterial);
+	if(!material) {
+		G4cout<<" ----> Material "<<fCanMaterial<<" not found, cannot build the detector shell! "<<G4endl;
+		return 0;
+	}
 
-    // Set visualization attributes
-    G4VisAttributes* visAtt = new G4VisAttributes(G4Colour(0.55, 0.38, 1.0));
-    visAtt->SetVisibility(true);
+	// Set visualization attributes
+	G4VisAttributes* visAtt = new G4VisAttributes(G4Colour(0.55, 0.38, 1.0));
+	visAtt->SetVisibility(true);
 
-    G4ThreeVector direction =  G4ThreeVector(0,0,1);
-    G4double zPosition;
-    G4ThreeVector move;
-    G4RotationMatrix* rotate = new G4RotationMatrix;
+	G4ThreeVector direction =  G4ThreeVector(0,0,1);
+	G4double zPosition;
+	G4ThreeVector move;
+	G4RotationMatrix* rotate = new G4RotationMatrix;
 
-    /////////////////////////////////////////////////////////////////////
-    // Build and Place Aluminum Can
-    /////////////////////////////////////////////////////////////////////
-    G4Tubs* canCylinder = BuildAluminumCan();
+	/////////////////////////////////////////////////////////////////////
+	// Build and Place Aluminum Can
+	/////////////////////////////////////////////////////////////////////
+	G4Tubs* canCylinder = BuildAluminumCan();
 
-    //logical volume
-    if( fCanCylinderLog == NULL ) {
-        fCanCylinderLog = new G4LogicalVolume(canCylinder, material, "canCylinderLog", 0, 0, 0);
-        fCanCylinderLog->SetVisAttributes(visAtt);
-    }
+	//logical volume
+	if(fCanCylinderLog == nullptr) {
+		fCanCylinderLog = new G4LogicalVolume(canCylinder, material, "canCylinderLog", 0, 0, 0);
+		fCanCylinderLog->SetVisAttributes(visAtt);
+	}
 
-    // place front canLid
-    zPosition 	= 0;
-    move 		= zPosition * direction;
+	// place front canLid
+	zPosition 	= 0;
+	move 		= zPosition * direction;
 
-    //add physical cylinder
-    fAssembly->AddPlacedVolume(fCanCylinderLog, move, rotate);
+	//add physical cylinder
+	fAssembly->AddPlacedVolume(fCanCylinderLog, move, rotate);
 
-    /////////////////////////////////////////////////////////////////////
-    // Build and Place Aluminum Front Lid
-    /////////////////////////////////////////////////////////////////////
-    G4Tubs* canFrontLid = BuildAluminumCanFrontLid();
+	/////////////////////////////////////////////////////////////////////
+	// Build and Place Aluminum Front Lid
+	/////////////////////////////////////////////////////////////////////
+	G4Tubs* canFrontLid = BuildAluminumCanFrontLid();
 
-    // logical volume
-    if( fCanFrontLidLog == NULL ) {
-        fCanFrontLidLog = new G4LogicalVolume(canFrontLid, material, "canFrontLidLog", 0, 0, 0);
-        fCanFrontLidLog->SetVisAttributes(visAtt);
-    }
+	// logical volume
+	if(fCanFrontLidLog == nullptr) {
+		fCanFrontLidLog = new G4LogicalVolume(canFrontLid, material, "canFrontLidLog", 0, 0, 0);
+		fCanFrontLidLog->SetVisAttributes(visAtt);
+	}
 
-    // place front canLid
+	// place front canLid
 
-    zPosition 	= -(fDetectorLengthZ/2.0) + (fCanFrontLidThickness/2.0);
-    move 		= zPosition * direction;
+	zPosition 	= -(fDetectorLengthZ/2.0) + (fCanFrontLidThickness/2.0);
+	move 		= zPosition * direction;
 
-    //add physical front canLid
-    fAssembly->AddPlacedVolume(fCanFrontLidLog, move, rotate);
+	//add physical front canLid
+	fAssembly->AddPlacedVolume(fCanFrontLidLog, move, rotate);
 
-    /////////////////////////////////////////////////////////////////////
-    // Build and Place Aluminum Back Lid
-    /////////////////////////////////////////////////////////////////////
-    G4Tubs* canBackLid = BuildAluminumCanBackLid();
+	/////////////////////////////////////////////////////////////////////
+	// Build and Place Aluminum Back Lid
+	/////////////////////////////////////////////////////////////////////
+	G4Tubs* canBackLid = BuildAluminumCanBackLid();
 
-    // logical volume
-    if( fCanBackLidLog == NULL ) {
-        fCanBackLidLog = new G4LogicalVolume(canBackLid, material, "canBackLidLog", 0, 0, 0);
-        fCanBackLidLog->SetVisAttributes(visAtt);
-    }
+	// logical volume
+	if(fCanBackLidLog == nullptr) {
+		fCanBackLidLog = new G4LogicalVolume(canBackLid, material, "canBackLidLog", 0, 0, 0);
+		fCanBackLidLog->SetVisAttributes(visAtt);
+	}
 
-    // place back canLid
-    zPosition 	= (fDetectorLengthZ/2.0) - (fCanBackLidThickness/2.0);
-    move 		= zPosition * direction;
+	// place back canLid
+	zPosition 	= (fDetectorLengthZ/2.0) - (fCanBackLidThickness/2.0);
+	move 		= zPosition * direction;
 
-    // add physical back canLid
-    fAssembly->AddPlacedVolume(fCanBackLidLog, move, rotate);
+	// add physical back canLid
+	fAssembly->AddPlacedVolume(fCanBackLidLog, move, rotate);
 
-    return 1;
+	return 1;
 }
 
 G4int DetectionSystemLanthanumBromide::BuildPackingVolume() {
-    G4Material* material = G4Material::GetMaterial(fPackingMaterial);
-    if( !material ) {
-        G4cout << " ----> Material " << fPackingMaterial << " not found, cannot build the detector shell! " << G4endl;
-        return 0;
-    }
+	G4Material* material = G4Material::GetMaterial(fPackingMaterial);
+	if(!material) {
+		G4cout<<" ----> Material "<<fPackingMaterial<<" not found, cannot build the detector shell! "<<G4endl;
+		return 0;
+	}
 
-    // Set visualization attributes
-    G4VisAttributes* visAtt = new G4VisAttributes(G4Colour(1.0,0.0,0.0));
-    visAtt->SetVisibility(true);
+	// Set visualization attributes
+	G4VisAttributes* visAtt = new G4VisAttributes(G4Colour(1.0,0.0,0.0));
+	visAtt->SetVisibility(true);
 
-    G4ThreeVector direction =  G4ThreeVector(0,0,1);
-    G4double zPosition;
-    G4ThreeVector move;
-    G4RotationMatrix* rotate = new G4RotationMatrix;
+	G4ThreeVector direction =  G4ThreeVector(0,0,1);
+	G4double zPosition;
+	G4ThreeVector move;
+	G4RotationMatrix* rotate = new G4RotationMatrix;
 
-    /////////////////////////////////////////////////////////////////////
-    // Build and Place Packing
-    /////////////////////////////////////////////////////////////////////
-    G4Tubs* packingCylinder = BuildPacking();
+	/////////////////////////////////////////////////////////////////////
+	// Build and Place Packing
+	/////////////////////////////////////////////////////////////////////
+	G4Tubs* packingCylinder = BuildPacking();
 
-    //logical volume
-    if( fPackingCylinderLog == NULL ) {
-        fPackingCylinderLog = new G4LogicalVolume(packingCylinder, material, "packingCylinderLog", 0, 0, 0);
-        fPackingCylinderLog->SetVisAttributes(visAtt);
-    }
+	//logical volume
+	if(fPackingCylinderLog == nullptr) {
+		fPackingCylinderLog = new G4LogicalVolume(packingCylinder, material, "packingCylinderLog", 0, 0, 0);
+		fPackingCylinderLog->SetVisAttributes(visAtt);
+	}
 
-    // place cylinder
-    zPosition 	= ( (fCanFrontLidThickness + fSealFrontLidThickness + fDiscFrontLidThickness + fPackingFrontLidThickness) - (fCanBackLidThickness) )/2.0;
-    move          = zPosition * direction;
+	// place cylinder
+	zPosition 	= ((fCanFrontLidThickness + fSealFrontLidThickness + fDiscFrontLidThickness + fPackingFrontLidThickness) - (fCanBackLidThickness))/2.0;
+	move          = zPosition * direction;
 
-    //add physical cylinder
-    fAssembly->AddPlacedVolume(fPackingCylinderLog, move, rotate);
+	//add physical cylinder
+	fAssembly->AddPlacedVolume(fPackingCylinderLog, move, rotate);
 
-    /////////////////////////////////////////////////////////////////////
-    // Build and Place Front Lid
-    /////////////////////////////////////////////////////////////////////
-    G4Tubs* packingFrontLid = BuildPackingFrontLid();
+	/////////////////////////////////////////////////////////////////////
+	// Build and Place Front Lid
+	/////////////////////////////////////////////////////////////////////
+	G4Tubs* packingFrontLid = BuildPackingFrontLid();
 
-    // logical volume
-    if( fPackingFrontLidLog == NULL ) {
-        fPackingFrontLidLog = new G4LogicalVolume(packingFrontLid, material, "packingFrontLidLog", 0, 0, 0);
-        fPackingFrontLidLog->SetVisAttributes(visAtt);
-    }
+	// logical volume
+	if(fPackingFrontLidLog == nullptr) {
+		fPackingFrontLidLog = new G4LogicalVolume(packingFrontLid, material, "packingFrontLidLog", 0, 0, 0);
+		fPackingFrontLidLog->SetVisAttributes(visAtt);
+	}
 
-    // place front packingLid
-    zPosition 	= -(fDetectorLengthZ/2.0) + (fCanFrontLidThickness + fSealFrontLidThickness + fDiscFrontLidThickness + (fPackingFrontLidThickness/2.0));
-    move 		= zPosition * direction;
+	// place front packingLid
+	zPosition 	= -(fDetectorLengthZ/2.0) + (fCanFrontLidThickness + fSealFrontLidThickness + fDiscFrontLidThickness + (fPackingFrontLidThickness/2.0));
+	move 		= zPosition * direction;
 
-    //add physical front packingLid
-    fAssembly->AddPlacedVolume(fPackingFrontLidLog, move, rotate);
+	//add physical front packingLid
+	fAssembly->AddPlacedVolume(fPackingFrontLidLog, move, rotate);
 
-    return 1;
+	return 1;
 }
 
 G4int DetectionSystemLanthanumBromide::BuildDiscVolume() {
-    G4Material* material = G4Material::GetMaterial(fDiscMaterial);
-    if( !material ) {
-        G4cout << " ----> Material " << fDiscMaterial << " not found, cannot build the detector shell! " << G4endl;
-        return 0;
-    }
+	G4Material* material = G4Material::GetMaterial(fDiscMaterial);
+	if(!material) {
+		G4cout<<" ----> Material "<<fDiscMaterial<<" not found, cannot build the detector shell! "<<G4endl;
+		return 0;
+	}
 
-    // Set visualization attributes
-    G4VisAttributes* visAtt = new G4VisAttributes(G4Colour(0.0,0.0,1.0));
-    visAtt->SetVisibility(true);
+	// Set visualization attributes
+	G4VisAttributes* visAtt = new G4VisAttributes(G4Colour(0.0,0.0,1.0));
+	visAtt->SetVisibility(true);
 
-    G4ThreeVector direction =  G4ThreeVector(0,0,1);
-    G4double zPosition;
-    G4ThreeVector move;
-    G4RotationMatrix* rotate = new G4RotationMatrix;
+	G4ThreeVector direction =  G4ThreeVector(0,0,1);
+	G4double zPosition;
+	G4ThreeVector move;
+	G4RotationMatrix* rotate = new G4RotationMatrix;
 
-    /////////////////////////////////////////////////////////////////////
-    // Build and Place Front Lid
-    /////////////////////////////////////////////////////////////////////
-    G4Tubs* discFrontLid = BuildDiscFrontLid();
+	/////////////////////////////////////////////////////////////////////
+	// Build and Place Front Lid
+	/////////////////////////////////////////////////////////////////////
+	G4Tubs* discFrontLid = BuildDiscFrontLid();
 
-    // logical volume
-    if( fDiscFrontLidLog == NULL ) {
-        fDiscFrontLidLog = new G4LogicalVolume(discFrontLid, material, "discFrontLidLog", 0, 0, 0);
-        fDiscFrontLidLog->SetVisAttributes(visAtt);
-    }
+	// logical volume
+	if(fDiscFrontLidLog == nullptr) {
+		fDiscFrontLidLog = new G4LogicalVolume(discFrontLid, material, "discFrontLidLog", 0, 0, 0);
+		fDiscFrontLidLog->SetVisAttributes(visAtt);
+	}
 
-    // place front discLid
-    zPosition 	= -(fDetectorLengthZ/2.0) + (fCanFrontLidThickness + fSealFrontLidThickness + (fDiscFrontLidThickness/2.0));
-    move 		= zPosition * direction;
+	// place front discLid
+	zPosition 	= -(fDetectorLengthZ/2.0) + (fCanFrontLidThickness + fSealFrontLidThickness + (fDiscFrontLidThickness/2.0));
+	move 		= zPosition * direction;
 
-    //add physical front discLid
-    fAssembly->AddPlacedVolume(fDiscFrontLidLog, move, rotate);
+	//add physical front discLid
+	fAssembly->AddPlacedVolume(fDiscFrontLidLog, move, rotate);
 
-    return 1;
+	return 1;
 }
 
 G4int DetectionSystemLanthanumBromide::BuildSealVolume() {
-    G4Material* material = G4Material::GetMaterial(fSealMaterial);
-    if( !material ) {
-        G4cout << " ----> Material " << fSealMaterial << " not found, cannot build the detector shell! " << G4endl;
-        return 0;
-    }
+	G4Material* material = G4Material::GetMaterial(fSealMaterial);
+	if(!material) {
+		G4cout<<" ----> Material "<<fSealMaterial<<" not found, cannot build the detector shell! "<<G4endl;
+		return 0;
+	}
 
-    // Set visualization attributes
-    G4VisAttributes* visAtt = new G4VisAttributes(G4Colour(0.0,0.0,0.0));
-    visAtt->SetVisibility(true);
+	// Set visualization attributes
+	G4VisAttributes* visAtt = new G4VisAttributes(G4Colour(0.0,0.0,0.0));
+	visAtt->SetVisibility(true);
 
-    G4ThreeVector direction =  G4ThreeVector(0,0,1);
-    G4double zPosition;
-    G4ThreeVector move;
-    G4RotationMatrix* rotate = new G4RotationMatrix;
+	G4ThreeVector direction =  G4ThreeVector(0,0,1);
+	G4double zPosition;
+	G4ThreeVector move;
+	G4RotationMatrix* rotate = new G4RotationMatrix;
 
-    /////////////////////////////////////////////////////////////////////
-    // Build and Place Front Lid
-    /////////////////////////////////////////////////////////////////////
-    G4Tubs* sealFrontLid = BuildSealFrontLid();
+	/////////////////////////////////////////////////////////////////////
+	// Build and Place Front Lid
+	/////////////////////////////////////////////////////////////////////
+	G4Tubs* sealFrontLid = BuildSealFrontLid();
 
-    // logical volume
-    if( fSealFrontLidLog == NULL ) {
-        fSealFrontLidLog = new G4LogicalVolume(sealFrontLid, material, "sealFrontLidLog", 0, 0, 0);
-        fSealFrontLidLog->SetVisAttributes(visAtt);
-    }
+	// logical volume
+	if(fSealFrontLidLog == nullptr) {
+		fSealFrontLidLog = new G4LogicalVolume(sealFrontLid, material, "sealFrontLidLog", 0, 0, 0);
+		fSealFrontLidLog->SetVisAttributes(visAtt);
+	}
 
-    // place front sealLid
-    zPosition 	= -(fDetectorLengthZ/2.0) + (fCanFrontLidThickness + (fSealFrontLidThickness/2.0));
-    move 		= zPosition * direction;
+	// place front sealLid
+	zPosition 	= -(fDetectorLengthZ/2.0) + (fCanFrontLidThickness + (fSealFrontLidThickness/2.0));
+	move 		= zPosition * direction;
 
-    //add physical front sealLid
-    fAssembly->AddPlacedVolume(fSealFrontLidLog, move, rotate);
+	//add physical front sealLid
+	fAssembly->AddPlacedVolume(fSealFrontLidLog, move, rotate);
 
-    return 1;
+	return 1;
 }
 
 ///////////////////////////////////////////////////////////////////////
 // Methods used to build shapes
 ///////////////////////////////////////////////////////////////////////
 G4Tubs* DetectionSystemLanthanumBromide::BuildCrystal() {
-    G4double startPhi = 0.0;
-    G4double endPhi = fDetailViewEndAngle;
+	G4double startPhi = 0.0;
+	G4double endPhi = fDetailViewEndAngle;
 
-    G4double innerRadius = fCrystalInnerRadius;
-    G4double outerRadius = fCrystalOuterRadius;
-    G4double halfLengthZ = (fCrystalLengthZ)/2.0;
+	G4double innerRadius = fCrystalInnerRadius;
+	G4double outerRadius = fCrystalOuterRadius;
+	G4double halfLengthZ = (fCrystalLengthZ)/2.0;
 
-    G4Tubs* crystalBlock = new G4Tubs("crystalBlock", innerRadius, outerRadius, halfLengthZ, startPhi, endPhi);
+	G4Tubs* crystalBlock = new G4Tubs("crystalBlock", innerRadius, outerRadius, halfLengthZ, startPhi, endPhi);
 
-    return crystalBlock;
+	return crystalBlock;
 }//end ::BuildCrystal
 
 
 G4Tubs* DetectionSystemLanthanumBromide::BuildAluminumCan() {
-    G4double startPhi = 0.0;
-    G4double endPhi = fDetailViewEndAngle;
+	G4double startPhi = 0.0;
+	G4double endPhi = fDetailViewEndAngle;
 
-    G4double innerRadius 	= fCanInnerRadius;
-    G4double outerRadius 	= fCanOuterRadius;
-    G4double halfLengthZ 	= fCanLengthZ/2.0;
+	G4double innerRadius 	= fCanInnerRadius;
+	G4double outerRadius 	= fCanOuterRadius;
+	G4double halfLengthZ 	= fCanLengthZ/2.0;
 
-    G4Tubs* canCylinder = new G4Tubs("canCylinder", innerRadius, outerRadius, halfLengthZ, startPhi, endPhi);
+	G4Tubs* canCylinder = new G4Tubs("canCylinder", innerRadius, outerRadius, halfLengthZ, startPhi, endPhi);
 
-    return canCylinder;
+	return canCylinder;
 }//end ::BuildAluminumCan
 
 G4Tubs* DetectionSystemLanthanumBromide::BuildAluminumCanFrontLid() {
-    G4double startPhi = 0.0;
-    G4double endPhi = fDetailViewEndAngle;
+	G4double startPhi = 0.0;
+	G4double endPhi = fDetailViewEndAngle;
 
-    G4double innerRadius = fCanLidInnerRadius;
-    G4double outerRadius = fCanLidOuterRadius;
-    G4double halfLengthZ = fCanFrontLidThickness/2.0;
+	G4double innerRadius = fCanLidInnerRadius;
+	G4double outerRadius = fCanLidOuterRadius;
+	G4double halfLengthZ = fCanFrontLidThickness/2.0;
 
-    G4Tubs* canLid = new G4Tubs("canLid", innerRadius, outerRadius, halfLengthZ, startPhi, endPhi);
+	G4Tubs* canLid = new G4Tubs("canLid", innerRadius, outerRadius, halfLengthZ, startPhi, endPhi);
 
-    return canLid;
+	return canLid;
 }//end ::BuildAluminumFrontLid
 
 G4Tubs* DetectionSystemLanthanumBromide::BuildAluminumCanBackLid() {
-    G4double startPhi = 0.0;
-    G4double endPhi = fDetailViewEndAngle;
+	G4double startPhi = 0.0;
+	G4double endPhi = fDetailViewEndAngle;
 
-    G4double innerRadius = fCanLidInnerRadius;
-    G4double outerRadius = fCanLidOuterRadius;
-    G4double halfLengthZ = fCanBackLidThickness/2.0;
+	G4double innerRadius = fCanLidInnerRadius;
+	G4double outerRadius = fCanLidOuterRadius;
+	G4double halfLengthZ = fCanBackLidThickness/2.0;
 
-    G4Tubs* canLid = new G4Tubs("canLid", innerRadius, outerRadius, halfLengthZ, startPhi, endPhi);
+	G4Tubs* canLid = new G4Tubs("canLid", innerRadius, outerRadius, halfLengthZ, startPhi, endPhi);
 
-    return canLid;
+	return canLid;
 }//end ::BuildAluminumBackLid
 
 G4Tubs* DetectionSystemLanthanumBromide::BuildPacking() {
-    G4double startPhi = 0.0;
-    G4double endPhi = fDetailViewEndAngle;
+	G4double startPhi = 0.0;
+	G4double endPhi = fDetailViewEndAngle;
 
-    G4double innerRadius 	= fPackingInnerRadius;
-    G4double outerRadius 	= fPackingOuterRadius;
-    G4double halfLengthZ 	= fPackingLengthZ/2.0;
+	G4double innerRadius 	= fPackingInnerRadius;
+	G4double outerRadius 	= fPackingOuterRadius;
+	G4double halfLengthZ 	= fPackingLengthZ/2.0;
 
-    G4Tubs* packingCylinder = new G4Tubs("packingCylinder", innerRadius, outerRadius, halfLengthZ, startPhi, endPhi);
+	G4Tubs* packingCylinder = new G4Tubs("packingCylinder", innerRadius, outerRadius, halfLengthZ, startPhi, endPhi);
 
-    return packingCylinder;
+	return packingCylinder;
 }//end ::BuildPacking
 
 G4Tubs* DetectionSystemLanthanumBromide::BuildPackingFrontLid() {
-    G4double startPhi = 0.0;
-    G4double endPhi = fDetailViewEndAngle;
+	G4double startPhi = 0.0;
+	G4double endPhi = fDetailViewEndAngle;
 
-    G4double innerRadius = fPackingLidInnerRadius;
-    G4double outerRadius = fPackingLidOuterRadius;
-    G4double halfLengthZ = fPackingFrontLidThickness/2.0;
+	G4double innerRadius = fPackingLidInnerRadius;
+	G4double outerRadius = fPackingLidOuterRadius;
+	G4double halfLengthZ = fPackingFrontLidThickness/2.0;
 
-    G4Tubs* packingLid = new G4Tubs("packingLid", innerRadius, outerRadius, halfLengthZ, startPhi, endPhi);
+	G4Tubs* packingLid = new G4Tubs("packingLid", innerRadius, outerRadius, halfLengthZ, startPhi, endPhi);
 
-    return packingLid;
+	return packingLid;
 }//end ::BuildPackingFrontLid
 
 G4Tubs* DetectionSystemLanthanumBromide::BuildDiscFrontLid() {
-    G4double startPhi = 0.0;
-    G4double endPhi = fDetailViewEndAngle;
+	G4double startPhi = 0.0;
+	G4double endPhi = fDetailViewEndAngle;
 
-    G4double innerRadius = fDiscLidInnerRadius;
-    G4double outerRadius = fDiscLidOuterRadius;
-    G4double halfLengthZ = fDiscFrontLidThickness/2.0;
+	G4double innerRadius = fDiscLidInnerRadius;
+	G4double outerRadius = fDiscLidOuterRadius;
+	G4double halfLengthZ = fDiscFrontLidThickness/2.0;
 
-    G4Tubs* discLid = new G4Tubs("discLid", innerRadius, outerRadius, halfLengthZ, startPhi, endPhi);
+	G4Tubs* discLid = new G4Tubs("discLid", innerRadius, outerRadius, halfLengthZ, startPhi, endPhi);
 
-    return discLid;
+	return discLid;
 }//end ::BuildDiscFrontLid
 
 G4Tubs* DetectionSystemLanthanumBromide::BuildSealFrontLid() {
-    G4double startPhi = 0.0;
-    G4double endPhi = fDetailViewEndAngle;
+	G4double startPhi = 0.0;
+	G4double endPhi = fDetailViewEndAngle;
 
-    G4double innerRadius = fSealLidInnerRadius;
-    G4double outerRadius = fSealLidOuterRadius;
-    G4double halfLengthZ = fSealFrontLidThickness/2.0;
+	G4double innerRadius = fSealLidInnerRadius;
+	G4double outerRadius = fSealLidOuterRadius;
+	G4double halfLengthZ = fSealFrontLidThickness/2.0;
 
-    G4Tubs* sealLid = new G4Tubs("sealLid", innerRadius, outerRadius, halfLengthZ, startPhi, endPhi);
+	G4Tubs* sealLid = new G4Tubs("sealLid", innerRadius, outerRadius, halfLengthZ, startPhi, endPhi);
 
-    return sealLid;
+	return sealLid;
 }//end ::BuildSealFrontLid
 
 //Calculate a direction vector from spherical theta & phi components
 G4ThreeVector DetectionSystemLanthanumBromide::GetDirectionXYZ(G4double theta, G4double phi) {
-    G4double x,y,z;
-    x = sin(theta) * cos(phi);
-    y = sin(theta) * sin(phi);
-    z = cos(theta);
+	G4double x,y,z;
+	x = sin(theta) * cos(phi);
+	y = sin(theta) * sin(phi);
+	z = cos(theta);
 
-    G4ThreeVector direction = G4ThreeVector(x,y,z);
+	G4ThreeVector direction = G4ThreeVector(x,y,z);
 
-    return direction;
+	return direction;
 }//end ::GetDirection

--- a/src/DetectionSystemPaces.cc
+++ b/src/DetectionSystemPaces.cc
@@ -26,736 +26,736 @@
 
 
 DetectionSystemPaces::DetectionSystemPaces() :
-    // Logical Volumes
-    fAluminumHemisphereLog(0),
-    fAluminumAnnulusTopLog(0),
-    fAluminumAnnulusBotLog(0),
-    fCanisterLog(0),
-    fSiliconBlockLog(0),
-    fSiliconDeadLayerLog(0),
+	// Logical Volumes
+	fAluminumHemisphereLog(0),
+	fAluminumAnnulusTopLog(0),
+	fAluminumAnnulusBotLog(0),
+	fCanisterLog(0),
+	fSiliconBlockLog(0),
+	fSiliconDeadLayerLog(0),
 
-    fTeflonAnnulusTopLog(0),
-    fTeflonAnnulusBotLog(0),
-    fDelrinHemisphereLog(0)
+	fTeflonAnnulusTopLog(0),
+	fTeflonAnnulusBotLog(0),
+	fDelrinHemisphereLog(0)
 {
-    /*Measurement status*/
-    //~   estimate
-    //OK  confirmed measurement
+	/*Measurement status*/
+	//~   estimate
+	//OK  confirmed measurement
 
-    // Cut clearance
-    fCutClearance = 0.01*mm;
+	// Cut clearance
+	fCutClearance = 0.01*mm;
 
-    // Aluminum hemisphere
-    fAluminumHemisphereInnerRadius =         (82.50 / 2)*mm; //OK
-    fAluminumHemisphereOuterRadius =         (88.86 / 2)*mm; //OK
-    fAluminumHemisphereBeamHoleRadius =     (34.50 / 2)*mm; //~
-    fAluminumHemisphereBeamHoleRimHeight = (3.0)*mm; //~
+	// Aluminum hemisphere
+	fAluminumHemisphereInnerRadius =         (82.50 / 2)*mm; //OK
+	fAluminumHemisphereOuterRadius =         (88.86 / 2)*mm; //OK
+	fAluminumHemisphereBeamHoleRadius =     (34.50 / 2)*mm; //~
+	fAluminumHemisphereBeamHoleRimHeight = (3.0)*mm; //~
 
-    // Annulus that sits in front of silicon crystal
-    fAluminumAnnulusTopInnerRadius =        (15.86 / 2)*mm; //OK
-    fAluminumAnnulusTopOuterRadius =        (31.71 / 2)*mm; //OK
-    fAluminumAnnulusTopThickness =           (2.37)*mm; //OK
+	// Annulus that sits in front of silicon crystal
+	fAluminumAnnulusTopInnerRadius =        (15.86 / 2)*mm; //OK
+	fAluminumAnnulusTopOuterRadius =        (31.71 / 2)*mm; //OK
+	fAluminumAnnulusTopThickness =           (2.37)*mm; //OK
 
-    // Annulus that sits in back of silicon crystal
-    fAluminumAnnulusBotInnerRadius =        (15.86 / 2)*mm; //~
-    fAluminumAnnulusBotOuterRadius =        (31.71 / 2)*mm; //~
-    fAluminumAnnulusBotThickness =           (4.50)*mm; //~
+	// Annulus that sits in back of silicon crystal
+	fAluminumAnnulusBotInnerRadius =        (15.86 / 2)*mm; //~
+	fAluminumAnnulusBotOuterRadius =        (31.71 / 2)*mm; //~
+	fAluminumAnnulusBotThickness =           (4.50)*mm; //~
 
-    // Canister holding crystal
-    fCanisterInnerRadius =                    (18.50 / 2)*mm; //~
-    fCanisterOuterRadius =                    (21.00 / 2)*mm; //~
-    fCanisterThickness =                       (5.00)*mm; //~
+	// Canister holding crystal
+	fCanisterInnerRadius =                    (18.50 / 2)*mm; //~
+	fCanisterOuterRadius =                    (21.00 / 2)*mm; //~
+	fCanisterThickness =                       (5.00)*mm; //~
 
-    // Silicon crystal detector
-    fSiliconBlockRadius =                     (15.86 / 2)*mm; //~
-    fSiliconBlockThickness =                  (4.90)*mm; //~
-    fSiliconDeadLayerThickness =             (0.004)*mm; //~ Nominal Structure Stopping Power of Window - Ortec, 2u Si equivalent
+	// Silicon crystal detector
+	fSiliconBlockRadius =                     (15.86 / 2)*mm; //~
+	fSiliconBlockThickness =                  (4.90)*mm; //~
+	fSiliconDeadLayerThickness =             (0.004)*mm; //~ Nominal Structure Stopping Power of Window - Ortec, 2u Si equivalent
 
-    // Front and back Au (0.2 and 2um) contacts.
-    //frontContactThickness =  		   (0.0002)*mm; //~ Common front contact thickness for Si(Li) Zhimin
-    //backContactThickness =  		   (0.002)*mm; //~ Common back contact thickness for Si(Li) Zhimin
+	// Front and back Au (0.2 and 2um) contacts.
+	//frontContactThickness =  		   (0.0002)*mm; //~ Common front contact thickness for Si(Li) Zhimin
+	//backContactThickness =  		   (0.002)*mm; //~ Common back contact thickness for Si(Li) Zhimin
 
-    // Screws
-    fScrewRadius =                             (1.00 / 2)*mm; //~
-    fScrewPlacementRadius =                   (22.50 / 2)*mm; //~
+	// Screws
+	fScrewRadius =                             (1.00 / 2)*mm; //~
+	fScrewPlacementRadius =                   (22.50 / 2)*mm; //~
 
-    // Teflon bases
-    fTeflonAnnulusTopInnerRadius =          (21.00 / 2)*mm; //~
-    fTeflonAnnulusTopOuterRadius =          (32.00 / 2)*mm; //~
-    fTeflonAnnulusTopThickness =             (2.22)*mm; //OK
-    fTeflonAnnulusBotInnerRadius =          (31.65 / 2)*mm; //~
-    fTeflonAnnulusBotOuterRadius =          (34.50 / 2)*mm; //~
-    fTeflonAnnulusBotThickness =             (4.00)*mm; //~
+	// Teflon bases
+	fTeflonAnnulusTopInnerRadius =          (21.00 / 2)*mm; //~
+	fTeflonAnnulusTopOuterRadius =          (32.00 / 2)*mm; //~
+	fTeflonAnnulusTopThickness =             (2.22)*mm; //OK
+	fTeflonAnnulusBotInnerRadius =          (31.65 / 2)*mm; //~
+	fTeflonAnnulusBotOuterRadius =          (34.50 / 2)*mm; //~
+	fTeflonAnnulusBotThickness =             (4.00)*mm; //~
 
-    // delrin hemisphere
-    fDelrinHemisphereInnerRadius =           (84.4)*mm; //OK
-    fDelrinHemisphereOuterRadius =           (89.4)*mm; //OK
-    fDelrinHemisphereBeamHoleRadius =       (20.00 / 2)*mm; //OK
+	// delrin hemisphere
+	fDelrinHemisphereInnerRadius =           (84.4)*mm; //OK
+	fDelrinHemisphereOuterRadius =           (89.4)*mm; //OK
+	fDelrinHemisphereBeamHoleRadius =       (20.00 / 2)*mm; //OK
 
-    // placement distances
-    fAluminumHemisphereDist =     (0.)*mm;
-    fDelrinHemisphereDist =       (0.)*mm;
-    fAluminumAnnulusTopDist =    (fAluminumAnnulusTopThickness / 2);
-    fCanisterDist =              (fAluminumAnnulusTopThickness) + (fCanisterThickness / 2) ;
-    fSiliconBlockDist =          (fAluminumAnnulusTopThickness) + (fSiliconBlockThickness / 2); // Takes dead layer into account
-    fSiliconDeadLayerFrontDist = (fAluminumAnnulusTopThickness) + (fSiliconDeadLayerThickness / 2) ;
-    fSiliconDeadLayerBackDist  = (fAluminumAnnulusTopThickness) + (fSiliconBlockThickness) - (fSiliconDeadLayerThickness / 2);
-    fTeflonAnnulusTopDist =      (fAluminumAnnulusTopThickness) + (fSiliconBlockThickness) - (fTeflonAnnulusTopThickness / 2);
-    fTeflonAnnulusBotDist =      (fTeflonAnnulusTopDist) + (fTeflonAnnulusTopThickness / 2) + (fTeflonAnnulusBotThickness / 2);
-    fAluminumAnnulusBotDist =    (fTeflonAnnulusTopDist) + (fTeflonAnnulusTopThickness / 2) + (fAluminumAnnulusBotThickness / 2);
+	// placement distances
+	fAluminumHemisphereDist =     (0.)*mm;
+	fDelrinHemisphereDist =       (0.)*mm;
+	fAluminumAnnulusTopDist =    (fAluminumAnnulusTopThickness / 2);
+	fCanisterDist =              (fAluminumAnnulusTopThickness) + (fCanisterThickness / 2) ;
+	fSiliconBlockDist =          (fAluminumAnnulusTopThickness) + (fSiliconBlockThickness / 2); // Takes dead layer into account
+	fSiliconDeadLayerFrontDist = (fAluminumAnnulusTopThickness) + (fSiliconDeadLayerThickness / 2) ;
+	fSiliconDeadLayerBackDist  = (fAluminumAnnulusTopThickness) + (fSiliconBlockThickness) - (fSiliconDeadLayerThickness / 2);
+	fTeflonAnnulusTopDist =      (fAluminumAnnulusTopThickness) + (fSiliconBlockThickness) - (fTeflonAnnulusTopThickness / 2);
+	fTeflonAnnulusBotDist =      (fTeflonAnnulusTopDist) + (fTeflonAnnulusTopThickness / 2) + (fTeflonAnnulusBotThickness / 2);
+	fAluminumAnnulusBotDist =    (fTeflonAnnulusTopDist) + (fTeflonAnnulusTopThickness / 2) + (fAluminumAnnulusBotThickness / 2);
 
-    // Placement and Orientation scalars
-    /*pacesPlacementDistance[5] = {  30.00*mm ,  30.00*mm ,  30.00*mm ,  30.00*mm ,  30.00*mm };
-  pacesPlacementPhi[5] =    {   0.0*deg ,  72.0*deg , 144.0*deg , 216.0*deg , 288.0*deg };
-  pacesPlacementTheta[5] =      {  60.0*deg ,  60.0*deg ,  60.0*deg ,  60.0*deg ,  60.0*deg };
-  pacesOrientationPhi[5] =  {   0.0*deg ,   0.0*deg ,   0.0*deg ,   0.0*deg ,   0.0*deg };
-  pacesOrientationTheta[5] =    {   0.0*deg ,   0.0*deg ,   0.0*deg ,   0.0*deg ,   0.0*deg };*/
+	// Placement and Orientation scalars
+	/*pacesPlacementDistance[5] = {  30.00*mm ,  30.00*mm ,  30.00*mm ,  30.00*mm ,  30.00*mm };
+	  pacesPlacementPhi[5] =    {   0.0*deg ,  72.0*deg , 144.0*deg , 216.0*deg , 288.0*deg };
+	  pacesPlacementTheta[5] =      {  60.0*deg ,  60.0*deg ,  60.0*deg ,  60.0*deg ,  60.0*deg };
+	  pacesOrientationPhi[5] =  {   0.0*deg ,   0.0*deg ,   0.0*deg ,   0.0*deg ,   0.0*deg };
+	  pacesOrientationTheta[5] =    {   0.0*deg ,   0.0*deg ,   0.0*deg ,   0.0*deg ,   0.0*deg };*/
 
-    // distance is deduced from Alumium hemisphere assembly
-    fPacesPlacementDistance[0] = 29.50*mm; // 29.5*mm Deduced from Alumium hemisphere
-    fPacesPlacementDistance[1] = 29.50*mm;
-    fPacesPlacementDistance[2] = 29.50*mm;
-    fPacesPlacementDistance[3] = 29.50*mm;
-    fPacesPlacementDistance[4] = 29.50*mm;
+	// distance is deduced from Alumium hemisphere assembly
+	fPacesPlacementDistance[0] = 29.50*mm; // 29.5*mm Deduced from Alumium hemisphere
+	fPacesPlacementDistance[1] = 29.50*mm;
+	fPacesPlacementDistance[2] = 29.50*mm;
+	fPacesPlacementDistance[3] = 29.50*mm;
+	fPacesPlacementDistance[4] = 29.50*mm;
 
-    // phi angle from measurement
-    fPacesPlacementPhi[0] =   0.0000*deg; //OK
-    fPacesPlacementPhi[1] =  -68.7575*deg; //OK
-    fPacesPlacementPhi[2] = -138.4082*deg; //OK
-    fPacesPlacementPhi[3] = -212.1280*deg; //OK
-    fPacesPlacementPhi[4] = -287.4275*deg; //OK
+	// phi angle from measurement
+	fPacesPlacementPhi[0] =   0.0000*deg; //OK
+	fPacesPlacementPhi[1] =  -68.7575*deg; //OK
+	fPacesPlacementPhi[2] = -138.4082*deg; //OK
+	fPacesPlacementPhi[3] = -212.1280*deg; //OK
+	fPacesPlacementPhi[4] = -287.4275*deg; //OK
 
-    // theta angle is guess estimate
-    fPacesPlacementTheta[0] = (180 - 60.0)*deg; //~
-    fPacesPlacementTheta[1] = (180 - 60.0)*deg; //~
-    fPacesPlacementTheta[2] = (180 - 60.0)*deg; //~
-    fPacesPlacementTheta[3] = (180 - 60.0)*deg; //~
-    fPacesPlacementTheta[4] = (180 - 60.0)*deg; //~
+	// theta angle is guess estimate
+	fPacesPlacementTheta[0] = (180 - 60.0)*deg; //~
+	fPacesPlacementTheta[1] = (180 - 60.0)*deg; //~
+	fPacesPlacementTheta[2] = (180 - 60.0)*deg; //~
+	fPacesPlacementTheta[3] = (180 - 60.0)*deg; //~
+	fPacesPlacementTheta[4] = (180 - 60.0)*deg; //~
 
-    fPacesOrientationPhi[0] = 0.0*deg;
-    fPacesOrientationPhi[1] = 0.0*deg;
-    fPacesOrientationPhi[2] = 0.0*deg;
-    fPacesOrientationPhi[3] = 0.0*deg;
-    fPacesOrientationPhi[4] = 0.0*deg;
+	fPacesOrientationPhi[0] = 0.0*deg;
+	fPacesOrientationPhi[1] = 0.0*deg;
+	fPacesOrientationPhi[2] = 0.0*deg;
+	fPacesOrientationPhi[3] = 0.0*deg;
+	fPacesOrientationPhi[4] = 0.0*deg;
 
-    fPacesOrientationTheta[0] = 0.1780*deg; //OK
-    fPacesOrientationTheta[1] = 0.8275*deg; //OK
-    fPacesOrientationTheta[2] =-0.2579*deg; //OK
-    fPacesOrientationTheta[3] = 0.2992*deg; //OK
-    fPacesOrientationTheta[4] = 0.1934*deg; //OK
+	fPacesOrientationTheta[0] = 0.1780*deg; //OK
+	fPacesOrientationTheta[1] = 0.8275*deg; //OK
+	fPacesOrientationTheta[2] =-0.2579*deg; //OK
+	fPacesOrientationTheta[3] = 0.2992*deg; //OK
+	fPacesOrientationTheta[4] = 0.1934*deg; //OK
 
-    // assembly volume sizes
-    fDetectorAssemblyRadius =    (34.50 / 2)*mm; //?
-    fDetectorAssemblyThickness = (15.0)*mm; //?
+	// assembly volume sizes
+	fDetectorAssemblyRadius =    (34.50 / 2)*mm; //?
+	fDetectorAssemblyThickness = (15.0)*mm; //?
 }
 
 DetectionSystemPaces::~DetectionSystemPaces() {
-    // logical volumes
-    delete fAluminumHemisphereLog;
-    delete fAluminumAnnulusTopLog;
-    delete fAluminumAnnulusBotLog;
-    delete fCanisterLog;
-    delete fSiliconBlockLog;
-    delete fSiliconDeadLayerLog;
-    delete fTeflonAnnulusTopLog;
-    delete fTeflonAnnulusBotLog;
-    delete fDelrinHemisphereLog;
+	// logical volumes
+	delete fAluminumHemisphereLog;
+	delete fAluminumAnnulusTopLog;
+	delete fAluminumAnnulusBotLog;
+	delete fCanisterLog;
+	delete fSiliconBlockLog;
+	delete fSiliconDeadLayerLog;
+	delete fTeflonAnnulusTopLog;
+	delete fTeflonAnnulusBotLog;
+	delete fDelrinHemisphereLog;
 
 }
 
 G4int DetectionSystemPaces::Build() {
 
-    // Build assembly volumes
-    fAssembly = new G4AssemblyVolume();
-    fAssemblyDetector = new G4AssemblyVolume();
-    fAssemblySilicon = new G4AssemblyVolume();
+	// Build assembly volumes
+	fAssembly = new G4AssemblyVolume();
+	fAssemblyDetector = new G4AssemblyVolume();
+	fAssemblySilicon = new G4AssemblyVolume();
 
-    // Add silicon assembly
-    AddSiliconBlock();
-    AddSiliconDeadLayer();
+	// Add silicon assembly
+	AddSiliconBlock();
+	AddSiliconDeadLayer();
 
-    // Add detector assembly
-    AddCanister();
-    AddAluminumAnnulusTop();
-    AddTeflonAnnulusTop();
-    AddTeflonAnnulusBot();
-    AddAluminumAnnulusBot();
-    AddScrews();
+	// Add detector assembly
+	AddCanister();
+	AddAluminumAnnulusTop();
+	AddTeflonAnnulusTop();
+	AddTeflonAnnulusBot();
+	AddAluminumAnnulusBot();
+	AddScrews();
 
-    // Add total assembly
-    AddAluminumHemisphere();
+	// Add total assembly
+	AddAluminumHemisphere();
 
-    // Assemble the ensemble
-    CombineAssemblySilicon();
-    CombineAssemblyDetector();
-    CombineAssembly();
-    
-    return 1;
+	// Assemble the ensemble
+	CombineAssemblySilicon();
+	CombineAssemblyDetector();
+	CombineAssembly();
+
+	return 1;
 }//end ::Build
 
 G4int DetectionSystemPaces::PlaceDetector(G4LogicalVolume* expHallLog, G4int ndet) {
-    //place detectors
-    G4int dI;
-    G4double* ptrPd = fPacesPlacementDistance;
-    G4double* ptrPt = fPacesPlacementPhi;//t=phi, but p=theta???????
-    G4double* ptrPp = fPacesPlacementTheta;
-    G4double* ptrOt = fPacesOrientationPhi;
-    G4double* ptrOp = fPacesOrientationTheta;
-    /*G4double* ptrPp = fPacesPlacementPhi;//changed code, rotated by 90 degrees
-    G4double* ptrPt = fPacesPlacementTheta;
-    G4double* ptrOp = fPacesOrientationPhi;
-    G4double* ptrOt = fPacesOrientationTheta;*/
-    if (ndet > 5 || ndet < 0) ndet = 5;
-    G4double dDist, dPhi, dTheta, oriPhi, oriTheta;
-    G4RotationMatrix* Ra;
-    G4ThreeVector Ta, yprimeaxis;
-    for (G4int i=0; i<ndet; i++) {
-        dI = i;
-        dDist = ptrPd[dI];
-        dPhi = ptrPt[dI];
-        dTheta = ptrPp[dI];
-        Ra = new G4RotationMatrix;
-        Ta.setX( dDist * cos(dPhi) * sin(dTheta) );
-        Ta.setY( dDist * sin(dPhi) * sin(dTheta) );
-        Ta.setZ( dDist *      1.0     * cos(dTheta) );
+	//place detectors
+	G4int dI;
+	G4double* ptrPd = fPacesPlacementDistance;
+	G4double* ptrPt = fPacesPlacementPhi;//t=phi, but p=theta???????
+	G4double* ptrPp = fPacesPlacementTheta;
+	G4double* ptrOt = fPacesOrientationPhi;
+	G4double* ptrOp = fPacesOrientationTheta;
+	/*G4double* ptrPp = fPacesPlacementPhi;//changed code, rotated by 90 degrees
+	  G4double* ptrPt = fPacesPlacementTheta;
+	  G4double* ptrOp = fPacesOrientationPhi;
+	  G4double* ptrOt = fPacesOrientationTheta;*/
+	if(ndet > 5 || ndet < 0) ndet = 5;
+	G4double dDist, dPhi, dTheta, oriPhi, oriTheta;
+	G4RotationMatrix* Ra;
+	G4ThreeVector Ta, yprimeaxis;
+	for(G4int i=0; i<ndet; i++) {
+		dI = i;
+		dDist = ptrPd[dI];
+		dPhi = ptrPt[dI];
+		dTheta = ptrPp[dI];
+		Ra = new G4RotationMatrix;
+		Ta.setX(dDist * cos(dPhi) * sin(dTheta));
+		Ta.setY(dDist * sin(dPhi) * sin(dTheta));
+		Ta.setZ(dDist *      1.0     * cos(dTheta));
 
-        oriPhi = dPhi + ptrOt[dI] + M_PI/2; //plus 90 deg
-        oriTheta = dTheta + ptrOp[dI];
-        yprimeaxis = G4ThreeVector(cos(oriPhi), sin(oriPhi), 0);
-        Ra->set(yprimeaxis, oriTheta);
+		oriPhi = dPhi + ptrOt[dI] + M_PI/2; //plus 90 deg
+		oriTheta = dTheta + ptrOp[dI];
+		yprimeaxis = G4ThreeVector(cos(oriPhi), sin(oriPhi), 0);
+		Ra->set(yprimeaxis, oriTheta);
 
-        //G4cout << "----------- dI = " << dI << G4endl;
-        fAssemblySilicon->MakeImprint(expHallLog, Ta, Ra, dI+1);
-        fAssemblyDetector->MakeImprint(expHallLog, Ta, Ra, dI*20);
-    }
+		//G4cout<<"----------- dI = "<<dI<<G4endl;
+		fAssemblySilicon->MakeImprint(expHallLog, Ta, Ra, dI+1);
+		fAssemblyDetector->MakeImprint(expHallLog, Ta, Ra, dI*20);
+	}
 
-    //place hemisphere
-    G4RotationMatrix* R0 = new G4RotationMatrix; G4ThreeVector T0;
-    fAssembly->MakeImprint(expHallLog, T0, R0, 5*40);
+	//place hemisphere
+	G4RotationMatrix* R0 = new G4RotationMatrix; G4ThreeVector T0;
+	fAssembly->MakeImprint(expHallLog, T0, R0, 5*40);
 
-    return 1;
+	return 1;
 }//end ::PlaceDetector
 
 G4int DetectionSystemPaces::CombineAssemblySilicon() {
-    G4RotationMatrix* Ra = new G4RotationMatrix; G4ThreeVector Ta;
-    Ta.setZ(fSiliconBlockDist);
-    fAssemblySilicon->AddPlacedVolume(fSiliconBlockLog, Ta, Ra);
+	G4RotationMatrix* Ra = new G4RotationMatrix; G4ThreeVector Ta;
+	Ta.setZ(fSiliconBlockDist);
+	fAssemblySilicon->AddPlacedVolume(fSiliconBlockLog, Ta, Ra);
 
-    return 1;
+	return 1;
 }//end ::CombineAssemblySilicon
 
 
 G4int DetectionSystemPaces::CombineAssemblyDetector() {
-    G4RotationMatrix* Ra = new G4RotationMatrix; G4ThreeVector Ta;
-    Ta.setZ(fSiliconDeadLayerFrontDist);
-    fAssemblyDetector->AddPlacedVolume(fSiliconDeadLayerLog, Ta, Ra);
-    Ta.setZ(fSiliconDeadLayerBackDist);
-    fAssemblyDetector->AddPlacedVolume(fSiliconDeadLayerLog, Ta, Ra);
-    Ta.setZ(fCanisterDist);
-    fAssemblyDetector->AddPlacedVolume(fCanisterLog, Ta, Ra);
-    Ta.setZ(fAluminumAnnulusTopDist);
-    fAssemblyDetector->AddPlacedVolume(fAluminumAnnulusTopLog, Ta, Ra);
-    Ta.setZ(fAluminumAnnulusBotDist);
-    fAssemblyDetector->AddPlacedVolume(fAluminumAnnulusBotLog, Ta, Ra);
-    Ta.setZ(fTeflonAnnulusTopDist);
-    fAssemblyDetector->AddPlacedVolume(fTeflonAnnulusTopLog, Ta, Ra);
-    Ta.setZ(fTeflonAnnulusBotDist);
-    fAssemblyDetector->AddPlacedVolume(fTeflonAnnulusBotLog, Ta, Ra);
+	G4RotationMatrix* Ra = new G4RotationMatrix; G4ThreeVector Ta;
+	Ta.setZ(fSiliconDeadLayerFrontDist);
+	fAssemblyDetector->AddPlacedVolume(fSiliconDeadLayerLog, Ta, Ra);
+	Ta.setZ(fSiliconDeadLayerBackDist);
+	fAssemblyDetector->AddPlacedVolume(fSiliconDeadLayerLog, Ta, Ra);
+	Ta.setZ(fCanisterDist);
+	fAssemblyDetector->AddPlacedVolume(fCanisterLog, Ta, Ra);
+	Ta.setZ(fAluminumAnnulusTopDist);
+	fAssemblyDetector->AddPlacedVolume(fAluminumAnnulusTopLog, Ta, Ra);
+	Ta.setZ(fAluminumAnnulusBotDist);
+	fAssemblyDetector->AddPlacedVolume(fAluminumAnnulusBotLog, Ta, Ra);
+	Ta.setZ(fTeflonAnnulusTopDist);
+	fAssemblyDetector->AddPlacedVolume(fTeflonAnnulusTopLog, Ta, Ra);
+	Ta.setZ(fTeflonAnnulusBotDist);
+	fAssemblyDetector->AddPlacedVolume(fTeflonAnnulusBotLog, Ta, Ra);
 
-    return 1;
+	return 1;
 }//end ::CombineAssemblyDetector
 
 G4int DetectionSystemPaces::CombineAssembly() {
-    //place aluminum hemisphere
-    G4RotationMatrix* Ra = new G4RotationMatrix; G4ThreeVector Ta;
-    Ta.setZ(fAluminumHemisphereDist);
-    fAssembly->AddPlacedVolume(fAluminumHemisphereLog, Ta, Ra);
+	//place aluminum hemisphere
+	G4RotationMatrix* Ra = new G4RotationMatrix; G4ThreeVector Ta;
+	Ta.setZ(fAluminumHemisphereDist);
+	fAssembly->AddPlacedVolume(fAluminumHemisphereLog, Ta, Ra);
 
-    return 1;
+	return 1;
 }//end ::CombineAssembly
 
 //Add silicon detector
 G4int DetectionSystemPaces::AddSiliconBlock() {
-    //material
-    G4Material* material = G4Material::GetMaterial("Silicon");
-    if( !material ) {
-        G4cout << " ----> Material " << "Silicon" << " not found, cannot build the detector shell! " << G4endl;
-        return 0;
-    }
+	//material
+	G4Material* material = G4Material::GetMaterial("Silicon");
+	if(!material) {
+		G4cout<<" ----> Material "<<"Silicon"<<" not found, cannot build the detector shell! "<<G4endl;
+		return 0;
+	}
 
-    //vis attributes
-    G4VisAttributes* siliconBlockVisAtt = new G4VisAttributes(G4Colour(1.0,0.0,0.0));
-    siliconBlockVisAtt->SetVisibility(true);
+	//vis attributes
+	G4VisAttributes* siliconBlockVisAtt = new G4VisAttributes(G4Colour(1.0,0.0,0.0));
+	siliconBlockVisAtt->SetVisibility(true);
 
-    //silicon block (without dead layer, smaller than actual)
-    G4double deadLayerCut = fSiliconDeadLayerThickness + fCutClearance;
-    G4double innerRadius = 0.*mm;
-    G4double outerRadius = fSiliconBlockRadius;
-    G4double halfLengthZ = fSiliconBlockThickness/2.0 - deadLayerCut;
+	//silicon block (without dead layer, smaller than actual)
+	G4double deadLayerCut = fSiliconDeadLayerThickness + fCutClearance;
+	G4double innerRadius = 0.*mm;
+	G4double outerRadius = fSiliconBlockRadius;
+	G4double halfLengthZ = fSiliconBlockThickness/2.0 - deadLayerCut;
 
-    //primitive volume
-    G4Tubs* siliconBlock = new G4Tubs("siliconBlock", innerRadius, outerRadius, halfLengthZ, 0*M_PI, 2*M_PI);
+	//primitive volume
+	G4Tubs* siliconBlock = new G4Tubs("siliconBlock", innerRadius, outerRadius, halfLengthZ, 0*M_PI, 2*M_PI);
 
-    //logical volume
-    if( fSiliconBlockLog == NULL ) {
-        fSiliconBlockLog = new G4LogicalVolume(siliconBlock, material, "pacesSiliconBlockLog", 0, 0, 0); // Renamed from "siliconBlockLog" to "pacesSiliconBlockLog"
-        fSiliconBlockLog->SetVisAttributes(siliconBlockVisAtt);
-    }
+	//logical volume
+	if(fSiliconBlockLog == nullptr) {
+		fSiliconBlockLog = new G4LogicalVolume(siliconBlock, material, "pacesSiliconBlockLog", 0, 0, 0); // Renamed from "siliconBlockLog" to "pacesSiliconBlockLog"
+		fSiliconBlockLog->SetVisAttributes(siliconBlockVisAtt);
+	}
 
-    return 1;
+	return 1;
 }//end ::end AddSiliconBlock
 
 //Add detector dead layer
 G4int DetectionSystemPaces::AddSiliconDeadLayer() {
-    //material
-    G4Material* material = G4Material::GetMaterial("Silicon"); // "Nominal Structure Stopping Power of Window-Ortec, 2u Si"
-    if( !material ) {
-        G4cout << " ----> Material " << "Silicon" << " not found, cannot build the detector shell! " << G4endl;
-        return 0;
-    }
+	//material
+	G4Material* material = G4Material::GetMaterial("Silicon"); // "Nominal Structure Stopping Power of Window-Ortec, 2u Si"
+	if(!material) {
+		G4cout<<" ----> Material "<<"Silicon"<<" not found, cannot build the detector shell! "<<G4endl;
+		return 0;
+	}
 
-    //vis attributes
-    G4VisAttributes* siliconDeadLayerVisAtt = new G4VisAttributes(G4Colour(0.0,1.0,0.0));
-    siliconDeadLayerVisAtt->SetVisibility(true);
+	//vis attributes
+	G4VisAttributes* siliconDeadLayerVisAtt = new G4VisAttributes(G4Colour(0.0,1.0,0.0));
+	siliconDeadLayerVisAtt->SetVisibility(true);
 
-    //dead layer
-    G4double innerRadius = 0.*mm;
-    G4double outerRadius = fSiliconBlockRadius;
-    G4double halfLengthZ = fSiliconDeadLayerThickness / 2.0;
+	//dead layer
+	G4double innerRadius = 0.*mm;
+	G4double outerRadius = fSiliconBlockRadius;
+	G4double halfLengthZ = fSiliconDeadLayerThickness / 2.0;
 
-    //primitive volume
-    G4Tubs* siliconDeadLayer = new G4Tubs("siliconDeadLayer", innerRadius, outerRadius, halfLengthZ, 0*M_PI, 2*M_PI);
+	//primitive volume
+	G4Tubs* siliconDeadLayer = new G4Tubs("siliconDeadLayer", innerRadius, outerRadius, halfLengthZ, 0*M_PI, 2*M_PI);
 
-    //logical volume
-    if( fSiliconDeadLayerLog == NULL ) {
-        fSiliconDeadLayerLog = new G4LogicalVolume(siliconDeadLayer, material, "siliconDeadLayerLog", 0, 0, 0);
-        fSiliconDeadLayerLog->SetVisAttributes(siliconDeadLayerVisAtt);
-    }
+	//logical volume
+	if(fSiliconDeadLayerLog == nullptr) {
+		fSiliconDeadLayerLog = new G4LogicalVolume(siliconDeadLayer, material, "siliconDeadLayerLog", 0, 0, 0);
+		fSiliconDeadLayerLog->SetVisAttributes(siliconDeadLayerVisAtt);
+	}
 
-    return 1;
+	return 1;
 }//end ::end AddSiliconDeadLayer
 
 //Add detector canister
 G4int DetectionSystemPaces::AddCanister() {
-    //material
-    G4Material* material = G4Material::GetMaterial("Silicon");  // would be Silicon, Zhimin
-    if( !material ) {
-        G4cout << " ----> Material " << "Silicon" << " not found, cannot build the detector shell! " << G4endl;
-        return 0;
-    }
+	//material
+	G4Material* material = G4Material::GetMaterial("Silicon");  // would be Silicon, Zhimin
+	if(!material) {
+		G4cout<<" ----> Material "<<"Silicon"<<" not found, cannot build the detector shell! "<<G4endl;
+		return 0;
+	}
 
-    //vis attributes
-    G4VisAttributes* canisterVisAtt = new G4VisAttributes(G4Colour(0.0,1.0,1.0));
-    canisterVisAtt->SetVisibility(true);
+	//vis attributes
+	G4VisAttributes* canisterVisAtt = new G4VisAttributes(G4Colour(0.0,1.0,1.0));
+	canisterVisAtt->SetVisibility(true);
 
-    //main annulus
-    G4double innerRadius = fCanisterInnerRadius + fCutClearance;
-    G4double outerRadius = fCanisterOuterRadius;
-    G4double halfLengthZ = fCanisterThickness/2.0;
+	//main annulus
+	G4double innerRadius = fCanisterInnerRadius + fCutClearance;
+	G4double outerRadius = fCanisterOuterRadius;
+	G4double halfLengthZ = fCanisterThickness/2.0;
 
-    //primitive volume
-    G4Tubs* canister = new G4Tubs("canister", innerRadius, outerRadius, halfLengthZ, 0*M_PI, 2*M_PI);
+	//primitive volume
+	G4Tubs* canister = new G4Tubs("canister", innerRadius, outerRadius, halfLengthZ, 0*M_PI, 2*M_PI);
 
-    //logical volume
-    if( fCanisterLog == NULL ) {
-        fCanisterLog = new G4LogicalVolume(canister, material, "canisterLog", 0, 0, 0);
-        fCanisterLog->SetVisAttributes(canisterVisAtt);
-    }
+	//logical volume
+	if(fCanisterLog == nullptr) {
+		fCanisterLog = new G4LogicalVolume(canister, material, "canisterLog", 0, 0, 0);
+		fCanisterLog->SetVisAttributes(canisterVisAtt);
+	}
 
-    return 1;
+	return 1;
 }//end ::end AddCanister
 
 //Add annulus that is on top of silicon detector
 G4int DetectionSystemPaces::AddAluminumAnnulusTop() {
-    //material
-    G4Material* material = G4Material::GetMaterial("Aluminum");
-    if( !material ) {
-        G4cout << " ----> Material " << "Aluminum" << " not found, cannot build the detector shell! " << G4endl;
-        return 0;
-    }
+	//material
+	G4Material* material = G4Material::GetMaterial("Aluminum");
+	if(!material) {
+		G4cout<<" ----> Material "<<"Aluminum"<<" not found, cannot build the detector shell! "<<G4endl;
+		return 0;
+	}
 
-    //vis attributes
-    G4VisAttributes* aluminumAnnulusTopVisAtt = new G4VisAttributes(G4Colour(0.5,0.5,0.0));
-    aluminumAnnulusTopVisAtt->SetVisibility(true);
+	//vis attributes
+	G4VisAttributes* aluminumAnnulusTopVisAtt = new G4VisAttributes(G4Colour(0.5,0.5,0.0));
+	aluminumAnnulusTopVisAtt->SetVisibility(true);
 
-    //main annulus
-    G4double innerRadius = fAluminumAnnulusTopInnerRadius;
-    G4double outerRadius = fAluminumAnnulusTopOuterRadius;
-    G4double halfLengthZ = fAluminumAnnulusTopThickness/2.0;
-    //screw cuts
-    G4double cutInnerRadius = 0.*mm;
-    G4double cutOuterRadius = fScrewRadius;
-    G4double cutHalfLengthZ = 20.*mm;
+	//main annulus
+	G4double innerRadius = fAluminumAnnulusTopInnerRadius;
+	G4double outerRadius = fAluminumAnnulusTopOuterRadius;
+	G4double halfLengthZ = fAluminumAnnulusTopThickness/2.0;
+	//screw cuts
+	G4double cutInnerRadius = 0.*mm;
+	G4double cutOuterRadius = fScrewRadius;
+	G4double cutHalfLengthZ = 20.*mm;
 
-    //primitive volume
-    G4Tubs* alAnToWithoutCuts = new G4Tubs("alAnToWithoutCuts", innerRadius, outerRadius, halfLengthZ, 0*M_PI, 2*M_PI);
-    G4Tubs* cutScrewHole = new G4Tubs("cutScrewHole", cutInnerRadius, cutOuterRadius, cutHalfLengthZ, 0*M_PI, 2*M_PI);
+	//primitive volume
+	G4Tubs* alAnToWithoutCuts = new G4Tubs("alAnToWithoutCuts", innerRadius, outerRadius, halfLengthZ, 0*M_PI, 2*M_PI);
+	G4Tubs* cutScrewHole = new G4Tubs("cutScrewHole", cutInnerRadius, cutOuterRadius, cutHalfLengthZ, 0*M_PI, 2*M_PI);
 
-    //cut out screw holes
-    G4double cI;
-    G4double cR = fScrewPlacementRadius;
-    G4double cDt = 45.*deg;
-    G4ThreeVector moveCut;
-    cI = 0; moveCut.setX( cR*cos(cI*cDt) ); moveCut.setY( cR*sin(cI*cDt) );
-    G4SubtractionSolid* alAnTo0 = new G4SubtractionSolid("alAnTo0", alAnToWithoutCuts, cutScrewHole, 0, moveCut);
-    cI = 1; moveCut.setX( cR*cos(cI*cDt) ); moveCut.setY( cR*sin(cI*cDt) );
-    G4SubtractionSolid* alAnTo1 = new G4SubtractionSolid("alAnTo1", alAnTo0, cutScrewHole, 0, moveCut);
-    cI = 2; moveCut.setX( cR*cos(cI*cDt) ); moveCut.setY( cR*sin(cI*cDt) );
-    G4SubtractionSolid* alAnTo2 = new G4SubtractionSolid("alAnTo2", alAnTo1, cutScrewHole, 0, moveCut);
-    cI = 3; moveCut.setX( cR*cos(cI*cDt) ); moveCut.setY( cR*sin(cI*cDt) );
-    G4SubtractionSolid* alAnTo3 = new G4SubtractionSolid("alAnTo3", alAnTo2, cutScrewHole, 0, moveCut);
-    cI = 4; moveCut.setX( cR*cos(cI*cDt) ); moveCut.setY( cR*sin(cI*cDt) );
-    G4SubtractionSolid* alAnTo4 = new G4SubtractionSolid("alAnTo4", alAnTo3, cutScrewHole, 0, moveCut);
-    cI = 5; moveCut.setX( cR*cos(cI*cDt) ); moveCut.setY( cR*sin(cI*cDt) );
-    G4SubtractionSolid* alAnTo5 = new G4SubtractionSolid("alAnTo5", alAnTo4, cutScrewHole, 0, moveCut);
-    cI = 6; moveCut.setX( cR*cos(cI*cDt) ); moveCut.setY( cR*sin(cI*cDt) );
-    G4SubtractionSolid* alAnTo6 = new G4SubtractionSolid("alAnTo6", alAnTo5, cutScrewHole, 0, moveCut);
-    //final cut
-    cI = 7; moveCut.setX( cR*cos(cI*cDt) ); moveCut.setY( cR*sin(cI*cDt) );
-    G4SubtractionSolid* aluminumAnnulusTop = new G4SubtractionSolid("aluminumAnnulusTop", alAnTo6, cutScrewHole, 0, moveCut);
+	//cut out screw holes
+	G4double cI;
+	G4double cR = fScrewPlacementRadius;
+	G4double cDt = 45.*deg;
+	G4ThreeVector moveCut;
+	cI = 0; moveCut.setX(cR*cos(cI*cDt)); moveCut.setY(cR*sin(cI*cDt));
+	G4SubtractionSolid* alAnTo0 = new G4SubtractionSolid("alAnTo0", alAnToWithoutCuts, cutScrewHole, 0, moveCut);
+	cI = 1; moveCut.setX(cR*cos(cI*cDt)); moveCut.setY(cR*sin(cI*cDt));
+	G4SubtractionSolid* alAnTo1 = new G4SubtractionSolid("alAnTo1", alAnTo0, cutScrewHole, 0, moveCut);
+	cI = 2; moveCut.setX(cR*cos(cI*cDt)); moveCut.setY(cR*sin(cI*cDt));
+	G4SubtractionSolid* alAnTo2 = new G4SubtractionSolid("alAnTo2", alAnTo1, cutScrewHole, 0, moveCut);
+	cI = 3; moveCut.setX(cR*cos(cI*cDt)); moveCut.setY(cR*sin(cI*cDt));
+	G4SubtractionSolid* alAnTo3 = new G4SubtractionSolid("alAnTo3", alAnTo2, cutScrewHole, 0, moveCut);
+	cI = 4; moveCut.setX(cR*cos(cI*cDt)); moveCut.setY(cR*sin(cI*cDt));
+	G4SubtractionSolid* alAnTo4 = new G4SubtractionSolid("alAnTo4", alAnTo3, cutScrewHole, 0, moveCut);
+	cI = 5; moveCut.setX(cR*cos(cI*cDt)); moveCut.setY(cR*sin(cI*cDt));
+	G4SubtractionSolid* alAnTo5 = new G4SubtractionSolid("alAnTo5", alAnTo4, cutScrewHole, 0, moveCut);
+	cI = 6; moveCut.setX(cR*cos(cI*cDt)); moveCut.setY(cR*sin(cI*cDt));
+	G4SubtractionSolid* alAnTo6 = new G4SubtractionSolid("alAnTo6", alAnTo5, cutScrewHole, 0, moveCut);
+	//final cut
+	cI = 7; moveCut.setX(cR*cos(cI*cDt)); moveCut.setY(cR*sin(cI*cDt));
+	G4SubtractionSolid* aluminumAnnulusTop = new G4SubtractionSolid("aluminumAnnulusTop", alAnTo6, cutScrewHole, 0, moveCut);
 
-    //logical volume
-    if( fAluminumAnnulusTopLog == NULL ) {
-        fAluminumAnnulusTopLog = new G4LogicalVolume(aluminumAnnulusTop, material, "aluminumAnnulusTopLog", 0, 0, 0);
-        fAluminumAnnulusTopLog->SetVisAttributes(aluminumAnnulusTopVisAtt);
-    }
+	//logical volume
+	if(fAluminumAnnulusTopLog == nullptr) {
+		fAluminumAnnulusTopLog = new G4LogicalVolume(aluminumAnnulusTop, material, "aluminumAnnulusTopLog", 0, 0, 0);
+		fAluminumAnnulusTopLog->SetVisAttributes(aluminumAnnulusTopVisAtt);
+	}
 
-    return 1;
+	return 1;
 }//end ::end AddAluminumAnnulusTop
 
 //Add annulus that is on bottom of silicon detector
 G4int DetectionSystemPaces::AddAluminumAnnulusBot() {
-    //material
-    G4Material* material = G4Material::GetMaterial("Aluminum");
-    if( !material ) {
-        G4cout << " ----> Material " << "Aluminum" << " not found, cannot build the detector shell! " << G4endl;
-        return 0;
-    }
+	//material
+	G4Material* material = G4Material::GetMaterial("Aluminum");
+	if(!material) {
+		G4cout<<" ----> Material "<<"Aluminum"<<" not found, cannot build the detector shell! "<<G4endl;
+		return 0;
+	}
 
-    //vis attributes
-    G4VisAttributes* aluminumAnnulusBotVisAtt = new G4VisAttributes(G4Colour(0.5,0.5,0.0));
-    aluminumAnnulusBotVisAtt->SetVisibility(true);
+	//vis attributes
+	G4VisAttributes* aluminumAnnulusBotVisAtt = new G4VisAttributes(G4Colour(0.5,0.5,0.0));
+	aluminumAnnulusBotVisAtt->SetVisibility(true);
 
-    //main annulus
-    G4double innerRadius = fAluminumAnnulusBotInnerRadius;
-    G4double outerRadius = fAluminumAnnulusBotOuterRadius;
-    G4double halfLengthZ = fAluminumAnnulusBotThickness/2.0;
-    //screw cuts
-    G4double cutInnerRadius = 0.*mm;
-    G4double cutOuterRadius = fScrewRadius;
-    G4double cutHalfLengthZ = 20.*mm;
+	//main annulus
+	G4double innerRadius = fAluminumAnnulusBotInnerRadius;
+	G4double outerRadius = fAluminumAnnulusBotOuterRadius;
+	G4double halfLengthZ = fAluminumAnnulusBotThickness/2.0;
+	//screw cuts
+	G4double cutInnerRadius = 0.*mm;
+	G4double cutOuterRadius = fScrewRadius;
+	G4double cutHalfLengthZ = 20.*mm;
 
-    //primitive volume
-    G4Tubs* alAnBoWithoutCuts = new G4Tubs("alAnBoWithoutCuts", innerRadius, outerRadius, halfLengthZ, 0*M_PI, 2*M_PI);
-    G4Tubs* cutScrewHole = new G4Tubs("cutScrewHole", cutInnerRadius, cutOuterRadius, cutHalfLengthZ, 0*M_PI, 2*M_PI);
+	//primitive volume
+	G4Tubs* alAnBoWithoutCuts = new G4Tubs("alAnBoWithoutCuts", innerRadius, outerRadius, halfLengthZ, 0*M_PI, 2*M_PI);
+	G4Tubs* cutScrewHole = new G4Tubs("cutScrewHole", cutInnerRadius, cutOuterRadius, cutHalfLengthZ, 0*M_PI, 2*M_PI);
 
-    //cut out screw holes
-    G4double cI;
-    G4double cR = fScrewPlacementRadius;
-    G4double cDt = 45.*deg;
-    G4ThreeVector moveCut;
-    cI = 0; moveCut.setX( cR*cos(cI*cDt) ); moveCut.setY( cR*sin(cI*cDt) );
-    G4SubtractionSolid* alAnBo0 = new G4SubtractionSolid("alAnBo0", alAnBoWithoutCuts, cutScrewHole, 0, moveCut);
-    cI = 1; moveCut.setX( cR*cos(cI*cDt) ); moveCut.setY( cR*sin(cI*cDt) );
-    G4SubtractionSolid* alAnBo1 = new G4SubtractionSolid("alAnBo1", alAnBo0, cutScrewHole, 0, moveCut);
-    cI = 2; moveCut.setX( cR*cos(cI*cDt) ); moveCut.setY( cR*sin(cI*cDt) );
-    G4SubtractionSolid* alAnBo2 = new G4SubtractionSolid("alAnBo2", alAnBo1, cutScrewHole, 0, moveCut);
-    cI = 3; moveCut.setX( cR*cos(cI*cDt) ); moveCut.setY( cR*sin(cI*cDt) );
-    G4SubtractionSolid* alAnBo3 = new G4SubtractionSolid("alAnBo3", alAnBo2, cutScrewHole, 0, moveCut);
-    cI = 4; moveCut.setX( cR*cos(cI*cDt) ); moveCut.setY( cR*sin(cI*cDt) );
-    G4SubtractionSolid* alAnBo4 = new G4SubtractionSolid("alAnBo4", alAnBo3, cutScrewHole, 0, moveCut);
-    cI = 5; moveCut.setX( cR*cos(cI*cDt) ); moveCut.setY( cR*sin(cI*cDt) );
-    G4SubtractionSolid* alAnBo5 = new G4SubtractionSolid("alAnBo5", alAnBo4, cutScrewHole, 0, moveCut);
-    cI = 6; moveCut.setX( cR*cos(cI*cDt) ); moveCut.setY( cR*sin(cI*cDt) );
-    G4SubtractionSolid* alAnBo6 = new G4SubtractionSolid("alAnBo6", alAnBo5, cutScrewHole, 0, moveCut);
-    //final cut
-    cI = 7; moveCut.setX( cR*cos(cI*cDt) ); moveCut.setY( cR*sin(cI*cDt) );
-    G4SubtractionSolid* aluminumAnnulusBot = new G4SubtractionSolid("aluminumAnnulusBot", alAnBo6, cutScrewHole, 0, moveCut);
+	//cut out screw holes
+	G4double cI;
+	G4double cR = fScrewPlacementRadius;
+	G4double cDt = 45.*deg;
+	G4ThreeVector moveCut;
+	cI = 0; moveCut.setX(cR*cos(cI*cDt)); moveCut.setY(cR*sin(cI*cDt));
+	G4SubtractionSolid* alAnBo0 = new G4SubtractionSolid("alAnBo0", alAnBoWithoutCuts, cutScrewHole, 0, moveCut);
+	cI = 1; moveCut.setX(cR*cos(cI*cDt)); moveCut.setY(cR*sin(cI*cDt));
+	G4SubtractionSolid* alAnBo1 = new G4SubtractionSolid("alAnBo1", alAnBo0, cutScrewHole, 0, moveCut);
+	cI = 2; moveCut.setX(cR*cos(cI*cDt)); moveCut.setY(cR*sin(cI*cDt));
+	G4SubtractionSolid* alAnBo2 = new G4SubtractionSolid("alAnBo2", alAnBo1, cutScrewHole, 0, moveCut);
+	cI = 3; moveCut.setX(cR*cos(cI*cDt)); moveCut.setY(cR*sin(cI*cDt));
+	G4SubtractionSolid* alAnBo3 = new G4SubtractionSolid("alAnBo3", alAnBo2, cutScrewHole, 0, moveCut);
+	cI = 4; moveCut.setX(cR*cos(cI*cDt)); moveCut.setY(cR*sin(cI*cDt));
+	G4SubtractionSolid* alAnBo4 = new G4SubtractionSolid("alAnBo4", alAnBo3, cutScrewHole, 0, moveCut);
+	cI = 5; moveCut.setX(cR*cos(cI*cDt)); moveCut.setY(cR*sin(cI*cDt));
+	G4SubtractionSolid* alAnBo5 = new G4SubtractionSolid("alAnBo5", alAnBo4, cutScrewHole, 0, moveCut);
+	cI = 6; moveCut.setX(cR*cos(cI*cDt)); moveCut.setY(cR*sin(cI*cDt));
+	G4SubtractionSolid* alAnBo6 = new G4SubtractionSolid("alAnBo6", alAnBo5, cutScrewHole, 0, moveCut);
+	//final cut
+	cI = 7; moveCut.setX(cR*cos(cI*cDt)); moveCut.setY(cR*sin(cI*cDt));
+	G4SubtractionSolid* aluminumAnnulusBot = new G4SubtractionSolid("aluminumAnnulusBot", alAnBo6, cutScrewHole, 0, moveCut);
 
-    //logical volume
-    if( fAluminumAnnulusBotLog == NULL ) {
-        fAluminumAnnulusBotLog = new G4LogicalVolume(aluminumAnnulusBot, material, "aluminumAnnulusBotLog", 0, 0, 0);
-        fAluminumAnnulusBotLog->SetVisAttributes(aluminumAnnulusBotVisAtt);
-    }
+	//logical volume
+	if(fAluminumAnnulusBotLog == nullptr) {
+		fAluminumAnnulusBotLog = new G4LogicalVolume(aluminumAnnulusBot, material, "aluminumAnnulusBotLog", 0, 0, 0);
+		fAluminumAnnulusBotLog->SetVisAttributes(aluminumAnnulusBotVisAtt);
+	}
 
-    return 1;
+	return 1;
 }//end ::end AddAluminumAnnulusBot
 
 //Add annulus that is on side of silicon detector
 G4int DetectionSystemPaces::AddTeflonAnnulusTop() {
-    //material
-    G4Material* material = G4Material::GetMaterial("Teflon");
-    if( !material ) {
-        G4cout << " ----> Material " << "Teflon" << " not found, cannot build the detector shell! " << G4endl;
-        return 0;
-    }
+	//material
+	G4Material* material = G4Material::GetMaterial("Teflon");
+	if(!material) {
+		G4cout<<" ----> Material "<<"Teflon"<<" not found, cannot build the detector shell! "<<G4endl;
+		return 0;
+	}
 
-    //vis attributes
-    G4VisAttributes* teflonAnnulusTopVisAtt = new G4VisAttributes(G4Colour(0.0,0.0,1.0));
-    teflonAnnulusTopVisAtt->SetVisibility(true);
+	//vis attributes
+	G4VisAttributes* teflonAnnulusTopVisAtt = new G4VisAttributes(G4Colour(0.0,0.0,1.0));
+	teflonAnnulusTopVisAtt->SetVisibility(true);
 
-    //main annulus
-    G4double innerRadius = fTeflonAnnulusTopInnerRadius;
-    G4double outerRadius = fTeflonAnnulusTopOuterRadius;
-    G4double halfLengthZ = fTeflonAnnulusTopThickness/2.0;
-    //screw cuts
-    G4double cutInnerRadius = 0.*mm;
-    G4double cutOuterRadius = fScrewRadius;
-    G4double cutHalfLengthZ = 20.*mm;
+	//main annulus
+	G4double innerRadius = fTeflonAnnulusTopInnerRadius;
+	G4double outerRadius = fTeflonAnnulusTopOuterRadius;
+	G4double halfLengthZ = fTeflonAnnulusTopThickness/2.0;
+	//screw cuts
+	G4double cutInnerRadius = 0.*mm;
+	G4double cutOuterRadius = fScrewRadius;
+	G4double cutHalfLengthZ = 20.*mm;
 
-    //primitive volume
-    G4Tubs* teAnToWithoutCuts = new G4Tubs("teAnToWithoutCuts", innerRadius, outerRadius, halfLengthZ, 0*M_PI, 2*M_PI);
-    G4Tubs* cutScrewHole = new G4Tubs("cutScrewHole", cutInnerRadius, cutOuterRadius, cutHalfLengthZ, 0*M_PI, 2*M_PI);
+	//primitive volume
+	G4Tubs* teAnToWithoutCuts = new G4Tubs("teAnToWithoutCuts", innerRadius, outerRadius, halfLengthZ, 0*M_PI, 2*M_PI);
+	G4Tubs* cutScrewHole = new G4Tubs("cutScrewHole", cutInnerRadius, cutOuterRadius, cutHalfLengthZ, 0*M_PI, 2*M_PI);
 
-    //cut out screw holes
-    G4double cI;
-    G4double cR = fScrewPlacementRadius;
-    G4double cDt = 45.*deg;
-    G4ThreeVector moveCut;
-    cI = 0; moveCut.setX( cR*cos(cI*cDt) ); moveCut.setY( cR*sin(cI*cDt) );
-    G4SubtractionSolid* teAnTo0 = new G4SubtractionSolid("teAnTo0", teAnToWithoutCuts, cutScrewHole, 0, moveCut);
-    cI = 1; moveCut.setX( cR*cos(cI*cDt) ); moveCut.setY( cR*sin(cI*cDt) );
-    G4SubtractionSolid* teAnTo1 = new G4SubtractionSolid("teAnTo1", teAnTo0, cutScrewHole, 0, moveCut);
-    cI = 2; moveCut.setX( cR*cos(cI*cDt) ); moveCut.setY( cR*sin(cI*cDt) );
-    G4SubtractionSolid* teAnTo2 = new G4SubtractionSolid("teAnTo2", teAnTo1, cutScrewHole, 0, moveCut);
-    cI = 3; moveCut.setX( cR*cos(cI*cDt) ); moveCut.setY( cR*sin(cI*cDt) );
-    G4SubtractionSolid* teAnTo3 = new G4SubtractionSolid("teAnTo3", teAnTo2, cutScrewHole, 0, moveCut);
-    cI = 4; moveCut.setX( cR*cos(cI*cDt) ); moveCut.setY( cR*sin(cI*cDt) );
-    G4SubtractionSolid* teAnTo4 = new G4SubtractionSolid("teAnTo4", teAnTo3, cutScrewHole, 0, moveCut);
-    cI = 5; moveCut.setX( cR*cos(cI*cDt) ); moveCut.setY( cR*sin(cI*cDt) );
-    G4SubtractionSolid* teAnTo5 = new G4SubtractionSolid("teAnTo5", teAnTo4, cutScrewHole, 0, moveCut);
-    cI = 6; moveCut.setX( cR*cos(cI*cDt) ); moveCut.setY( cR*sin(cI*cDt) );
-    G4SubtractionSolid* teAnTo6 = new G4SubtractionSolid("teAnTo6", teAnTo5, cutScrewHole, 0, moveCut);
-    //final cut
-    cI = 7; moveCut.setX( cR*cos(cI*cDt) ); moveCut.setY( cR*sin(cI*cDt) );
-    G4SubtractionSolid* teflonAnnulusTop = new G4SubtractionSolid("teflonAnnulusTop", teAnTo6, cutScrewHole, 0, moveCut);
+	//cut out screw holes
+	G4double cI;
+	G4double cR = fScrewPlacementRadius;
+	G4double cDt = 45.*deg;
+	G4ThreeVector moveCut;
+	cI = 0; moveCut.setX(cR*cos(cI*cDt)); moveCut.setY(cR*sin(cI*cDt));
+	G4SubtractionSolid* teAnTo0 = new G4SubtractionSolid("teAnTo0", teAnToWithoutCuts, cutScrewHole, 0, moveCut);
+	cI = 1; moveCut.setX(cR*cos(cI*cDt)); moveCut.setY(cR*sin(cI*cDt));
+	G4SubtractionSolid* teAnTo1 = new G4SubtractionSolid("teAnTo1", teAnTo0, cutScrewHole, 0, moveCut);
+	cI = 2; moveCut.setX(cR*cos(cI*cDt)); moveCut.setY(cR*sin(cI*cDt));
+	G4SubtractionSolid* teAnTo2 = new G4SubtractionSolid("teAnTo2", teAnTo1, cutScrewHole, 0, moveCut);
+	cI = 3; moveCut.setX(cR*cos(cI*cDt)); moveCut.setY(cR*sin(cI*cDt));
+	G4SubtractionSolid* teAnTo3 = new G4SubtractionSolid("teAnTo3", teAnTo2, cutScrewHole, 0, moveCut);
+	cI = 4; moveCut.setX(cR*cos(cI*cDt)); moveCut.setY(cR*sin(cI*cDt));
+	G4SubtractionSolid* teAnTo4 = new G4SubtractionSolid("teAnTo4", teAnTo3, cutScrewHole, 0, moveCut);
+	cI = 5; moveCut.setX(cR*cos(cI*cDt)); moveCut.setY(cR*sin(cI*cDt));
+	G4SubtractionSolid* teAnTo5 = new G4SubtractionSolid("teAnTo5", teAnTo4, cutScrewHole, 0, moveCut);
+	cI = 6; moveCut.setX(cR*cos(cI*cDt)); moveCut.setY(cR*sin(cI*cDt));
+	G4SubtractionSolid* teAnTo6 = new G4SubtractionSolid("teAnTo6", teAnTo5, cutScrewHole, 0, moveCut);
+	//final cut
+	cI = 7; moveCut.setX(cR*cos(cI*cDt)); moveCut.setY(cR*sin(cI*cDt));
+	G4SubtractionSolid* teflonAnnulusTop = new G4SubtractionSolid("teflonAnnulusTop", teAnTo6, cutScrewHole, 0, moveCut);
 
-    //logical volume
-    if( fTeflonAnnulusTopLog == NULL ) {
-        fTeflonAnnulusTopLog = new G4LogicalVolume(teflonAnnulusTop, material, "teflonAnnulusTopLog", 0, 0, 0);
-        fTeflonAnnulusTopLog->SetVisAttributes(teflonAnnulusTopVisAtt);
-    }
+	//logical volume
+	if(fTeflonAnnulusTopLog == nullptr) {
+		fTeflonAnnulusTopLog = new G4LogicalVolume(teflonAnnulusTop, material, "teflonAnnulusTopLog", 0, 0, 0);
+		fTeflonAnnulusTopLog->SetVisAttributes(teflonAnnulusTopVisAtt);
+	}
 
-    return 1;
+	return 1;
 }//end ::end AddTeflonAnnulusTop
 
 //Add annulus that is on bottom of silicon detector
 G4int DetectionSystemPaces::AddTeflonAnnulusBot() {
-    //material
-    G4Material* material = G4Material::GetMaterial("Teflon");
-    if( !material ) {
-        G4cout << " ----> Material " << "Teflon" << " not found, cannot build the detector shell! " << G4endl;
-        return 0;
-    }
+	//material
+	G4Material* material = G4Material::GetMaterial("Teflon");
+	if(!material) {
+		G4cout<<" ----> Material "<<"Teflon"<<" not found, cannot build the detector shell! "<<G4endl;
+		return 0;
+	}
 
-    //vis attributes
-    G4VisAttributes* teflonAnnulusBotVisAtt = new G4VisAttributes(G4Colour(0.0,0.0,1.0));
-    teflonAnnulusBotVisAtt->SetVisibility(true);
+	//vis attributes
+	G4VisAttributes* teflonAnnulusBotVisAtt = new G4VisAttributes(G4Colour(0.0,0.0,1.0));
+	teflonAnnulusBotVisAtt->SetVisibility(true);
 
-    //main annulus
-    G4double innerRadius = fTeflonAnnulusBotInnerRadius;
-    G4double outerRadius = fTeflonAnnulusBotOuterRadius;
-    G4double halfLengthZ = fTeflonAnnulusBotThickness/2.0;
-    //screw cuts
-    G4double cutInnerRadius = 0.*mm;
-    G4double cutOuterRadius = fScrewRadius;
-    G4double cutHalfLengthZ = 20.*mm;
+	//main annulus
+	G4double innerRadius = fTeflonAnnulusBotInnerRadius;
+	G4double outerRadius = fTeflonAnnulusBotOuterRadius;
+	G4double halfLengthZ = fTeflonAnnulusBotThickness/2.0;
+	//screw cuts
+	G4double cutInnerRadius = 0.*mm;
+	G4double cutOuterRadius = fScrewRadius;
+	G4double cutHalfLengthZ = 20.*mm;
 
-    //primitive volume
-    G4Tubs* teAnBoWithoutCuts = new G4Tubs("teAnBoWithoutCuts", innerRadius, outerRadius, halfLengthZ, 0*M_PI, 2*M_PI);
-    G4Tubs* cutScrewHole = new G4Tubs("cutScrewHole", cutInnerRadius, cutOuterRadius, cutHalfLengthZ, 0*M_PI, 2*M_PI);
+	//primitive volume
+	G4Tubs* teAnBoWithoutCuts = new G4Tubs("teAnBoWithoutCuts", innerRadius, outerRadius, halfLengthZ, 0*M_PI, 2*M_PI);
+	G4Tubs* cutScrewHole = new G4Tubs("cutScrewHole", cutInnerRadius, cutOuterRadius, cutHalfLengthZ, 0*M_PI, 2*M_PI);
 
-    //cut out screw holes
-    G4double cI;
-    G4double cR = fScrewPlacementRadius;
-    G4double cDt = 45.*deg;
-    G4ThreeVector moveCut;
-    cI = 0; moveCut.setX( cR*cos(cI*cDt) ); moveCut.setY( cR*sin(cI*cDt) );
-    G4SubtractionSolid* teAnBo0 = new G4SubtractionSolid("teAnBo0", teAnBoWithoutCuts, cutScrewHole, 0, moveCut);
-    cI = 1; moveCut.setX( cR*cos(cI*cDt) ); moveCut.setY( cR*sin(cI*cDt) );
-    G4SubtractionSolid* teAnBo1 = new G4SubtractionSolid("teAnBo1", teAnBo0, cutScrewHole, 0, moveCut);
-    cI = 2; moveCut.setX( cR*cos(cI*cDt) ); moveCut.setY( cR*sin(cI*cDt) );
-    G4SubtractionSolid* teAnBo2 = new G4SubtractionSolid("teAnBo2", teAnBo1, cutScrewHole, 0, moveCut);
-    cI = 3; moveCut.setX( cR*cos(cI*cDt) ); moveCut.setY( cR*sin(cI*cDt) );
-    G4SubtractionSolid* teAnBo3 = new G4SubtractionSolid("teAnBo3", teAnBo2, cutScrewHole, 0, moveCut);
-    cI = 4; moveCut.setX( cR*cos(cI*cDt) ); moveCut.setY( cR*sin(cI*cDt) );
-    G4SubtractionSolid* teAnBo4 = new G4SubtractionSolid("teAnBo4", teAnBo3, cutScrewHole, 0, moveCut);
-    cI = 5; moveCut.setX( cR*cos(cI*cDt) ); moveCut.setY( cR*sin(cI*cDt) );
-    G4SubtractionSolid* teAnBo5 = new G4SubtractionSolid("teAnBo5", teAnBo4, cutScrewHole, 0, moveCut);
-    cI = 6; moveCut.setX( cR*cos(cI*cDt) ); moveCut.setY( cR*sin(cI*cDt) );
-    G4SubtractionSolid* teAnBo6 = new G4SubtractionSolid("teAnBo6", teAnBo5, cutScrewHole, 0, moveCut);
-    //final cut
-    cI = 7; moveCut.setX( cR*cos(cI*cDt) ); moveCut.setY( cR*sin(cI*cDt) );
-    G4SubtractionSolid* teflonAnnulusBot = new G4SubtractionSolid("teflonAnnulusBot", teAnBo6, cutScrewHole, 0, moveCut);
+	//cut out screw holes
+	G4double cI;
+	G4double cR = fScrewPlacementRadius;
+	G4double cDt = 45.*deg;
+	G4ThreeVector moveCut;
+	cI = 0; moveCut.setX(cR*cos(cI*cDt)); moveCut.setY(cR*sin(cI*cDt));
+	G4SubtractionSolid* teAnBo0 = new G4SubtractionSolid("teAnBo0", teAnBoWithoutCuts, cutScrewHole, 0, moveCut);
+	cI = 1; moveCut.setX(cR*cos(cI*cDt)); moveCut.setY(cR*sin(cI*cDt));
+	G4SubtractionSolid* teAnBo1 = new G4SubtractionSolid("teAnBo1", teAnBo0, cutScrewHole, 0, moveCut);
+	cI = 2; moveCut.setX(cR*cos(cI*cDt)); moveCut.setY(cR*sin(cI*cDt));
+	G4SubtractionSolid* teAnBo2 = new G4SubtractionSolid("teAnBo2", teAnBo1, cutScrewHole, 0, moveCut);
+	cI = 3; moveCut.setX(cR*cos(cI*cDt)); moveCut.setY(cR*sin(cI*cDt));
+	G4SubtractionSolid* teAnBo3 = new G4SubtractionSolid("teAnBo3", teAnBo2, cutScrewHole, 0, moveCut);
+	cI = 4; moveCut.setX(cR*cos(cI*cDt)); moveCut.setY(cR*sin(cI*cDt));
+	G4SubtractionSolid* teAnBo4 = new G4SubtractionSolid("teAnBo4", teAnBo3, cutScrewHole, 0, moveCut);
+	cI = 5; moveCut.setX(cR*cos(cI*cDt)); moveCut.setY(cR*sin(cI*cDt));
+	G4SubtractionSolid* teAnBo5 = new G4SubtractionSolid("teAnBo5", teAnBo4, cutScrewHole, 0, moveCut);
+	cI = 6; moveCut.setX(cR*cos(cI*cDt)); moveCut.setY(cR*sin(cI*cDt));
+	G4SubtractionSolid* teAnBo6 = new G4SubtractionSolid("teAnBo6", teAnBo5, cutScrewHole, 0, moveCut);
+	//final cut
+	cI = 7; moveCut.setX(cR*cos(cI*cDt)); moveCut.setY(cR*sin(cI*cDt));
+	G4SubtractionSolid* teflonAnnulusBot = new G4SubtractionSolid("teflonAnnulusBot", teAnBo6, cutScrewHole, 0, moveCut);
 
-    //logical volume
-    if( fTeflonAnnulusBotLog == NULL ) {
-        fTeflonAnnulusBotLog = new G4LogicalVolume(teflonAnnulusBot, material, "teflonAnnulusBotLog", 0, 0, 0);
-        fTeflonAnnulusBotLog->SetVisAttributes(teflonAnnulusBotVisAtt);
-    }
+	//logical volume
+	if(fTeflonAnnulusBotLog == nullptr) {
+		fTeflonAnnulusBotLog = new G4LogicalVolume(teflonAnnulusBot, material, "teflonAnnulusBotLog", 0, 0, 0);
+		fTeflonAnnulusBotLog->SetVisAttributes(teflonAnnulusBotVisAtt);
+	}
 
-    return 1;
+	return 1;
 }//end ::end AddTeflonAnnulusBot
 
 //Add the aluminum hemisphere, housing for PACES
 G4int DetectionSystemPaces::AddAluminumHemisphere() {
-    //material
-    G4Material* material = G4Material::GetMaterial("Aluminum");
-    if( !material ) {
-        G4cout << " ----> Material " << "Aluminum" << " not found, cannot build the detector shell! " << G4endl;
-        return 0;
-    }
+	//material
+	G4Material* material = G4Material::GetMaterial("Aluminum");
+	if(!material) {
+		G4cout<<" ----> Material "<<"Aluminum"<<" not found, cannot build the detector shell! "<<G4endl;
+		return 0;
+	}
 
-    //vis attributes
-    G4VisAttributes* aluminumHemisphereVisAtt = new G4VisAttributes(G4Colour(0.5,0.5,0.5));
-    aluminumHemisphereVisAtt->SetVisibility(true);
+	//vis attributes
+	G4VisAttributes* aluminumHemisphereVisAtt = new G4VisAttributes(G4Colour(0.5,0.5,0.5));
+	aluminumHemisphereVisAtt->SetVisibility(true);
 
-    //main hemisphere shell
-    G4double innerRadius = fAluminumHemisphereInnerRadius;
-    G4double outerRadius = fAluminumHemisphereOuterRadius;
-    G4double thickness = std::abs(outerRadius - innerRadius);
-    G4double startPhi = M_PI/2;
-    G4double endPhi = M_PI - startPhi;
-    //beam hole rim
-    G4double rimInnerRadius = std::abs(innerRadius - fAluminumHemisphereBeamHoleRimHeight);
-    G4double rimOuterRadius = innerRadius;
-    G4double rimEndPhi = asin( (fAluminumHemisphereBeamHoleRadius + thickness) / innerRadius );
-    G4double rimStartPhi = M_PI - rimEndPhi;
-    //beam hole cut
-    G4double beamHoleInnerRadius = 0.*mm;
-    G4double beamHoleOuterRadius = fAluminumHemisphereBeamHoleRadius;
-    G4double beamHoleHalfLengthZ = outerRadius;
-    //cuts where detectors go
-    G4double detectorInnerRadius = 0.*mm;
-    G4double detectorOuterRadius = fDetectorAssemblyRadius + fCutClearance;
-    G4double detectorHalfLengthZ = fDetectorAssemblyThickness/2.0;
+	//main hemisphere shell
+	G4double innerRadius = fAluminumHemisphereInnerRadius;
+	G4double outerRadius = fAluminumHemisphereOuterRadius;
+	G4double thickness = std::abs(outerRadius - innerRadius);
+	G4double startPhi = M_PI/2;
+	G4double endPhi = M_PI - startPhi;
+	//beam hole rim
+	G4double rimInnerRadius = std::abs(innerRadius - fAluminumHemisphereBeamHoleRimHeight);
+	G4double rimOuterRadius = innerRadius;
+	G4double rimEndPhi = asin((fAluminumHemisphereBeamHoleRadius + thickness) / innerRadius);
+	G4double rimStartPhi = M_PI - rimEndPhi;
+	//beam hole cut
+	G4double beamHoleInnerRadius = 0.*mm;
+	G4double beamHoleOuterRadius = fAluminumHemisphereBeamHoleRadius;
+	G4double beamHoleHalfLengthZ = outerRadius;
+	//cuts where detectors go
+	G4double detectorInnerRadius = 0.*mm;
+	G4double detectorOuterRadius = fDetectorAssemblyRadius + fCutClearance;
+	G4double detectorHalfLengthZ = fDetectorAssemblyThickness/2.0;
 
-    //primitive volumes
-    G4Sphere* alHeShell = new G4Sphere("alHeShell", innerRadius, outerRadius, 0*M_PI, 2*M_PI, startPhi, endPhi);
-    G4Sphere* alHeRim = new G4Sphere("alHeRim", rimInnerRadius, rimOuterRadius, 0*M_PI, 2*M_PI, rimStartPhi, rimEndPhi);
-    G4Tubs* cutBeamHole = new G4Tubs("cutBeamHole", beamHoleInnerRadius, beamHoleOuterRadius, beamHoleHalfLengthZ, 0*M_PI, 2*M_PI);
-    G4Tubs* cutDetector = new G4Tubs("cutDetector", detectorInnerRadius, detectorOuterRadius, detectorHalfLengthZ, 0*M_PI, 2*M_PI);
+	//primitive volumes
+	G4Sphere* alHeShell = new G4Sphere("alHeShell", innerRadius, outerRadius, 0*M_PI, 2*M_PI, startPhi, endPhi);
+	G4Sphere* alHeRim = new G4Sphere("alHeRim", rimInnerRadius, rimOuterRadius, 0*M_PI, 2*M_PI, rimStartPhi, rimEndPhi);
+	G4Tubs* cutBeamHole = new G4Tubs("cutBeamHole", beamHoleInnerRadius, beamHoleOuterRadius, beamHoleHalfLengthZ, 0*M_PI, 2*M_PI);
+	G4Tubs* cutDetector = new G4Tubs("cutDetector", detectorInnerRadius, detectorOuterRadius, detectorHalfLengthZ, 0*M_PI, 2*M_PI);
 
-    //add rim and beam hole
-    G4RotationMatrix* R0 = new G4RotationMatrix; G4ThreeVector T0;
-    G4UnionSolid* alHeShellRim = new G4UnionSolid("alHeShellRim", alHeShell, alHeRim, R0, T0);
-    G4SubtractionSolid* alHeShellRimHole = new G4SubtractionSolid("alHeShellRimHole", alHeShellRim, cutBeamHole, R0, T0);
-    //cut out detectors
+	//add rim and beam hole
+	G4RotationMatrix* R0 = new G4RotationMatrix; G4ThreeVector T0;
+	G4UnionSolid* alHeShellRim = new G4UnionSolid("alHeShellRim", alHeShell, alHeRim, R0, T0);
+	G4SubtractionSolid* alHeShellRimHole = new G4SubtractionSolid("alHeShellRimHole", alHeShellRim, cutBeamHole, R0, T0);
+	//cut out detectors
 
-    G4double* ptrPd = fPacesPlacementDistance;
-    G4double* ptrPt = fPacesPlacementPhi;
-    G4double* ptrPp = fPacesPlacementTheta;
-    G4double* ptrOt = fPacesOrientationPhi;
-    G4double* ptrOp = fPacesOrientationTheta;
+	G4double* ptrPd = fPacesPlacementDistance;
+	G4double* ptrPt = fPacesPlacementPhi;
+	G4double* ptrPp = fPacesPlacementTheta;
+	G4double* ptrOt = fPacesOrientationPhi;
+	G4double* ptrOp = fPacesOrientationTheta;
 
-    //  G4RotationMatrix* rotateCut[5];
-    //  G4ThreeVector moveCut[5], yprimeaxis;
-    //  G4double dDist, dPhi, dTheta, oriPhi, oriTheta;
-    //
-    //  for (int i=0; i<5; i++)
-    //  {
-    //    dDist = ptrPd[i] + detectorHalfLengthZ;
-    //    dPhi = ptrPt[i];
-    //    dTheta = ptrPp[i];
-    //    rotateCut[i] = new G4RotationMatrix;
-    //    moveCut[i].setX( dDist * cos(dPhi) * sin(dTheta) );
-    //    moveCut[i].setY( dDist * sin(dPhi) * sin(dTheta) );
-    //    moveCut[i].setZ( dDist *    1.0     * cos(dTheta) );
-    //    oriPhi = dPhi + ptrOt[i] - M_PI/2; //minus 90 deg
-    //    oriTheta = dTheta + ptrOp[i];
-    ////    yprimeaxis = G4ThreeVector(cos(oriPhi), sin(oriPhi), 0);
-    //	  yprimeaxis.set(cos(oriPhi), sin(oriPhi), 0);
-    //    rotateCut[i]->set(yprimeaxis, oriTheta);
-    //  }
-    //  G4SubtractionSolid* alHe0 = new G4SubtractionSolid("alHe0", alHeShellRimHole, cutDetector, rotateCut[0], moveCut[0]);
-    //  G4SubtractionSolid* alHe1 = new G4SubtractionSolid("alHe1", alHe0, cutDetector, rotateCut[1], moveCut[1]);
-    //  G4SubtractionSolid* alHe2 = new G4SubtractionSolid("alHe2", alHe1, cutDetector, rotateCut[2], moveCut[2]);
-    //  G4SubtractionSolid* alHe3 = new G4SubtractionSolid("alHe3", alHe2, cutDetector, rotateCut[3], moveCut[3]);
-    //  G4SubtractionSolid* aluminumHemisphere = new G4SubtractionSolid("aluminumHemisphere", alHe3, cutDetector, rotateCut[4], moveCut[4]);
-    //  for (int i=0; i<5; i++) delete rotateCut[i]; //safety
+	//  G4RotationMatrix* rotateCut[5];
+	//  G4ThreeVector moveCut[5], yprimeaxis;
+	//  G4double dDist, dPhi, dTheta, oriPhi, oriTheta;
+	//
+	//  for(int i=0; i<5; i++)
+	//  {
+	//    dDist = ptrPd[i] + detectorHalfLengthZ;
+	//    dPhi = ptrPt[i];
+	//    dTheta = ptrPp[i];
+	//    rotateCut[i] = new G4RotationMatrix;
+	//    moveCut[i].setX(dDist * cos(dPhi) * sin(dTheta));
+	//    moveCut[i].setY(dDist * sin(dPhi) * sin(dTheta));
+	//    moveCut[i].setZ(dDist *    1.0     * cos(dTheta));
+	//    oriPhi = dPhi + ptrOt[i] - M_PI/2; //minus 90 deg
+	//    oriTheta = dTheta + ptrOp[i];
+	////    yprimeaxis = G4ThreeVector(cos(oriPhi), sin(oriPhi), 0);
+	//	  yprimeaxis.set(cos(oriPhi), sin(oriPhi), 0);
+	//    rotateCut[i]->set(yprimeaxis, oriTheta);
+	//  }
+	//  G4SubtractionSolid* alHe0 = new G4SubtractionSolid("alHe0", alHeShellRimHole, cutDetector, rotateCut[0], moveCut[0]);
+	//  G4SubtractionSolid* alHe1 = new G4SubtractionSolid("alHe1", alHe0, cutDetector, rotateCut[1], moveCut[1]);
+	//  G4SubtractionSolid* alHe2 = new G4SubtractionSolid("alHe2", alHe1, cutDetector, rotateCut[2], moveCut[2]);
+	//  G4SubtractionSolid* alHe3 = new G4SubtractionSolid("alHe3", alHe2, cutDetector, rotateCut[3], moveCut[3]);
+	//  G4SubtractionSolid* aluminumHemisphere = new G4SubtractionSolid("aluminumHemisphere", alHe3, cutDetector, rotateCut[4], moveCut[4]);
+	//  for(int i=0; i<5; i++) delete rotateCut[i]; //safety
 
-    G4ThreeVector moveCut, yprimeaxis;
-    G4RotationMatrix* rotateCut = new G4RotationMatrix;
-    G4double dDist, dPhi, dTheta, oriPhi, oriTheta;
-    G4int dI;
-    //one
-    dI = 0;
-    dDist = ptrPd[dI] + detectorHalfLengthZ;
-    dPhi = ptrPt[dI];
-    dTheta = ptrPp[dI];
-    moveCut.setX( dDist * cos(dPhi) * sin(dTheta) );
-    moveCut.setY( dDist * sin(dPhi) * sin(dTheta) );
-    moveCut.setZ( dDist *      1.0     * cos(dTheta) );
-    oriPhi = dPhi + ptrOt[dI] - M_PI/2;
-    oriTheta = dTheta + ptrOp[dI];
-    yprimeaxis.set(cos(oriPhi), sin(oriPhi), 0);
-    rotateCut->set(yprimeaxis, oriTheta);
-    G4SubtractionSolid* alHe0 = new G4SubtractionSolid("alHe0", alHeShellRimHole, cutDetector, rotateCut, moveCut);
-    //two
-    dI = 1;
-    dDist = ptrPd[dI] + detectorHalfLengthZ;
-    dPhi = ptrPt[dI];
-    dTheta = ptrPp[dI];
-    moveCut.setX( dDist * cos(dPhi) * sin(dTheta) );
-    moveCut.setY( dDist * sin(dPhi) * sin(dTheta) );
-    moveCut.setZ( dDist *      1.0     * cos(dTheta) );
-    oriPhi = dPhi + ptrOt[dI] - M_PI/2;
-    oriTheta = dTheta + ptrOp[dI];
-    yprimeaxis.set(cos(oriPhi), sin(oriPhi), 0);
-    rotateCut->set(yprimeaxis, oriTheta);
-    G4SubtractionSolid* alHe1 = new G4SubtractionSolid("alHe1", alHe0, cutDetector, rotateCut, moveCut);
-    //three
-    dI = 2;
-    dDist = ptrPd[dI] + detectorHalfLengthZ;
-    dPhi = ptrPt[dI];
-    dTheta = ptrPp[dI];
-    moveCut.setX( dDist * cos(dPhi) * sin(dTheta) );
-    moveCut.setY( dDist * sin(dPhi) * sin(dTheta) );
-    moveCut.setZ( dDist *      1.0     * cos(dTheta) );
-    oriPhi = dPhi + ptrOt[dI] - M_PI/2;
-    oriTheta = dTheta + ptrOp[dI];
-    yprimeaxis.set(cos(oriPhi), sin(oriPhi), 0);
-    rotateCut->set(yprimeaxis, oriTheta);
-    G4SubtractionSolid* alHe2 = new G4SubtractionSolid("alHe2", alHe1, cutDetector, rotateCut, moveCut);
-    //four
-    dI = 3;
-    dDist = ptrPd[dI] + detectorHalfLengthZ;
-    dPhi = ptrPt[dI];
-    dTheta = ptrPp[dI];
-    moveCut.setX( dDist * cos(dPhi) * sin(dTheta) );
-    moveCut.setY( dDist * sin(dPhi) * sin(dTheta) );
-    moveCut.setZ( dDist *      1.0     * cos(dTheta) );
-    oriPhi = dPhi + ptrOt[dI] - M_PI/2;
-    oriTheta = dTheta + ptrOp[dI];
-    yprimeaxis.set(cos(oriPhi), sin(oriPhi), 0);
-    rotateCut->set(yprimeaxis, oriTheta);
-    G4SubtractionSolid* alHe3 = new G4SubtractionSolid("alHe3", alHe2, cutDetector, rotateCut, moveCut);
-    //five
-    dI = 4;
-    dDist = ptrPd[dI] + detectorHalfLengthZ;
-    dPhi = ptrPt[dI];
-    dTheta = ptrPp[dI];
-    moveCut.setX( dDist * cos(dPhi) * sin(dTheta) );
-    moveCut.setY( dDist * sin(dPhi) * sin(dTheta) );
-    moveCut.setZ( dDist *      1.0     * cos(dTheta) );
-    oriPhi = dPhi + ptrOt[dI] - M_PI/2;
-    oriTheta = dTheta + ptrOp[dI];
-    yprimeaxis.set(cos(oriPhi), sin(oriPhi), 0);
-    rotateCut->set(yprimeaxis, oriTheta);
-    G4SubtractionSolid* aluminumHemisphere = new G4SubtractionSolid("aluminumHemisphere", alHe3, cutDetector, rotateCut, moveCut);
-    //  //end
+	G4ThreeVector moveCut, yprimeaxis;
+	G4RotationMatrix* rotateCut = new G4RotationMatrix;
+	G4double dDist, dPhi, dTheta, oriPhi, oriTheta;
+	G4int dI;
+	//one
+	dI = 0;
+	dDist = ptrPd[dI] + detectorHalfLengthZ;
+	dPhi = ptrPt[dI];
+	dTheta = ptrPp[dI];
+	moveCut.setX(dDist * cos(dPhi) * sin(dTheta));
+	moveCut.setY(dDist * sin(dPhi) * sin(dTheta));
+	moveCut.setZ(dDist *      1.0     * cos(dTheta));
+	oriPhi = dPhi + ptrOt[dI] - M_PI/2;
+	oriTheta = dTheta + ptrOp[dI];
+	yprimeaxis.set(cos(oriPhi), sin(oriPhi), 0);
+	rotateCut->set(yprimeaxis, oriTheta);
+	G4SubtractionSolid* alHe0 = new G4SubtractionSolid("alHe0", alHeShellRimHole, cutDetector, rotateCut, moveCut);
+	//two
+	dI = 1;
+	dDist = ptrPd[dI] + detectorHalfLengthZ;
+	dPhi = ptrPt[dI];
+	dTheta = ptrPp[dI];
+	moveCut.setX(dDist * cos(dPhi) * sin(dTheta));
+	moveCut.setY(dDist * sin(dPhi) * sin(dTheta));
+	moveCut.setZ(dDist *      1.0     * cos(dTheta));
+	oriPhi = dPhi + ptrOt[dI] - M_PI/2;
+	oriTheta = dTheta + ptrOp[dI];
+	yprimeaxis.set(cos(oriPhi), sin(oriPhi), 0);
+	rotateCut->set(yprimeaxis, oriTheta);
+	G4SubtractionSolid* alHe1 = new G4SubtractionSolid("alHe1", alHe0, cutDetector, rotateCut, moveCut);
+	//three
+	dI = 2;
+	dDist = ptrPd[dI] + detectorHalfLengthZ;
+	dPhi = ptrPt[dI];
+	dTheta = ptrPp[dI];
+	moveCut.setX(dDist * cos(dPhi) * sin(dTheta));
+	moveCut.setY(dDist * sin(dPhi) * sin(dTheta));
+	moveCut.setZ(dDist *      1.0     * cos(dTheta));
+	oriPhi = dPhi + ptrOt[dI] - M_PI/2;
+	oriTheta = dTheta + ptrOp[dI];
+	yprimeaxis.set(cos(oriPhi), sin(oriPhi), 0);
+	rotateCut->set(yprimeaxis, oriTheta);
+	G4SubtractionSolid* alHe2 = new G4SubtractionSolid("alHe2", alHe1, cutDetector, rotateCut, moveCut);
+	//four
+	dI = 3;
+	dDist = ptrPd[dI] + detectorHalfLengthZ;
+	dPhi = ptrPt[dI];
+	dTheta = ptrPp[dI];
+	moveCut.setX(dDist * cos(dPhi) * sin(dTheta));
+	moveCut.setY(dDist * sin(dPhi) * sin(dTheta));
+	moveCut.setZ(dDist *      1.0     * cos(dTheta));
+	oriPhi = dPhi + ptrOt[dI] - M_PI/2;
+	oriTheta = dTheta + ptrOp[dI];
+	yprimeaxis.set(cos(oriPhi), sin(oriPhi), 0);
+	rotateCut->set(yprimeaxis, oriTheta);
+	G4SubtractionSolid* alHe3 = new G4SubtractionSolid("alHe3", alHe2, cutDetector, rotateCut, moveCut);
+	//five
+	dI = 4;
+	dDist = ptrPd[dI] + detectorHalfLengthZ;
+	dPhi = ptrPt[dI];
+	dTheta = ptrPp[dI];
+	moveCut.setX(dDist * cos(dPhi) * sin(dTheta));
+	moveCut.setY(dDist * sin(dPhi) * sin(dTheta));
+	moveCut.setZ(dDist *      1.0     * cos(dTheta));
+	oriPhi = dPhi + ptrOt[dI] - M_PI/2;
+	oriTheta = dTheta + ptrOp[dI];
+	yprimeaxis.set(cos(oriPhi), sin(oriPhi), 0);
+	rotateCut->set(yprimeaxis, oriTheta);
+	G4SubtractionSolid* aluminumHemisphere = new G4SubtractionSolid("aluminumHemisphere", alHe3, cutDetector, rotateCut, moveCut);
+	//  //end
 
-    //logical volume
-    if( fAluminumHemisphereLog == NULL ) {
-        fAluminumHemisphereLog = new G4LogicalVolume(aluminumHemisphere, material, "aluminumHemisphereLog", 0, 0, 0);
-        fAluminumHemisphereLog->SetVisAttributes(aluminumHemisphereVisAtt);
-    }
+	//logical volume
+	if(fAluminumHemisphereLog == nullptr) {
+		fAluminumHemisphereLog = new G4LogicalVolume(aluminumHemisphere, material, "aluminumHemisphereLog", 0, 0, 0);
+		fAluminumHemisphereLog->SetVisAttributes(aluminumHemisphereVisAtt);
+	}
 
-    return 1;
+	return 1;
 }//end ::end AddAluminumHemisphere
 
 
 //Add screws
 G4int DetectionSystemPaces::AddScrews() {
-    return 1;
+	return 1;
 }//end ::end AddScrews

--- a/src/DetectionSystemS3.cc
+++ b/src/DetectionSystemS3.cc
@@ -24,41 +24,41 @@
 #include "G4SystemOfUnits.hh" // new version geant4.10 requires units
 
 DetectionSystemS3::DetectionSystemS3() :
-    // LogicalVolumes
-    fS3InnerGuardRingLog(0),
-    fS3OuterGuardRingLog(0)
+	// LogicalVolumes
+	fS3InnerGuardRingLog(0),
+	fS3OuterGuardRingLog(0)
 {
-    /////////////////////////////////////////////////////////////////////
-    // SPICE Physical Properties
-    /////////////////////////////////////////////////////////////////////
+	/////////////////////////////////////////////////////////////////////
+	// SPICE Physical Properties
+	/////////////////////////////////////////////////////////////////////
 
-    fWaferMaterial             = "Silicon";
+	fWaferMaterial             = "Silicon";
 
-    //-----------------------------//
-    // parameters for the annular  //
-    // planar detector crystal     //
-    //-----------------------------//
-    fS3DetCrystalOuterDiameter = 70.*mm;
-    fS3DetCrystalInnerDiameter = 22.*mm;
-    fS3DetCrystalThickness = .15*mm;
-    fS3DetRadialSegments = 24.;
-    fS3DetPhiSegments = 32.;
+	//-----------------------------//
+	// parameters for the annular  //
+	// planar detector crystal     //
+	//-----------------------------//
+	fS3DetCrystalOuterDiameter = 70.*mm;
+	fS3DetCrystalInnerDiameter = 22.*mm;
+	fS3DetCrystalThickness = .15*mm;
+	fS3DetRadialSegments = 24.;
+	fS3DetPhiSegments = 32.;
 
-    //-----------------------------//
-    // parameters for guard ring   //
-    //-----------------------------//
-    fS3DetGuardRingOuterDiameter = 76*mm;
-    fS3DetGuardRingInnerDiameter = 20*mm;
+	//-----------------------------//
+	// parameters for guard ring   //
+	//-----------------------------//
+	fS3DetGuardRingOuterDiameter = 76*mm;
+	fS3DetGuardRingInnerDiameter = 20*mm;
 }
 
 DetectionSystemS3::~DetectionSystemS3() {
-  for(int i = 0; i < 24; ++i) {
-    if(fSiDetS3RingLog[i] != NULL) {
-      delete fSiDetS3RingLog[i];
-    }
-  }
-    delete fS3InnerGuardRingLog;
-    delete fS3OuterGuardRingLog;
+	for(int i = 0; i < 24; ++i) {
+		if(fSiDetS3RingLog[i] != nullptr) {
+			delete fSiDetS3RingLog[i];
+		}
+	}
+	delete fS3InnerGuardRingLog;
+	delete fS3OuterGuardRingLog;
 
 }
 
@@ -67,18 +67,18 @@ DetectionSystemS3::~DetectionSystemS3() {
 // when detector is constructed                            //
 //---------------------------------------------------------//
 G4int DetectionSystemS3::Build() {
-    fAssembly =  new G4AssemblyVolume();
+	fAssembly =  new G4AssemblyVolume();
 
-    for (int ringID=0; ringID<24; ringID++) {	// Loop through each ring ...
-        fAssemblyS3Ring[ringID] = new G4AssemblyVolume(); 		// Build assembly volumes
-        BuildSiliconWafer(ringID);		// Build Silicon Ring
-    } // end for(int ringID)
+	for(int ringID=0; ringID<24; ringID++) {	// Loop through each ring ...
+		fAssemblyS3Ring[ringID] = new G4AssemblyVolume(); 		// Build assembly volumes
+		BuildSiliconWafer(ringID);		// Build Silicon Ring
+	} // end for(int ringID)
 
-    // Build Guard Rings
-    BuildInnerGuardRing();
-    BuildOuterGuardRing();
+	// Build Guard Rings
+	BuildInnerGuardRing();
+	BuildOuterGuardRing();
 
-    return 1;
+	return 1;
 }
 
 //---------------------------------------------------------//
@@ -86,21 +86,21 @@ G4int DetectionSystemS3::Build() {
 // if detector is added                                    //
 //---------------------------------------------------------//
 G4int DetectionSystemS3::PlaceDetector(G4LogicalVolume* expHallLog, G4ThreeVector move, G4int ringNumber, G4int Seg, G4int detectorNumber) {
-    G4RotationMatrix* rotate = new G4RotationMatrix;
-    G4int NumberSeg = (G4int) fS3DetPhiSegments;
-    G4double angle = (360./NumberSeg)*(Seg-0.5)*deg;
-    rotate->rotateZ(angle);
-    fAssemblyS3Ring[ringNumber]->MakeImprint(expHallLog, move, rotate, detectorNumber);
+	G4RotationMatrix* rotate = new G4RotationMatrix;
+	G4int NumberSeg = (G4int) fS3DetPhiSegments;
+	G4double angle = (360./NumberSeg)*(Seg-0.5)*deg;
+	rotate->rotateZ(angle);
+	fAssemblyS3Ring[ringNumber]->MakeImprint(expHallLog, move, rotate, detectorNumber);
 
-    return 1;
+	return 1;
 }
 
 G4int DetectionSystemS3::PlaceGuardRing(G4LogicalVolume* expHallLog, G4ThreeVector move) {
-    G4RotationMatrix* rotate = new G4RotationMatrix;
-    rotate->rotateZ(0*deg);
-    fAssembly->MakeImprint(expHallLog, move, rotate, 0);
+	G4RotationMatrix* rotate = new G4RotationMatrix;
+	rotate->rotateZ(0*deg);
+	fAssembly->MakeImprint(expHallLog, move, rotate, 0);
 
-    return 1;
+	return 1;
 }
 
 //---------------------------------------------------------//
@@ -108,108 +108,108 @@ G4int DetectionSystemS3::PlaceGuardRing(G4LogicalVolume* expHallLog, G4ThreeVect
 // called in main build function                           //
 //---------------------------------------------------------//
 G4int DetectionSystemS3::BuildSiliconWafer(G4int RingID) {
-    // Define the material, return error if not found
-    G4Material* material = G4Material::GetMaterial(fWaferMaterial);
-    if( !material ) {
-        G4cout << " ----> Material " << fWaferMaterial
-               << " not found, cannot build the detector shell! " << G4endl;
-        return 0;
-    }
+	// Define the material, return error if not found
+	G4Material* material = G4Material::GetMaterial(fWaferMaterial);
+	if(!material) {
+		G4cout<<" ----> Material "<<fWaferMaterial
+			<<" not found, cannot build the detector shell! "<<G4endl;
+		return 0;
+	}
 
-    // Set visualization attributes
-    G4VisAttributes* visAtt = new G4VisAttributes(G4Colour(0.0,1.0,1.0));
-    visAtt->SetVisibility(true);
+	// Set visualization attributes
+	G4VisAttributes* visAtt = new G4VisAttributes(G4Colour(0.0,1.0,1.0));
+	visAtt->SetVisibility(true);
 
-    // Define rotation and movement objects
-    G4ThreeVector direction 	= G4ThreeVector(0,0,1);
-    G4double zPosition		= -(fS3DetCrystalThickness/2.);
-    G4ThreeVector move 		= zPosition * direction;
-    G4RotationMatrix* rotate = new G4RotationMatrix;
-    rotate->rotateZ(0*deg);
+	// Define rotation and movement objects
+	G4ThreeVector direction 	= G4ThreeVector(0,0,1);
+	G4double zPosition		= -(fS3DetCrystalThickness/2.);
+	G4ThreeVector move 		= zPosition * direction;
+	G4RotationMatrix* rotate = new G4RotationMatrix;
+	rotate->rotateZ(0*deg);
 
-    // construct solid
-    G4Tubs* siDetS3RingSec = BuildCrystal(RingID);
+	// construct solid
+	G4Tubs* siDetS3RingSec = BuildCrystal(RingID);
 
-    // construct logical volume if it doesn't already exist
-    if(!fSiDetS3RingLog[RingID]) {
-        G4String s3name = "siDetS3Ring_";
-        s3name += G4UIcommand::ConvertToString(RingID);
-        s3name += "_Log";
+	// construct logical volume if it doesn't already exist
+	if(!fSiDetS3RingLog[RingID]) {
+		G4String s3name = "siDetS3Ring_";
+		s3name += G4UIcommand::ConvertToString(RingID);
+		s3name += "_Log";
 
-        fSiDetS3RingLog[RingID] = new G4LogicalVolume(siDetS3RingSec, material, s3name, 0, 0, 0);
-        fSiDetS3RingLog[RingID]->SetVisAttributes(visAtt);
-    }
-    fAssemblyS3Ring[RingID]->AddPlacedVolume(fSiDetS3RingLog[RingID], move, rotate);
-    
-    return 1;
+		fSiDetS3RingLog[RingID] = new G4LogicalVolume(siDetS3RingSec, material, s3name, 0, 0, 0);
+		fSiDetS3RingLog[RingID]->SetVisAttributes(visAtt);
+	}
+	fAssemblyS3Ring[RingID]->AddPlacedVolume(fSiDetS3RingLog[RingID], move, rotate);
+
+	return 1;
 }
 
 G4int DetectionSystemS3::BuildInnerGuardRing() {
-    G4Material* material = G4Material::GetMaterial(fWaferMaterial);
-    if( !material ) {
-        G4cout << " ----> Material " << fWaferMaterial << " not found, cannot build the inner guard ring of the S3 detector! " << G4endl;
-        return 0;
-    }
+	G4Material* material = G4Material::GetMaterial(fWaferMaterial);
+	if(!material) {
+		G4cout<<" ----> Material "<<fWaferMaterial<<" not found, cannot build the inner guard ring of the S3 detector! "<<G4endl;
+		return 0;
+	}
 
-    // Set visualization attributes
-    G4VisAttributes* visAtt = new G4VisAttributes(G4Colour(0.0,1.0,1.0));
-    visAtt->SetVisibility(true);
+	// Set visualization attributes
+	G4VisAttributes* visAtt = new G4VisAttributes(G4Colour(0.0,1.0,1.0));
+	visAtt->SetVisibility(true);
 
-    G4Tubs* innerGuardRing = new G4Tubs("innerGuardRing",
-                                        fS3DetGuardRingInnerDiameter/2.,
-                                        fS3DetCrystalInnerDiameter/2.,
-                                        fS3DetCrystalThickness/2.,0,360);
+	G4Tubs* innerGuardRing = new G4Tubs("innerGuardRing",
+			fS3DetGuardRingInnerDiameter/2.,
+			fS3DetCrystalInnerDiameter/2.,
+			fS3DetCrystalThickness/2.,0,360);
 
-    // Define rotation and movement objects
-    G4ThreeVector direction 	= G4ThreeVector(0,0,1);
-    G4double zPosition		= -(fS3DetCrystalThickness/2.);
-    G4ThreeVector move 		= zPosition * direction;
-    G4RotationMatrix* rotate = new G4RotationMatrix;
-    rotate->rotateZ(0*deg);
+	// Define rotation and movement objects
+	G4ThreeVector direction 	= G4ThreeVector(0,0,1);
+	G4double zPosition		= -(fS3DetCrystalThickness/2.);
+	G4ThreeVector move 		= zPosition * direction;
+	G4RotationMatrix* rotate = new G4RotationMatrix;
+	rotate->rotateZ(0*deg);
 
-    //logical volume
-    if(fS3InnerGuardRingLog == NULL) {
-        fS3InnerGuardRingLog = new G4LogicalVolume(innerGuardRing, material, "innerGuardRing", 0,0,0);
-        fS3InnerGuardRingLog->SetVisAttributes(visAtt);
-    }
+	//logical volume
+	if(fS3InnerGuardRingLog == nullptr) {
+		fS3InnerGuardRingLog = new G4LogicalVolume(innerGuardRing, material, "innerGuardRing", 0,0,0);
+		fS3InnerGuardRingLog->SetVisAttributes(visAtt);
+	}
 
-    fAssembly->AddPlacedVolume(fS3InnerGuardRingLog, move, rotate);
+	fAssembly->AddPlacedVolume(fS3InnerGuardRingLog, move, rotate);
 
-    return 1;
+	return 1;
 }
 
 G4int DetectionSystemS3::BuildOuterGuardRing() {
-    G4Material* material = G4Material::GetMaterial(fWaferMaterial);
-    if( !material ) {
-        G4cout << " ----> Material " << fWaferMaterial << " not found, cannot build the outer guard ring of the S3 detector! " << G4endl;
-        return 0;
-    }
+	G4Material* material = G4Material::GetMaterial(fWaferMaterial);
+	if(!material) {
+		G4cout<<" ----> Material "<<fWaferMaterial<<" not found, cannot build the outer guard ring of the S3 detector! "<<G4endl;
+		return 0;
+	}
 
-    // Set visualization attributes
-    G4VisAttributes* visAtt = new G4VisAttributes(G4Colour(0.0,1.0,1.0));
-    visAtt->SetVisibility(true);
+	// Set visualization attributes
+	G4VisAttributes* visAtt = new G4VisAttributes(G4Colour(0.0,1.0,1.0));
+	visAtt->SetVisibility(true);
 
-    G4Tubs* outerGuardRing = new G4Tubs("outerGuardRing",
-                                        fS3DetCrystalOuterDiameter/2.,
-                                        fS3DetGuardRingOuterDiameter/2.,
-                                        fS3DetCrystalThickness/2.,0,360);
+	G4Tubs* outerGuardRing = new G4Tubs("outerGuardRing",
+			fS3DetCrystalOuterDiameter/2.,
+			fS3DetGuardRingOuterDiameter/2.,
+			fS3DetCrystalThickness/2.,0,360);
 
-    // Define rotation and movement objects
-    G4ThreeVector direction 	= G4ThreeVector(0,0,1);
-    G4double zPosition		= -(fS3DetCrystalThickness/2.);
-    G4ThreeVector move 		= zPosition * direction;
-    G4RotationMatrix* rotate = new G4RotationMatrix;
-    rotate->rotateZ(0*deg);
+	// Define rotation and movement objects
+	G4ThreeVector direction 	= G4ThreeVector(0,0,1);
+	G4double zPosition		= -(fS3DetCrystalThickness/2.);
+	G4ThreeVector move 		= zPosition * direction;
+	G4RotationMatrix* rotate = new G4RotationMatrix;
+	rotate->rotateZ(0*deg);
 
-    //logical volume
-    if(fS3OuterGuardRingLog == NULL) {
-        fS3OuterGuardRingLog = new G4LogicalVolume(outerGuardRing, material, "outerGuardRing", 0,0,0);
-        fS3OuterGuardRingLog->SetVisAttributes(visAtt);
-    }
+	//logical volume
+	if(fS3OuterGuardRingLog == nullptr) {
+		fS3OuterGuardRingLog = new G4LogicalVolume(outerGuardRing, material, "outerGuardRing", 0,0,0);
+		fS3OuterGuardRingLog->SetVisAttributes(visAtt);
+	}
 
-    fAssembly->AddPlacedVolume(fS3OuterGuardRingLog, move, rotate);
+	fAssembly->AddPlacedVolume(fS3OuterGuardRingLog, move, rotate);
 
-    return 1;
+	return 1;
 }
 
 ///////////////////////////////////////////////////////
@@ -217,17 +217,17 @@ G4int DetectionSystemS3::BuildOuterGuardRing() {
 // the geometry depends on the distance from the center
 ///////////////////////////////////////////////////////
 G4Tubs* DetectionSystemS3::BuildCrystal(G4int RingID) {
-    // define angle, length, thickness, and inner and outer diameter
-    // of silicon detector segment
-    G4double tubeElementLength = (fS3DetCrystalOuterDiameter - fS3DetCrystalInnerDiameter)/(2*(fS3DetRadialSegments));
-    G4double tubeElementAngularWidth = (360./fS3DetPhiSegments)*deg;
-    G4double tubeElementInnerRadius = (fS3DetCrystalInnerDiameter)/2.0 + tubeElementLength*(RingID);
-    G4double tubeElementOuterRadius = ((G4double)fS3DetCrystalInnerDiameter)/2.0 + tubeElementLength*(RingID+1);
-    G4double tubeElementHalfThickness = (fS3DetCrystalThickness)/2.0;
+	// define angle, length, thickness, and inner and outer diameter
+	// of silicon detector segment
+	G4double tubeElementLength = (fS3DetCrystalOuterDiameter - fS3DetCrystalInnerDiameter)/(2*(fS3DetRadialSegments));
+	G4double tubeElementAngularWidth = (360./fS3DetPhiSegments)*deg;
+	G4double tubeElementInnerRadius = (fS3DetCrystalInnerDiameter)/2.0 + tubeElementLength*(RingID);
+	G4double tubeElementOuterRadius = ((G4double)fS3DetCrystalInnerDiameter)/2.0 + tubeElementLength*(RingID+1);
+	G4double tubeElementHalfThickness = (fS3DetCrystalThickness)/2.0;
 
-    // establish solid
-    G4Tubs* crystalBlock = new G4Tubs("crystalBlock",tubeElementInnerRadius,tubeElementOuterRadius,tubeElementHalfThickness,0,tubeElementAngularWidth);
+	// establish solid
+	G4Tubs* crystalBlock = new G4Tubs("crystalBlock",tubeElementInnerRadius,tubeElementOuterRadius,tubeElementHalfThickness,0,tubeElementAngularWidth);
 
-    return crystalBlock;
+	return crystalBlock;
 }//end ::BuildCrystal
 

--- a/src/DetectionSystemSceptar.cc
+++ b/src/DetectionSystemSceptar.cc
@@ -25,452 +25,452 @@
 #include "G4SystemOfUnits.hh" // new version geant4.10 requires units
 
 DetectionSystemSceptar::DetectionSystemSceptar() :
-    // LogicalVolumes
-    fSquareMylarLog(0),
-    fAngledMylarLog(0),
-    fSquareScintillatorLog(0),
-    fAngledScintillatorLog(0),
-    fDelrinShellLog(0),
-    fDelrinShell2Log(0),
-    fHevimetShellLog(0)
+	// LogicalVolumes
+	fSquareMylarLog(0),
+	fAngledMylarLog(0),
+	fSquareScintillatorLog(0),
+	fAngledScintillatorLog(0),
+	fDelrinShellLog(0),
+	fDelrinShell2Log(0),
+	fHevimetShellLog(0)
 {
 
-    /////////////////////////////////////////////////////////////////////
-    // Detector Properties
-    /////////////////////////////////////////////////////////////////////
-    fSeparateHemispheres = 1.0*mm;
-    fConvert = 0.0254*m; //Needed to convert inches to meters
+	/////////////////////////////////////////////////////////////////////
+	// Detector Properties
+	/////////////////////////////////////////////////////////////////////
+	fSeparateHemispheres = 1.0*mm;
+	fConvert = 0.0254*m; //Needed to convert inches to meters
 
-    fSquareScintillatorLength = 1.194*fConvert;
-    fSquareScintillatorWidth = 0.449*fConvert;
-    fSquareScintillatorThickness = fConvert/16.0;
-    fAngledScintillatorLength  = 1.003*fConvert;
-    fAngledScintillatorLongWidth = 1.045*fConvert;
-    fAngledScintillatorShortWidth = 0.690*fConvert;
-    fAngledScintillatorThickness = fConvert/16.0;
-    fMylarThickness = 0.01*mm;
-    fScintGap = 0.75*mm;
-    fScintAngle1 = 36.0*deg;
-    fScintAngleMove = 18.0*deg;
+	fSquareScintillatorLength = 1.194*fConvert;
+	fSquareScintillatorWidth = 0.449*fConvert;
+	fSquareScintillatorThickness = fConvert/16.0;
+	fAngledScintillatorLength  = 1.003*fConvert;
+	fAngledScintillatorLongWidth = 1.045*fConvert;
+	fAngledScintillatorShortWidth = 0.690*fConvert;
+	fAngledScintillatorThickness = fConvert/16.0;
+	fMylarThickness = 0.01*mm;
+	fScintGap = 0.75*mm;
+	fScintAngle1 = 36.0*deg;
+	fScintAngleMove = 18.0*deg;
 
-    //*********This angle is the tapering along the length (10.05)
-    fScintAngle2 = atan((fAngledScintillatorLongWidth -fAngledScintillatorShortWidth)/(2.0*fAngledScintillatorLength));
+	//*********This angle is the tapering along the length (10.05)
+	fScintAngle2 = atan((fAngledScintillatorLongWidth -fAngledScintillatorShortWidth)/(2.0*fAngledScintillatorLength));
 
-    //*********This angle is the slight tapering of the sides (34.765))
-    fScintAngle3 = acos(cos(fScintAngle1)/cos(fScintAngle2));
+	//*********This angle is the slight tapering of the sides (34.765))
+	fScintAngle3 = acos(cos(fScintAngle1)/cos(fScintAngle2));
 
-    //%%%%% This is the angle that defines the packed
-    //%%%%% configuration of the angledScints
-    //%%%%%
-    fScintAngle4 = asin((fAngledScintillatorLongWidth -fAngledScintillatorShortWidth)/(2.0*fAngledScintillatorLength*tan(fScintAngle1)));
+	//%%%%% This is the angle that defines the packed
+	//%%%%% configuration of the angledScints
+	//%%%%%
+	fScintAngle4 = asin((fAngledScintillatorLongWidth -fAngledScintillatorShortWidth)/(2.0*fAngledScintillatorLength*tan(fScintAngle1)));
 
-    //%%%%% This is the radial distance from the center of the
-    //%%%%% pentagon formed by the squareDetectors to the
-    //%%%%% center of any one of the squareDetectors in that pentagon
-    //%%%%% The gap between scintillators and the mylar coating are taken into account
-    //%%%%%
-    fSquareScintRadialDistance = ((fSquareScintillatorLength +2.0*fMylarThickness +fScintGap/cos(fScintAngle1))*tan((M_PI/2.0)-fScintAngle1)-(fSquareScintillatorThickness+2.0*fMylarThickness))/2.0;
+	//%%%%% This is the radial distance from the center of the
+	//%%%%% pentagon formed by the squareDetectors to the
+	//%%%%% center of any one of the squareDetectors in that pentagon
+	//%%%%% The gap between scintillators and the mylar coating are taken into account
+	//%%%%%
+	fSquareScintRadialDistance = ((fSquareScintillatorLength +2.0*fMylarThickness +fScintGap/cos(fScintAngle1))*tan((M_PI/2.0)-fScintAngle1)-(fSquareScintillatorThickness+2.0*fMylarThickness))/2.0;
 
-    //%%%%% This is the radial distance from the axis of the
-    //%%%%% pentagon formed by the angledDetectors to the
-    //%%%%% center of any one of the angledDetectors in that pentagon
-    //%%%%% The gap between the scintillators and the mylar coating are taken into account
-    //%%%%%
-    fAngledScintRadialDistance = 0.5*(((fAngledScintillatorShortWidth +2.0*fMylarThickness +fScintGap/cos(fScintAngle1))/tan(fScintAngle1)) +(fAngledScintillatorLength+2.0*fMylarThickness)*sin(fScintAngle4)-(fAngledScintillatorThickness +2.0*fMylarThickness)*cos(fScintAngle4));
+	//%%%%% This is the radial distance from the axis of the
+	//%%%%% pentagon formed by the angledDetectors to the
+	//%%%%% center of any one of the angledDetectors in that pentagon
+	//%%%%% The gap between the scintillators and the mylar coating are taken into account
+	//%%%%%
+	fAngledScintRadialDistance = 0.5*(((fAngledScintillatorShortWidth +2.0*fMylarThickness +fScintGap/cos(fScintAngle1))/tan(fScintAngle1)) +(fAngledScintillatorLength+2.0*fMylarThickness)*sin(fScintAngle4)-(fAngledScintillatorThickness +2.0*fMylarThickness)*cos(fScintAngle4));
 
-    //%%%%% This is the distance from the origin, along-y that
-    //%%%%% the angledScints need to be moved to give
-    //%%%%% proper alignment with the squareScints
-    //%%%%% The mylar coating is taken into account
-    //%%%%%
-    fAngledScintMoveBack = fSquareScintillatorWidth -(fSquareScintRadialDistance -0.5*fSquareScintillatorThickness -0.5*fAngledScintillatorLongWidth/tan(fScintAngle1))/tan(atan((fSquareScintRadialDistance -0.5*fSquareScintillatorThickness)/fSquareScintillatorWidth))+0.5*fAngledScintillatorLength*cos(fScintAngle4);
+	//%%%%% This is the distance from the origin, along-y that
+	//%%%%% the angledScints need to be moved to give
+	//%%%%% proper alignment with the squareScints
+	//%%%%% The mylar coating is taken into account
+	//%%%%%
+	fAngledScintMoveBack = fSquareScintillatorWidth -(fSquareScintRadialDistance -0.5*fSquareScintillatorThickness -0.5*fAngledScintillatorLongWidth/tan(fScintAngle1))/tan(atan((fSquareScintRadialDistance -0.5*fSquareScintillatorThickness)/fSquareScintillatorWidth))+0.5*fAngledScintillatorLength*cos(fScintAngle4);
 
-    fDelrinInnerRadius = 3.275*fConvert;
-    fDelrinOuterRadius = 3.475*fConvert;
-    fDelrin2InnerRadius = 8.90*cm;
-    fDelrin2OuterRadius = 9.90*cm;
-    fHevimetInnerRadius = 9.906*cm;
-    fHevimetOuterRadius = 12.446*cm;
-    fDelrinHoleRadius = 1.25*fConvert;
+	fDelrinInnerRadius = 3.275*fConvert;
+	fDelrinOuterRadius = 3.475*fConvert;
+	fDelrin2InnerRadius = 8.90*cm;
+	fDelrin2OuterRadius = 9.90*cm;
+	fHevimetInnerRadius = 9.906*cm;
+	fHevimetOuterRadius = 12.446*cm;
+	fDelrinHoleRadius = 1.25*fConvert;
 }
 
 DetectionSystemSceptar::~DetectionSystemSceptar() {
-    // LogicalVolumes
-    delete fSquareMylarLog;
-    delete fAngledMylarLog;
-    delete fSquareScintillatorLog;
-    delete fAngledScintillatorLog;
-    delete fDelrinShellLog;
-    delete fDelrinShell2Log;
-    delete fHevimetShellLog;
+	// LogicalVolumes
+	delete fSquareMylarLog;
+	delete fAngledMylarLog;
+	delete fSquareScintillatorLog;
+	delete fAngledScintillatorLog;
+	delete fDelrinShellLog;
+	delete fDelrinShell2Log;
+	delete fHevimetShellLog;
 }
 
 G4int DetectionSystemSceptar::Build() {
-    // Build assembly volume
-    fAssembly = new G4AssemblyVolume();
-    fAssemblySquare = new G4AssemblyVolume();
-    fAssemblyAngled = new G4AssemblyVolume();
-    fAssemblySquareSD = new G4AssemblyVolume();
-    fAssemblyAngledSD = new G4AssemblyVolume();
+	// Build assembly volume
+	fAssembly = new G4AssemblyVolume();
+	fAssemblySquare = new G4AssemblyVolume();
+	fAssemblyAngled = new G4AssemblyVolume();
+	fAssemblySquareSD = new G4AssemblyVolume();
+	fAssemblyAngledSD = new G4AssemblyVolume();
 
-    ConstructScintillator();
-    //  ConstructDelrinShell();
-    //  Construct2ndDelrinShell();
-    //  ConstructHevimetShell();
+	ConstructScintillator();
+	//  ConstructDelrinShell();
+	//  Construct2ndDelrinShell();
+	//  ConstructHevimetShell();
 
-    return 1;
+	return 1;
 }
 
 G4int DetectionSystemSceptar::PlaceDetector(G4LogicalVolume* expHallLog, G4int detectorNumber) {
 
-    //G4RotationMatrix* rotateNull = new G4RotationMatrix;
-    G4ThreeVector moveNull(0.0,0.0,0.0);
+	//G4RotationMatrix* rotateNull = new G4RotationMatrix;
+	G4ThreeVector moveNull(0.0,0.0,0.0);
 
-    G4double extra = 2.0*fMylarThickness;
+	G4double extra = 2.0*fMylarThickness;
 
-    G4RotationMatrix* rotate = new G4RotationMatrix;
-    G4ThreeVector move;
+	G4RotationMatrix* rotate = new G4RotationMatrix;
+	G4ThreeVector move;
 
-    G4RotationMatrix* rotateSquareScint1 = new G4RotationMatrix;
-    rotateSquareScint1->rotateX(M_PI/2.0);
-    rotateSquareScint1->rotateZ(M_PI/2.0);
-    G4ThreeVector moveSquareScint1(	-fSquareScintRadialDistance ,
-                                        0,
-                                        -(fSquareScintillatorWidth +extra + fSeparateHemispheres)/2.0);
+	G4RotationMatrix* rotateSquareScint1 = new G4RotationMatrix;
+	rotateSquareScint1->rotateX(M_PI/2.0);
+	rotateSquareScint1->rotateZ(M_PI/2.0);
+	G4ThreeVector moveSquareScint1(	-fSquareScintRadialDistance ,
+			0,
+			-(fSquareScintillatorWidth +extra + fSeparateHemispheres)/2.0);
 
-    G4RotationMatrix* rotateSquareScint2 = new G4RotationMatrix;
-    rotateSquareScint2->rotateY(-1.0*(2.0*fScintAngle1));
-    rotateSquareScint2->rotateX(M_PI/2.0);
-    rotateSquareScint2->rotateZ(M_PI/2.0);
-    G4ThreeVector moveSquareScint2(	-fSquareScintRadialDistance*cos(2.0*fScintAngle1),
-                                        fSquareScintRadialDistance*sin(2.0*fScintAngle1),
-                                        -(fSquareScintillatorWidth +extra + fSeparateHemispheres) / 2.0 ) ;
+	G4RotationMatrix* rotateSquareScint2 = new G4RotationMatrix;
+	rotateSquareScint2->rotateY(-1.0*(2.0*fScintAngle1));
+	rotateSquareScint2->rotateX(M_PI/2.0);
+	rotateSquareScint2->rotateZ(M_PI/2.0);
+	G4ThreeVector moveSquareScint2(	-fSquareScintRadialDistance*cos(2.0*fScintAngle1),
+			fSquareScintRadialDistance*sin(2.0*fScintAngle1),
+			-(fSquareScintillatorWidth +extra + fSeparateHemispheres) / 2.0) ;
 
-    G4RotationMatrix* rotateSquareScint3 = new G4RotationMatrix;
-    rotateSquareScint3->rotateY(-1.0*(M_PI -fScintAngle1));
-    rotateSquareScint3->rotateX(M_PI/2.0);
-    rotateSquareScint3->rotateZ(M_PI/2.0);
-    G4ThreeVector moveSquareScint3(	fSquareScintRadialDistance*cos(fScintAngle1),
-                                        fSquareScintRadialDistance*sin(fScintAngle1),
-                                        -(fSquareScintillatorWidth +extra + fSeparateHemispheres) / 2.0 ) ;
+	G4RotationMatrix* rotateSquareScint3 = new G4RotationMatrix;
+	rotateSquareScint3->rotateY(-1.0*(M_PI -fScintAngle1));
+	rotateSquareScint3->rotateX(M_PI/2.0);
+	rotateSquareScint3->rotateZ(M_PI/2.0);
+	G4ThreeVector moveSquareScint3(	fSquareScintRadialDistance*cos(fScintAngle1),
+			fSquareScintRadialDistance*sin(fScintAngle1),
+			-(fSquareScintillatorWidth +extra + fSeparateHemispheres) / 2.0) ;
 
-    G4RotationMatrix* rotateSquareScint4 = new G4RotationMatrix;
-    rotateSquareScint4->rotateY(-1.0*(fScintAngle1 -M_PI));
-    rotateSquareScint4->rotateX(M_PI/2.0);
-    rotateSquareScint4->rotateZ(M_PI/2.0);
-    G4ThreeVector moveSquareScint4(	fSquareScintRadialDistance*cos(fScintAngle1),
-                                        -fSquareScintRadialDistance*sin(fScintAngle1),
-                                        -(fSquareScintillatorWidth +extra + fSeparateHemispheres) / 2.0 ) ;
+	G4RotationMatrix* rotateSquareScint4 = new G4RotationMatrix;
+	rotateSquareScint4->rotateY(-1.0*(fScintAngle1 -M_PI));
+	rotateSquareScint4->rotateX(M_PI/2.0);
+	rotateSquareScint4->rotateZ(M_PI/2.0);
+	G4ThreeVector moveSquareScint4(	fSquareScintRadialDistance*cos(fScintAngle1),
+			-fSquareScintRadialDistance*sin(fScintAngle1),
+			-(fSquareScintillatorWidth +extra + fSeparateHemispheres) / 2.0) ;
 
-    G4RotationMatrix* rotateSquareScint5 = new G4RotationMatrix;
-    rotateSquareScint5->rotateY(-1.0*(-2.0*fScintAngle1));
-    rotateSquareScint5->rotateX(M_PI/2.0);
-    rotateSquareScint5->rotateZ(M_PI/2.0);
-    G4ThreeVector moveSquareScint5(	-fSquareScintRadialDistance*cos(2.0*fScintAngle1),
-                                        -fSquareScintRadialDistance*sin(2.0*fScintAngle1),
-                                        -(fSquareScintillatorWidth +extra + fSeparateHemispheres) / 2.0 ) ;
+	G4RotationMatrix* rotateSquareScint5 = new G4RotationMatrix;
+	rotateSquareScint5->rotateY(-1.0*(-2.0*fScintAngle1));
+	rotateSquareScint5->rotateX(M_PI/2.0);
+	rotateSquareScint5->rotateZ(M_PI/2.0);
+	G4ThreeVector moveSquareScint5(	-fSquareScintRadialDistance*cos(2.0*fScintAngle1),
+			-fSquareScintRadialDistance*sin(2.0*fScintAngle1),
+			-(fSquareScintillatorWidth +extra + fSeparateHemispheres) / 2.0) ;
 
-    G4RotationMatrix* rotateSquareScint6 = new G4RotationMatrix;
-    rotateSquareScint6->rotateY(M_PI);
-    rotateSquareScint6->rotateX(M_PI/2.0);
-    rotateSquareScint6->rotateZ(M_PI/2.0);
-    G4ThreeVector moveSquareScint6;
-    moveSquareScint6 = - 1.0 * moveSquareScint1;
+	G4RotationMatrix* rotateSquareScint6 = new G4RotationMatrix;
+	rotateSquareScint6->rotateY(M_PI);
+	rotateSquareScint6->rotateX(M_PI/2.0);
+	rotateSquareScint6->rotateZ(M_PI/2.0);
+	G4ThreeVector moveSquareScint6;
+	moveSquareScint6 = - 1.0 * moveSquareScint1;
 
-    G4RotationMatrix* rotateSquareScint7 = new G4RotationMatrix;
-    rotateSquareScint7->rotateY(-1.0*(2.0*fScintAngle1 -M_PI));
-    rotateSquareScint7->rotateX(M_PI/2.0);
-    rotateSquareScint7->rotateZ(M_PI/2.0);
-    G4ThreeVector moveSquareScint7;
-    moveSquareScint7 = -1.0*moveSquareScint2;
+	G4RotationMatrix* rotateSquareScint7 = new G4RotationMatrix;
+	rotateSquareScint7->rotateY(-1.0*(2.0*fScintAngle1 -M_PI));
+	rotateSquareScint7->rotateX(M_PI/2.0);
+	rotateSquareScint7->rotateZ(M_PI/2.0);
+	G4ThreeVector moveSquareScint7;
+	moveSquareScint7 = -1.0*moveSquareScint2;
 
-    G4RotationMatrix* rotateSquareScint8 = new G4RotationMatrix;
-    rotateSquareScint8->rotateY(-1.0*(-fScintAngle1));
-    rotateSquareScint8->rotateX(M_PI/2.0);
-    rotateSquareScint8->rotateZ(M_PI/2.0);
-    G4ThreeVector moveSquareScint8;
-    moveSquareScint8 = -1.0*moveSquareScint3;
+	G4RotationMatrix* rotateSquareScint8 = new G4RotationMatrix;
+	rotateSquareScint8->rotateY(-1.0*(-fScintAngle1));
+	rotateSquareScint8->rotateX(M_PI/2.0);
+	rotateSquareScint8->rotateZ(M_PI/2.0);
+	G4ThreeVector moveSquareScint8;
+	moveSquareScint8 = -1.0*moveSquareScint3;
 
-    G4RotationMatrix* rotateSquareScint9 = new G4RotationMatrix;
-    rotateSquareScint9->rotateY(-1.0*(fScintAngle1));
-    rotateSquareScint9->rotateX(M_PI/2.0);
-    rotateSquareScint9->rotateZ(M_PI/2.0);
-    G4ThreeVector moveSquareScint9;
-    moveSquareScint9 = -1.0*moveSquareScint4;
+	G4RotationMatrix* rotateSquareScint9 = new G4RotationMatrix;
+	rotateSquareScint9->rotateY(-1.0*(fScintAngle1));
+	rotateSquareScint9->rotateX(M_PI/2.0);
+	rotateSquareScint9->rotateZ(M_PI/2.0);
+	G4ThreeVector moveSquareScint9;
+	moveSquareScint9 = -1.0*moveSquareScint4;
 
-    G4RotationMatrix* rotateSquareScint10 = new G4RotationMatrix;
-    rotateSquareScint10->rotateY(-1.0*(-2.0*fScintAngle1 -M_PI));
-    rotateSquareScint10->rotateX(M_PI/2.0);
-    rotateSquareScint10->rotateZ(M_PI/2.0);
-    G4ThreeVector moveSquareScint10;
-    moveSquareScint10 = -1.0*moveSquareScint5;
+	G4RotationMatrix* rotateSquareScint10 = new G4RotationMatrix;
+	rotateSquareScint10->rotateY(-1.0*(-2.0*fScintAngle1 -M_PI));
+	rotateSquareScint10->rotateX(M_PI/2.0);
+	rotateSquareScint10->rotateZ(M_PI/2.0);
+	G4ThreeVector moveSquareScint10;
+	moveSquareScint10 = -1.0*moveSquareScint5;
 
-    G4RotationMatrix* rotateAngledScint1 = new G4RotationMatrix;
-    rotateAngledScint1->rotateX(-1.0*(fScintAngle4 -M_PI/2.0));
-    rotateAngledScint1->rotateX(M_PI/2.0);
-    rotateAngledScint1->rotateZ(M_PI/2.0);
-    G4ThreeVector moveAngledScint1(	-fAngledScintRadialDistance,
-                                        0,
-                                        -fAngledScintMoveBack);
+	G4RotationMatrix* rotateAngledScint1 = new G4RotationMatrix;
+	rotateAngledScint1->rotateX(-1.0*(fScintAngle4 -M_PI/2.0));
+	rotateAngledScint1->rotateX(M_PI/2.0);
+	rotateAngledScint1->rotateZ(M_PI/2.0);
+	G4ThreeVector moveAngledScint1(	-fAngledScintRadialDistance,
+			0,
+			-fAngledScintMoveBack);
 
-    G4RotationMatrix* rotateAngledScint2 = new G4RotationMatrix;
-    rotateAngledScint2->rotateX(-1.0*(fScintAngle4));
-    rotateAngledScint2->rotateZ(-1.0*(-2.0*fScintAngle1));
-    rotateAngledScint2->rotateX(M_PI);
-    rotateAngledScint2->rotateZ(M_PI/2.0);
-    G4ThreeVector moveAngledScint2(	-fAngledScintRadialDistance*cos(2.0*fScintAngle1),
-                                        fAngledScintRadialDistance*sin(2.0*fScintAngle1),
-                                        -fAngledScintMoveBack);
+	G4RotationMatrix* rotateAngledScint2 = new G4RotationMatrix;
+	rotateAngledScint2->rotateX(-1.0*(fScintAngle4));
+	rotateAngledScint2->rotateZ(-1.0*(-2.0*fScintAngle1));
+	rotateAngledScint2->rotateX(M_PI);
+	rotateAngledScint2->rotateZ(M_PI/2.0);
+	G4ThreeVector moveAngledScint2(	-fAngledScintRadialDistance*cos(2.0*fScintAngle1),
+			fAngledScintRadialDistance*sin(2.0*fScintAngle1),
+			-fAngledScintMoveBack);
 
-    G4RotationMatrix* rotateAngledScint3 = new G4RotationMatrix;
-    rotateAngledScint3->rotateX(-1.0*(fScintAngle4));
-    rotateAngledScint3->rotateZ(-1.0*(fScintAngle1 -M_PI));
-    rotateAngledScint3->rotateX(M_PI);
-    rotateAngledScint3->rotateZ(M_PI/2.0);
-    G4ThreeVector moveAngledScint3(	fAngledScintRadialDistance*cos(fScintAngle1),
-                                        fAngledScintRadialDistance*sin(fScintAngle1),
-                                        -fAngledScintMoveBack);
+	G4RotationMatrix* rotateAngledScint3 = new G4RotationMatrix;
+	rotateAngledScint3->rotateX(-1.0*(fScintAngle4));
+	rotateAngledScint3->rotateZ(-1.0*(fScintAngle1 -M_PI));
+	rotateAngledScint3->rotateX(M_PI);
+	rotateAngledScint3->rotateZ(M_PI/2.0);
+	G4ThreeVector moveAngledScint3(	fAngledScintRadialDistance*cos(fScintAngle1),
+			fAngledScintRadialDistance*sin(fScintAngle1),
+			-fAngledScintMoveBack);
 
-    G4RotationMatrix* rotateAngledScint4 = new G4RotationMatrix;
-    rotateAngledScint4->rotateX(-1.0*(fScintAngle4));
-    rotateAngledScint4->rotateZ(-1.0*(M_PI -fScintAngle1));
-    rotateAngledScint4->rotateX(M_PI);
-    rotateAngledScint4->rotateZ(M_PI/2.0);
-    G4ThreeVector moveAngledScint4(	fAngledScintRadialDistance*cos(fScintAngle1),
-                                        -fAngledScintRadialDistance*sin(fScintAngle1),
-                                        -fAngledScintMoveBack);
+	G4RotationMatrix* rotateAngledScint4 = new G4RotationMatrix;
+	rotateAngledScint4->rotateX(-1.0*(fScintAngle4));
+	rotateAngledScint4->rotateZ(-1.0*(M_PI -fScintAngle1));
+	rotateAngledScint4->rotateX(M_PI);
+	rotateAngledScint4->rotateZ(M_PI/2.0);
+	G4ThreeVector moveAngledScint4(	fAngledScintRadialDistance*cos(fScintAngle1),
+			-fAngledScintRadialDistance*sin(fScintAngle1),
+			-fAngledScintMoveBack);
 
-    G4RotationMatrix* rotateAngledScint5 = new G4RotationMatrix;
-    rotateAngledScint5->rotateX(-1.0*(fScintAngle4));
-    rotateAngledScint5->rotateZ(-1.0*(2.0*fScintAngle1));
-    rotateAngledScint5->rotateX(M_PI);
-    rotateAngledScint5->rotateZ(M_PI/2.0);
-    G4ThreeVector moveAngledScint5(	-fAngledScintRadialDistance*cos(2.0*fScintAngle1),
-                                        -fAngledScintRadialDistance*sin(2.0*fScintAngle1),
-                                        -fAngledScintMoveBack);
+	G4RotationMatrix* rotateAngledScint5 = new G4RotationMatrix;
+	rotateAngledScint5->rotateX(-1.0*(fScintAngle4));
+	rotateAngledScint5->rotateZ(-1.0*(2.0*fScintAngle1));
+	rotateAngledScint5->rotateX(M_PI);
+	rotateAngledScint5->rotateZ(M_PI/2.0);
+	G4ThreeVector moveAngledScint5(	-fAngledScintRadialDistance*cos(2.0*fScintAngle1),
+			-fAngledScintRadialDistance*sin(2.0*fScintAngle1),
+			-fAngledScintMoveBack);
 
-    G4RotationMatrix* rotateAngledScint6 = new G4RotationMatrix;
-    rotateAngledScint6->rotateX(-1.0*(fScintAngle4 +M_PI/2.0));
-    rotateAngledScint6->rotateX(M_PI/2.0);
-    rotateAngledScint6->rotateZ(M_PI/2.0);
-    G4ThreeVector moveAngledScint6;
-    moveAngledScint6 = -1.0*moveAngledScint1;
+	G4RotationMatrix* rotateAngledScint6 = new G4RotationMatrix;
+	rotateAngledScint6->rotateX(-1.0*(fScintAngle4 +M_PI/2.0));
+	rotateAngledScint6->rotateX(M_PI/2.0);
+	rotateAngledScint6->rotateZ(M_PI/2.0);
+	G4ThreeVector moveAngledScint6;
+	moveAngledScint6 = -1.0*moveAngledScint1;
 
-    G4RotationMatrix* rotateAngledScint7 = new G4RotationMatrix;
-    rotateAngledScint7->rotateX(-1.0*(fScintAngle4));
-    rotateAngledScint7->rotateZ(-1.0*(2.0*fScintAngle1));
-    rotateAngledScint7->rotateZ(M_PI/2.0);
-    G4ThreeVector moveAngledScint7;
-    moveAngledScint7 = -1.0*moveAngledScint2;
+	G4RotationMatrix* rotateAngledScint7 = new G4RotationMatrix;
+	rotateAngledScint7->rotateX(-1.0*(fScintAngle4));
+	rotateAngledScint7->rotateZ(-1.0*(2.0*fScintAngle1));
+	rotateAngledScint7->rotateZ(M_PI/2.0);
+	G4ThreeVector moveAngledScint7;
+	moveAngledScint7 = -1.0*moveAngledScint2;
 
-    G4RotationMatrix* rotateAngledScint8 = new G4RotationMatrix;
-    rotateAngledScint8->rotateX(-1.0*(fScintAngle4));
-    rotateAngledScint8->rotateZ(-1.0*(M_PI -fScintAngle1));
-    rotateAngledScint8->rotateZ(M_PI/2.0);
-    G4ThreeVector moveAngledScint8;
-    moveAngledScint8 = -1.0*moveAngledScint3;
+	G4RotationMatrix* rotateAngledScint8 = new G4RotationMatrix;
+	rotateAngledScint8->rotateX(-1.0*(fScintAngle4));
+	rotateAngledScint8->rotateZ(-1.0*(M_PI -fScintAngle1));
+	rotateAngledScint8->rotateZ(M_PI/2.0);
+	G4ThreeVector moveAngledScint8;
+	moveAngledScint8 = -1.0*moveAngledScint3;
 
-    G4RotationMatrix* rotateAngledScint9 = new G4RotationMatrix;
-    rotateAngledScint9->rotateX(-1.0*(fScintAngle4));
-    rotateAngledScint9->rotateZ(-1.0*(fScintAngle1 -M_PI));
-    rotateAngledScint9->rotateZ(M_PI/2.0);
-    G4ThreeVector moveAngledScint9;
-    moveAngledScint9 = -1.0*moveAngledScint4;
+	G4RotationMatrix* rotateAngledScint9 = new G4RotationMatrix;
+	rotateAngledScint9->rotateX(-1.0*(fScintAngle4));
+	rotateAngledScint9->rotateZ(-1.0*(fScintAngle1 -M_PI));
+	rotateAngledScint9->rotateZ(M_PI/2.0);
+	G4ThreeVector moveAngledScint9;
+	moveAngledScint9 = -1.0*moveAngledScint4;
 
-    G4RotationMatrix* rotateAngledScint10 = new G4RotationMatrix;
-    rotateAngledScint10->rotateX(-1.0*(fScintAngle4));
-    rotateAngledScint10->rotateZ(-1.0*(-2.0*fScintAngle1));
-    rotateAngledScint10->rotateZ(M_PI/2.0);
-    G4ThreeVector moveAngledScint10;
-    moveAngledScint10 = -1.0*moveAngledScint5;
+	G4RotationMatrix* rotateAngledScint10 = new G4RotationMatrix;
+	rotateAngledScint10->rotateX(-1.0*(fScintAngle4));
+	rotateAngledScint10->rotateZ(-1.0*(-2.0*fScintAngle1));
+	rotateAngledScint10->rotateZ(M_PI/2.0);
+	G4ThreeVector moveAngledScint10;
+	moveAngledScint10 = -1.0*moveAngledScint5;
 
-    for(G4int detNum = 0; detNum < detectorNumber; detNum++) {
-        if(detNum == 0) {
-            rotate = rotateSquareScint6;
-            move = moveSquareScint6;
-            move.rotateZ(fScintAngleMove);
-            rotate->rotateZ(fScintAngleMove);
-        } else if(detNum == 1) {
-            rotate = rotateSquareScint7;
-            move = moveSquareScint7;
-            move.rotateZ(fScintAngleMove);
-            rotate->rotateZ(fScintAngleMove);
-        } else if(detNum == 2) {
-            rotate = rotateSquareScint8;
-            move = moveSquareScint8;
-            move.rotateZ(fScintAngleMove);
-            rotate->rotateZ(fScintAngleMove);
-        } else if(detNum == 3) {
-            rotate = rotateSquareScint9;
-            move = moveSquareScint9;
-            move.rotateZ(fScintAngleMove);
-            rotate->rotateZ(fScintAngleMove);
-        } else if(detNum == 4) {
-            rotate = rotateSquareScint10;
-            move = moveSquareScint10;
-            move.rotateZ(fScintAngleMove);
-            rotate->rotateZ(fScintAngleMove);
-        } else if(detNum == 5) {
-            rotate = rotateAngledScint6;
-            move = moveAngledScint6;
-            move.rotateZ(fScintAngleMove);
-            rotate->rotateZ(fScintAngleMove);
-        } else if(detNum == 6) {
-            rotate = rotateAngledScint7;
-            move = moveAngledScint7;
-            move.rotateZ(fScintAngleMove);
-            rotate->rotateZ(fScintAngleMove);
-        } else if(detNum == 7) {
-            rotate = rotateAngledScint8;
-            move = moveAngledScint8;
-            move.rotateZ(fScintAngleMove);
-            rotate->rotateZ(fScintAngleMove);
-        } else if(detNum == 8) {
-            rotate = rotateAngledScint9;
-            move = moveAngledScint9;
-            move.rotateZ(fScintAngleMove);
-            rotate->rotateZ(fScintAngleMove);
-        } else if(detNum == 9) {
-            rotate = rotateAngledScint10;
-            move = moveAngledScint10;
-            move.rotateZ(fScintAngleMove);
-            rotate->rotateZ(fScintAngleMove);
-        } else if(detNum == 10) {
-            rotate = rotateSquareScint1;
-            move = moveSquareScint1;
-            move.rotateZ(fScintAngleMove+fScintAngle1);
-            rotate->rotateZ(fScintAngleMove+fScintAngle1);
-        } else if(detNum == 11) {
-            rotate = rotateSquareScint2;
-            move = moveSquareScint2;
-            move.rotateZ(fScintAngleMove+fScintAngle1);
-            rotate->rotateZ(fScintAngleMove+fScintAngle1);
-        } else if(detNum == 12) {
-            rotate = rotateSquareScint3;
-            move = moveSquareScint3;
-            move.rotateZ(fScintAngleMove+fScintAngle1);
-            rotate->rotateZ(fScintAngleMove+fScintAngle1);
-        } else if(detNum == 13) {
-            rotate = rotateSquareScint4;
-            move = moveSquareScint4;
-            move.rotateZ(fScintAngleMove+fScintAngle1);
-            rotate->rotateZ(fScintAngleMove+fScintAngle1);
-        } else if(detNum == 14) {
-            rotate = rotateSquareScint5;
-            move = moveSquareScint5;
-            move.rotateZ(fScintAngleMove+fScintAngle1);
-            rotate->rotateZ(fScintAngleMove+fScintAngle1);
-        } else if(detNum == 15) {
-            rotate = rotateAngledScint1;
-            move = moveAngledScint1;
-            move.rotateZ(fScintAngleMove+fScintAngle1);
-            rotate->rotateZ(fScintAngleMove+fScintAngle1);
-        } else if(detNum == 16) {
-            rotate = rotateAngledScint2;
-            move = moveAngledScint2;
-            move.rotateZ(fScintAngleMove+fScintAngle1);
-            rotate->rotateZ(fScintAngleMove+fScintAngle1);
-        } else if(detNum == 17) {
-            rotate = rotateAngledScint3;
-            move = moveAngledScint3;
-            move.rotateZ(fScintAngleMove+fScintAngle1);
-            rotate->rotateZ(fScintAngleMove+fScintAngle1);
-        } else if(detNum == 18) {
-            rotate = rotateAngledScint4;
-            move = moveAngledScint4;
-            move.rotateZ(fScintAngleMove+fScintAngle1);
-            rotate->rotateZ(fScintAngleMove+fScintAngle1);
-        } else if(detNum == 19) {
-            rotate = rotateAngledScint5;
-            move = moveAngledScint5;
-            move.rotateZ(fScintAngleMove+fScintAngle1);
-            rotate->rotateZ(fScintAngleMove+fScintAngle1);
-        }
+	for(G4int detNum = 0; detNum < detectorNumber; detNum++) {
+		if(detNum == 0) {
+			rotate = rotateSquareScint6;
+			move = moveSquareScint6;
+			move.rotateZ(fScintAngleMove);
+			rotate->rotateZ(fScintAngleMove);
+		} else if(detNum == 1) {
+			rotate = rotateSquareScint7;
+			move = moveSquareScint7;
+			move.rotateZ(fScintAngleMove);
+			rotate->rotateZ(fScintAngleMove);
+		} else if(detNum == 2) {
+			rotate = rotateSquareScint8;
+			move = moveSquareScint8;
+			move.rotateZ(fScintAngleMove);
+			rotate->rotateZ(fScintAngleMove);
+		} else if(detNum == 3) {
+			rotate = rotateSquareScint9;
+			move = moveSquareScint9;
+			move.rotateZ(fScintAngleMove);
+			rotate->rotateZ(fScintAngleMove);
+		} else if(detNum == 4) {
+			rotate = rotateSquareScint10;
+			move = moveSquareScint10;
+			move.rotateZ(fScintAngleMove);
+			rotate->rotateZ(fScintAngleMove);
+		} else if(detNum == 5) {
+			rotate = rotateAngledScint6;
+			move = moveAngledScint6;
+			move.rotateZ(fScintAngleMove);
+			rotate->rotateZ(fScintAngleMove);
+		} else if(detNum == 6) {
+			rotate = rotateAngledScint7;
+			move = moveAngledScint7;
+			move.rotateZ(fScintAngleMove);
+			rotate->rotateZ(fScintAngleMove);
+		} else if(detNum == 7) {
+			rotate = rotateAngledScint8;
+			move = moveAngledScint8;
+			move.rotateZ(fScintAngleMove);
+			rotate->rotateZ(fScintAngleMove);
+		} else if(detNum == 8) {
+			rotate = rotateAngledScint9;
+			move = moveAngledScint9;
+			move.rotateZ(fScintAngleMove);
+			rotate->rotateZ(fScintAngleMove);
+		} else if(detNum == 9) {
+			rotate = rotateAngledScint10;
+			move = moveAngledScint10;
+			move.rotateZ(fScintAngleMove);
+			rotate->rotateZ(fScintAngleMove);
+		} else if(detNum == 10) {
+			rotate = rotateSquareScint1;
+			move = moveSquareScint1;
+			move.rotateZ(fScintAngleMove+fScintAngle1);
+			rotate->rotateZ(fScintAngleMove+fScintAngle1);
+		} else if(detNum == 11) {
+			rotate = rotateSquareScint2;
+			move = moveSquareScint2;
+			move.rotateZ(fScintAngleMove+fScintAngle1);
+			rotate->rotateZ(fScintAngleMove+fScintAngle1);
+		} else if(detNum == 12) {
+			rotate = rotateSquareScint3;
+			move = moveSquareScint3;
+			move.rotateZ(fScintAngleMove+fScintAngle1);
+			rotate->rotateZ(fScintAngleMove+fScintAngle1);
+		} else if(detNum == 13) {
+			rotate = rotateSquareScint4;
+			move = moveSquareScint4;
+			move.rotateZ(fScintAngleMove+fScintAngle1);
+			rotate->rotateZ(fScintAngleMove+fScintAngle1);
+		} else if(detNum == 14) {
+			rotate = rotateSquareScint5;
+			move = moveSquareScint5;
+			move.rotateZ(fScintAngleMove+fScintAngle1);
+			rotate->rotateZ(fScintAngleMove+fScintAngle1);
+		} else if(detNum == 15) {
+			rotate = rotateAngledScint1;
+			move = moveAngledScint1;
+			move.rotateZ(fScintAngleMove+fScintAngle1);
+			rotate->rotateZ(fScintAngleMove+fScintAngle1);
+		} else if(detNum == 16) {
+			rotate = rotateAngledScint2;
+			move = moveAngledScint2;
+			move.rotateZ(fScintAngleMove+fScintAngle1);
+			rotate->rotateZ(fScintAngleMove+fScintAngle1);
+		} else if(detNum == 17) {
+			rotate = rotateAngledScint3;
+			move = moveAngledScint3;
+			move.rotateZ(fScintAngleMove+fScintAngle1);
+			rotate->rotateZ(fScintAngleMove+fScintAngle1);
+		} else if(detNum == 18) {
+			rotate = rotateAngledScint4;
+			move = moveAngledScint4;
+			move.rotateZ(fScintAngleMove+fScintAngle1);
+			rotate->rotateZ(fScintAngleMove+fScintAngle1);
+		} else if(detNum == 19) {
+			rotate = rotateAngledScint5;
+			move = moveAngledScint5;
+			move.rotateZ(fScintAngleMove+fScintAngle1);
+			rotate->rotateZ(fScintAngleMove+fScintAngle1);
+		}
 
 
 
-        if( (detNum < 5) || (detNum >= 10 && detNum < 15) ) {
-            fAssemblySquareSD->MakeImprint(expHallLog, move, rotate, 0);
-            fAssemblySquare->MakeImprint(expHallLog, move, rotate, 0);
-        }
-        if( (detNum >= 5 && detNum < 10) || (detNum >= 15) ) {
-            fAssemblyAngledSD->MakeImprint(expHallLog, move, rotate, 0);
-            fAssemblyAngled->MakeImprint(expHallLog, move, rotate, 0);
-        }
+		if((detNum < 5) || (detNum >= 10 && detNum < 15)) {
+			fAssemblySquareSD->MakeImprint(expHallLog, move, rotate, 0);
+			fAssemblySquare->MakeImprint(expHallLog, move, rotate, 0);
+		}
+		if((detNum >= 5 && detNum < 10) || (detNum >= 15)) {
+			fAssemblyAngledSD->MakeImprint(expHallLog, move, rotate, 0);
+			fAssemblyAngled->MakeImprint(expHallLog, move, rotate, 0);
+		}
 
-    }
+	}
 
-    return 1;
+	return 1;
 }
 
 G4int DetectionSystemSceptar::ConstructScintillator() {
-    G4Material* materialMylar = G4Material::GetMaterial("Mylar");
-    if( !materialMylar ) {
-        G4cout << " ----> Material " << "Mylar" << " not found, cannot build the detector shell! " << G4endl;
-        return 0;
-    }
-    G4Material* materialBc404 = G4Material::GetMaterial("BC404");
-    if( !materialBc404 ) {
-        G4cout << " ----> Material " << "BC404" << " not found, cannot build the detector shell! " << G4endl;
-        return 0;
-    }
+	G4Material* materialMylar = G4Material::GetMaterial("Mylar");
+	if(!materialMylar) {
+		G4cout<<" ----> Material "<<"Mylar"<<" not found, cannot build the detector shell! "<<G4endl;
+		return 0;
+	}
+	G4Material* materialBc404 = G4Material::GetMaterial("BC404");
+	if(!materialBc404) {
+		G4cout<<" ----> Material "<<"BC404"<<" not found, cannot build the detector shell! "<<G4endl;
+		return 0;
+	}
 
-    G4ThreeVector moveNew;
+	G4ThreeVector moveNew;
 
-    // Set visualization attributes
-    G4VisAttributes* scintillatorVisAtt = new G4VisAttributes(G4Colour(0.0,0.3,0.7));
-    scintillatorVisAtt->SetVisibility(true);
-    G4VisAttributes* mylarVisAtt = new G4VisAttributes(G4Colour(0.6,0.6,0.6));
-    mylarVisAtt->SetVisibility(true);
+	// Set visualization attributes
+	G4VisAttributes* scintillatorVisAtt = new G4VisAttributes(G4Colour(0.0,0.3,0.7));
+	scintillatorVisAtt->SetVisibility(true);
+	G4VisAttributes* mylarVisAtt = new G4VisAttributes(G4Colour(0.6,0.6,0.6));
+	mylarVisAtt->SetVisibility(true);
 
-    //G4double extra = 2.0*fMylarThickness;
+	//G4double extra = 2.0*fMylarThickness;
 
-    //&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&
-    //&&&&&&& Making the square-ish shaped scintillators 1-5 are &&&&&&&
-    //&&&&&&& neg-y of origin, while 6-10 are in pos-y of origin &&&&&&&
-    //&&&&&&& NOTE: this numbering scheme does not reflect the   &&&&&&&
-    //&&&&&&&    actual way the detectors will be numbered       &&&&&&&
-    //&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&
+	//&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&
+	//&&&&&&& Making the square-ish shaped scintillators 1-5 are &&&&&&&
+	//&&&&&&& neg-y of origin, while 6-10 are in pos-y of origin &&&&&&&
+	//&&&&&&& NOTE: this numbering scheme does not reflect the   &&&&&&&
+	//&&&&&&&    actual way the detectors will be numbered       &&&&&&&
+	//&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&
 
-    //******* Making the Mylar coating
+	//******* Making the Mylar coating
 
-    //  G4Trd* squareMylar = squareMylar();
+	//  G4Trd* squareMylar = squareMylar();
 
-    G4SubtractionSolid* squareMylar = SquareMylarWithCut();
+	G4SubtractionSolid* squareMylar = SquareMylarWithCut();
 
-    fSquareMylarLog = new G4LogicalVolume(squareMylar, materialMylar, "squareScintillatorLog", 0, 0, 0);
-    fSquareMylarLog->SetVisAttributes(mylarVisAtt);
+	fSquareMylarLog = new G4LogicalVolume(squareMylar, materialMylar, "squareScintillatorLog", 0, 0, 0);
+	fSquareMylarLog->SetVisAttributes(mylarVisAtt);
 
-    //******* Making the square scint and putting it in the Mylar
+	//******* Making the square scint and putting it in the Mylar
 
-    G4Trd* squareScintillator = SquareScintillator();
+	G4Trd* squareScintillator = SquareScintillator();
 
-    fSquareScintillatorLog = new G4LogicalVolume(squareScintillator, materialBc404, "sceptarSquareScintillatorLog", 0, 0, 0);
-    fSquareScintillatorLog->SetVisAttributes(scintillatorVisAtt);
+	fSquareScintillatorLog = new G4LogicalVolume(squareScintillator, materialBc404, "sceptarSquareScintillatorLog", 0, 0, 0);
+	fSquareScintillatorLog->SetVisAttributes(scintillatorVisAtt);
 
-    G4RotationMatrix* rotateNull = new G4RotationMatrix;
-    G4ThreeVector moveNull(0.0,0.0,0.0);
+	G4RotationMatrix* rotateNull = new G4RotationMatrix;
+	G4ThreeVector moveNull(0.0,0.0,0.0);
 
-    fAssemblySquare->AddPlacedVolume(fSquareMylarLog, moveNull, rotateNull);
-    fAssemblySquareSD->AddPlacedVolume(fSquareScintillatorLog, moveNull, rotateNull);
-    //******* Making the Mylar coating
+	fAssemblySquare->AddPlacedVolume(fSquareMylarLog, moveNull, rotateNull);
+	fAssemblySquareSD->AddPlacedVolume(fSquareScintillatorLog, moveNull, rotateNull);
+	//******* Making the Mylar coating
 
-    G4SubtractionSolid* angledMylar = AngledMylarWithCut();
+	G4SubtractionSolid* angledMylar = AngledMylarWithCut();
 
-    fAngledMylarLog = new G4LogicalVolume(angledMylar, materialMylar, "angledMylarLog", 0, 0, 0);
-    fAngledMylarLog->SetVisAttributes(mylarVisAtt);
+	fAngledMylarLog = new G4LogicalVolume(angledMylar, materialMylar, "angledMylarLog", 0, 0, 0);
+	fAngledMylarLog->SetVisAttributes(mylarVisAtt);
 
-    //******* Making the angled scint and putting it in the Mylar
+	//******* Making the angled scint and putting it in the Mylar
 
-    G4SubtractionSolid* angledScintillator = AngledScintillator();
+	G4SubtractionSolid* angledScintillator = AngledScintillator();
 
-    fAngledScintillatorLog = new G4LogicalVolume(angledScintillator, materialBc404, "sceptarAngledScintillatorLog", 0, 0, 0);
-    fAngledScintillatorLog->SetVisAttributes(scintillatorVisAtt);
+	fAngledScintillatorLog = new G4LogicalVolume(angledScintillator, materialBc404, "sceptarAngledScintillatorLog", 0, 0, 0);
+	fAngledScintillatorLog->SetVisAttributes(scintillatorVisAtt);
 
-    fAssemblyAngled->AddPlacedVolume(fAngledMylarLog, moveNull, rotateNull);
-    fAssemblyAngledSD->AddPlacedVolume(fAngledScintillatorLog, moveNull, rotateNull);
+	fAssemblyAngled->AddPlacedVolume(fAngledMylarLog, moveNull, rotateNull);
+	fAssemblyAngledSD->AddPlacedVolume(fAngledScintillatorLog, moveNull, rotateNull);
 
-    return 1;
+	return 1;
 }
 
 
@@ -480,26 +480,26 @@ G4int DetectionSystemSceptar::ConstructScintillator() {
 //*****************************************************************
 
 G4int DetectionSystemSceptar::ConstructDelrinShell() {
-    G4Material* materialDelrin = G4Material::GetMaterial("Delrin");
-    if( !materialDelrin ) {
-        G4cout << " ----> Material " << "Delrin" << " not found, cannot build the detector shell! " << G4endl;
-        return 0;
-    }
+	G4Material* materialDelrin = G4Material::GetMaterial("Delrin");
+	if(!materialDelrin) {
+		G4cout<<" ----> Material "<<"Delrin"<<" not found, cannot build the detector shell! "<<G4endl;
+		return 0;
+	}
 
-    G4VisAttributes* DelrinVisAtt = new G4VisAttributes(G4Colour(0.1,0.1,0.1));
-    DelrinVisAtt->SetVisibility(true);
+	G4VisAttributes* DelrinVisAtt = new G4VisAttributes(G4Colour(0.1,0.1,0.1));
+	DelrinVisAtt->SetVisibility(true);
 
-    G4SubtractionSolid* shell = DelrinShell();
+	G4SubtractionSolid* shell = DelrinShell();
 
-    fDelrinShellLog = new G4LogicalVolume(shell, materialDelrin, "DelrinShellLog", 0, 0, 0);
-    fDelrinShellLog->SetVisAttributes(DelrinVisAtt);
+	fDelrinShellLog = new G4LogicalVolume(shell, materialDelrin, "DelrinShellLog", 0, 0, 0);
+	fDelrinShellLog->SetVisAttributes(DelrinVisAtt);
 
-    G4RotationMatrix* rotateNull = new G4RotationMatrix;
-    G4ThreeVector moveNull(0.0,0.0,0.0);
+	G4RotationMatrix* rotateNull = new G4RotationMatrix;
+	G4ThreeVector moveNull(0.0,0.0,0.0);
 
-    fAssembly->AddPlacedVolume(fDelrinShellLog, moveNull, rotateNull);
+	fAssembly->AddPlacedVolume(fDelrinShellLog, moveNull, rotateNull);
 
-    return 1;
+	return 1;
 } //end ::ConstructDelrinShell
 
 
@@ -510,26 +510,26 @@ G4int DetectionSystemSceptar::ConstructDelrinShell() {
 //*******************************************************************
 
 G4int DetectionSystemSceptar::Construct2ndDelrinShell() {
-    G4Material* materialDelrin = G4Material::GetMaterial("Delrin");
-    if( !materialDelrin ) {
-        G4cout << " ----> Material " << "Delrin" << " not found, cannot build the detector shell! " << G4endl;
-        return 0;
-    }
+	G4Material* materialDelrin = G4Material::GetMaterial("Delrin");
+	if(!materialDelrin) {
+		G4cout<<" ----> Material "<<"Delrin"<<" not found, cannot build the detector shell! "<<G4endl;
+		return 0;
+	}
 
-    G4VisAttributes* Delrin2VisAtt = new G4VisAttributes(G4Colour(1,1,1));
-    Delrin2VisAtt->SetVisibility(true);
+	G4VisAttributes* Delrin2VisAtt = new G4VisAttributes(G4Colour(1,1,1));
+	Delrin2VisAtt->SetVisibility(true);
 
-    G4SubtractionSolid* shell2 = DelrinShell2();
+	G4SubtractionSolid* shell2 = DelrinShell2();
 
-    fDelrinShell2Log = new G4LogicalVolume(shell2, materialDelrin, "DelrinShell2Log", 0, 0, 0);
-    fDelrinShell2Log->SetVisAttributes(Delrin2VisAtt);
+	fDelrinShell2Log = new G4LogicalVolume(shell2, materialDelrin, "DelrinShell2Log", 0, 0, 0);
+	fDelrinShell2Log->SetVisAttributes(Delrin2VisAtt);
 
-    G4RotationMatrix* rotateNull = new G4RotationMatrix;
-    G4ThreeVector moveNull(0.0,0.0,0.0);
+	G4RotationMatrix* rotateNull = new G4RotationMatrix;
+	G4ThreeVector moveNull(0.0,0.0,0.0);
 
-    fAssembly->AddPlacedVolume(fDelrinShell2Log, moveNull, rotateNull);
+	fAssembly->AddPlacedVolume(fDelrinShell2Log, moveNull, rotateNull);
 
-    return 1;
+	return 1;
 
 } //end ::Construct2ndDelrinShell
 
@@ -541,26 +541,26 @@ G4int DetectionSystemSceptar::Construct2ndDelrinShell() {
 //*******************************************************************
 
 G4int DetectionSystemSceptar::ConstructHevimetShell() {
-    G4Material* materialHevimet = G4Material::GetMaterial("Hevimet");
-    if( !materialHevimet ) {
-        G4cout << " ----> Material " << "Hevimet" << " not found, cannot build the detector shell! " << G4endl;
-        return 0;
-    }
+	G4Material* materialHevimet = G4Material::GetMaterial("Hevimet");
+	if(!materialHevimet) {
+		G4cout<<" ----> Material "<<"Hevimet"<<" not found, cannot build the detector shell! "<<G4endl;
+		return 0;
+	}
 
-    G4VisAttributes* HevimetVisAtt = new G4VisAttributes(G4Colour(0.3,0.3,0.3));
-    HevimetVisAtt->SetVisibility(true);
+	G4VisAttributes* HevimetVisAtt = new G4VisAttributes(G4Colour(0.3,0.3,0.3));
+	HevimetVisAtt->SetVisibility(true);
 
-    G4SubtractionSolid* shell3 = HevimetShell();
+	G4SubtractionSolid* shell3 = HevimetShell();
 
-    fHevimetShellLog = new G4LogicalVolume(shell3, materialHevimet, "HevimetShellLog", 0, 0, 0);
-    fHevimetShellLog->SetVisAttributes(HevimetVisAtt);
+	fHevimetShellLog = new G4LogicalVolume(shell3, materialHevimet, "HevimetShellLog", 0, 0, 0);
+	fHevimetShellLog->SetVisAttributes(HevimetVisAtt);
 
-    G4RotationMatrix* rotateNull = new G4RotationMatrix;
-    G4ThreeVector moveNull(0.0,0.0,0.0);
+	G4RotationMatrix* rotateNull = new G4RotationMatrix;
+	G4ThreeVector moveNull(0.0,0.0,0.0);
 
-    fAssembly->AddPlacedVolume(fHevimetShellLog, moveNull, rotateNull);
+	fAssembly->AddPlacedVolume(fHevimetShellLog, moveNull, rotateNull);
 
-    return 1;
+	return 1;
 
 } //end ::Construct2ndDelrinShell
 
@@ -569,207 +569,207 @@ G4int DetectionSystemSceptar::ConstructHevimetShell() {
 // Methods used to build shapes
 ///////////////////////////////////////////////////////////////////////
 G4Trd* DetectionSystemSceptar::SquareMylar() {
-    G4double extra = 2.0*fMylarThickness;
+	G4double extra = 2.0*fMylarThickness;
 
-    G4double halfLengthLongerX = (fSquareScintillatorLength +extra)/2.0;
-    G4double halfLengthShorterX = halfLengthLongerX - tan(fScintAngle1)*(fSquareScintillatorThickness +extra);
-    G4double halfLengthY = (fSquareScintillatorWidth +extra)/2.0;
-    G4double halfLengthZ = (fSquareScintillatorThickness +extra)/2.0;
+	G4double halfLengthLongerX = (fSquareScintillatorLength +extra)/2.0;
+	G4double halfLengthShorterX = halfLengthLongerX - tan(fScintAngle1)*(fSquareScintillatorThickness +extra);
+	G4double halfLengthY = (fSquareScintillatorWidth +extra)/2.0;
+	G4double halfLengthZ = (fSquareScintillatorThickness +extra)/2.0;
 
-    G4Trd* squareMylar = new G4Trd("squareMylar", halfLengthLongerX, halfLengthShorterX,halfLengthY, halfLengthY, halfLengthZ);
+	G4Trd* squareMylar = new G4Trd("squareMylar", halfLengthLongerX, halfLengthShorterX,halfLengthY, halfLengthY, halfLengthZ);
 
-    return squareMylar;
+	return squareMylar;
 } //end ::squareMylar
 
 G4SubtractionSolid* DetectionSystemSceptar::SquareMylarWithCut() {
-    G4double extra = 2.0*fMylarThickness;
+	G4double extra = 2.0*fMylarThickness;
 
-    G4double halfLengthLongerX = (fSquareScintillatorLength +extra)/2.0;
-    G4double halfLengthShorterX = halfLengthLongerX - tan(fScintAngle1)*(fSquareScintillatorThickness +extra);
-    G4double halfLengthY = (fSquareScintillatorWidth +extra)/2.0;
-    G4double halfLengthZ = (fSquareScintillatorThickness +extra)/2.0;
+	G4double halfLengthLongerX = (fSquareScintillatorLength +extra)/2.0;
+	G4double halfLengthShorterX = halfLengthLongerX - tan(fScintAngle1)*(fSquareScintillatorThickness +extra);
+	G4double halfLengthY = (fSquareScintillatorWidth +extra)/2.0;
+	G4double halfLengthZ = (fSquareScintillatorThickness +extra)/2.0;
 
-    G4Trd* squareMylar = new G4Trd("squareMylar", halfLengthLongerX, halfLengthShorterX,halfLengthY, halfLengthY, halfLengthZ);
+	G4Trd* squareMylar = new G4Trd("squareMylar", halfLengthLongerX, halfLengthShorterX,halfLengthY, halfLengthY, halfLengthZ);
 
-    G4Trd* scintCut = SquareScintillator();
+	G4Trd* scintCut = SquareScintillator();
 
-    G4RotationMatrix* rotateCut = new G4RotationMatrix;
-    G4ThreeVector moveCut(0, 0, 0);
+	G4RotationMatrix* rotateCut = new G4RotationMatrix;
+	G4ThreeVector moveCut(0, 0, 0);
 
-    G4SubtractionSolid* squareMylarWithCut = new G4SubtractionSolid("squareMylarWithCut", squareMylar, scintCut, rotateCut, moveCut);
+	G4SubtractionSolid* squareMylarWithCut = new G4SubtractionSolid("squareMylarWithCut", squareMylar, scintCut, rotateCut, moveCut);
 
-    return squareMylarWithCut;
+	return squareMylarWithCut;
 } //end ::squareMylar
 
 G4SubtractionSolid* DetectionSystemSceptar::AngledMylar() {
-    G4double extra = 2.0*fMylarThickness;
+	G4double extra = 2.0*fMylarThickness;
 
-    G4double halfLengthNegX = (fAngledScintillatorLongWidth +extra)/2.0;
-    G4double halfLengthPosX = (fAngledScintillatorShortWidth +extra)/2.0;
-    G4double halfLengthZ = (fAngledScintillatorLength +extra)/2.0;
-    G4double halfLengthY = (fAngledScintillatorThickness +extra)/2.0;
+	G4double halfLengthNegX = (fAngledScintillatorLongWidth +extra)/2.0;
+	G4double halfLengthPosX = (fAngledScintillatorShortWidth +extra)/2.0;
+	G4double halfLengthZ = (fAngledScintillatorLength +extra)/2.0;
+	G4double halfLengthY = (fAngledScintillatorThickness +extra)/2.0;
 
-    G4Trd* mylar = new G4Trd("mylar", halfLengthNegX, halfLengthPosX, halfLengthY, halfLengthY, halfLengthZ);
+	G4Trd* mylar = new G4Trd("mylar", halfLengthNegX, halfLengthPosX, halfLengthY, halfLengthY, halfLengthZ);
 
-    G4double halfThickness = (fAngledScintillatorThickness +extra)/(2.0*cos(fScintAngle3));
-    G4double halfLength = fAngledScintillatorLength +extra;
+	G4double halfThickness = (fAngledScintillatorThickness +extra)/(2.0*cos(fScintAngle3));
+	G4double halfLength = fAngledScintillatorLength +extra;
 
-    G4Box* box = new G4Box("box", halfThickness, halfThickness, halfLength);
+	G4Box* box = new G4Box("box", halfThickness, halfThickness, halfLength);
 
-    G4RotationMatrix* rotateBox1 = new G4RotationMatrix;
-    rotateBox1->rotateY(fScintAngle2);
-    rotateBox1->rotateZ(-fScintAngle3);
+	G4RotationMatrix* rotateBox1 = new G4RotationMatrix;
+	rotateBox1->rotateY(fScintAngle2);
+	rotateBox1->rotateZ(-fScintAngle3);
 
-    G4ThreeVector moveBox1((fAngledScintillatorShortWidth +extra +tan(fScintAngle2)*(fAngledScintillatorLength +extra) -tan(fScintAngle3)*(fAngledScintillatorThickness +extra)/cos(fScintAngle2))/2.0 +cos(fScintAngle3)*halfThickness/cos(fScintAngle2), halfThickness*sin(fScintAngle3), 0);
+	G4ThreeVector moveBox1((fAngledScintillatorShortWidth +extra +tan(fScintAngle2)*(fAngledScintillatorLength +extra) -tan(fScintAngle3)*(fAngledScintillatorThickness +extra)/cos(fScintAngle2))/2.0 +cos(fScintAngle3)*halfThickness/cos(fScintAngle2), halfThickness*sin(fScintAngle3), 0);
 
-    G4SubtractionSolid* angledMylar1 = new G4SubtractionSolid("angledMylar1", mylar, box, rotateBox1, moveBox1);
+	G4SubtractionSolid* angledMylar1 = new G4SubtractionSolid("angledMylar1", mylar, box, rotateBox1, moveBox1);
 
-    G4RotationMatrix* rotateBox2 = new G4RotationMatrix;
-    rotateBox2->rotateY(-fScintAngle2);
-    rotateBox2->rotateZ(fScintAngle3);
+	G4RotationMatrix* rotateBox2 = new G4RotationMatrix;
+	rotateBox2->rotateY(-fScintAngle2);
+	rotateBox2->rotateZ(fScintAngle3);
 
-    G4ThreeVector moveBox2(-(fAngledScintillatorShortWidth +extra +tan(fScintAngle2)*(fAngledScintillatorLength +extra) -tan(fScintAngle3)*(fAngledScintillatorThickness +extra)/cos(fScintAngle2))/2.0 -cos(fScintAngle3)*halfThickness/cos(fScintAngle2), halfThickness*sin(fScintAngle3), 0);
+	G4ThreeVector moveBox2(-(fAngledScintillatorShortWidth +extra +tan(fScintAngle2)*(fAngledScintillatorLength +extra) -tan(fScintAngle3)*(fAngledScintillatorThickness +extra)/cos(fScintAngle2))/2.0 -cos(fScintAngle3)*halfThickness/cos(fScintAngle2), halfThickness*sin(fScintAngle3), 0);
 
-    G4SubtractionSolid* angledMylar = new G4SubtractionSolid("angledMylar", angledMylar1, box, rotateBox2, moveBox2);
+	G4SubtractionSolid* angledMylar = new G4SubtractionSolid("angledMylar", angledMylar1, box, rotateBox2, moveBox2);
 
-    return angledMylar;
+	return angledMylar;
 
 } //end ::angledMylar
 
 
 G4SubtractionSolid* DetectionSystemSceptar::AngledMylarWithCut() {
-    G4double extra = 2.0*fMylarThickness;
+	G4double extra = 2.0*fMylarThickness;
 
-    G4double halfLengthNegX = (fAngledScintillatorLongWidth +extra)/2.0;
-    G4double halfLengthPosX = (fAngledScintillatorShortWidth +extra)/2.0;
-    G4double halfLengthZ = (fAngledScintillatorLength +extra)/2.0;
-    G4double halfLengthY = (fAngledScintillatorThickness +extra)/2.0;
+	G4double halfLengthNegX = (fAngledScintillatorLongWidth +extra)/2.0;
+	G4double halfLengthPosX = (fAngledScintillatorShortWidth +extra)/2.0;
+	G4double halfLengthZ = (fAngledScintillatorLength +extra)/2.0;
+	G4double halfLengthY = (fAngledScintillatorThickness +extra)/2.0;
 
-    G4Trd* mylar = new G4Trd("mylar", halfLengthNegX, halfLengthPosX, halfLengthY, halfLengthY, halfLengthZ);
+	G4Trd* mylar = new G4Trd("mylar", halfLengthNegX, halfLengthPosX, halfLengthY, halfLengthY, halfLengthZ);
 
-    G4double halfThickness = (fAngledScintillatorThickness +extra)/(2.0*cos(fScintAngle3));
-    G4double halfLength = fAngledScintillatorLength +extra;
+	G4double halfThickness = (fAngledScintillatorThickness +extra)/(2.0*cos(fScintAngle3));
+	G4double halfLength = fAngledScintillatorLength +extra;
 
-    G4Box* box = new G4Box("box", halfThickness, halfThickness, halfLength);
+	G4Box* box = new G4Box("box", halfThickness, halfThickness, halfLength);
 
-    G4RotationMatrix* rotateBox1 = new G4RotationMatrix;
-    rotateBox1->rotateY(fScintAngle2);
-    rotateBox1->rotateZ(-fScintAngle3);
+	G4RotationMatrix* rotateBox1 = new G4RotationMatrix;
+	rotateBox1->rotateY(fScintAngle2);
+	rotateBox1->rotateZ(-fScintAngle3);
 
-    G4ThreeVector moveBox1((fAngledScintillatorShortWidth +extra +tan(fScintAngle2)*(fAngledScintillatorLength +extra) -tan(fScintAngle3)*(fAngledScintillatorThickness +extra)/cos(fScintAngle2))/2.0 +cos(fScintAngle3)*halfThickness/cos(fScintAngle2), halfThickness*sin(fScintAngle3), 0);
+	G4ThreeVector moveBox1((fAngledScintillatorShortWidth +extra +tan(fScintAngle2)*(fAngledScintillatorLength +extra) -tan(fScintAngle3)*(fAngledScintillatorThickness +extra)/cos(fScintAngle2))/2.0 +cos(fScintAngle3)*halfThickness/cos(fScintAngle2), halfThickness*sin(fScintAngle3), 0);
 
-    G4SubtractionSolid* angledMylar1 = new G4SubtractionSolid("angledMylar1", mylar, box, rotateBox1, moveBox1);
+	G4SubtractionSolid* angledMylar1 = new G4SubtractionSolid("angledMylar1", mylar, box, rotateBox1, moveBox1);
 
-    G4RotationMatrix* rotateBox2 = new G4RotationMatrix;
-    rotateBox2->rotateY(-fScintAngle2);
-    rotateBox2->rotateZ(fScintAngle3);
+	G4RotationMatrix* rotateBox2 = new G4RotationMatrix;
+	rotateBox2->rotateY(-fScintAngle2);
+	rotateBox2->rotateZ(fScintAngle3);
 
-    G4ThreeVector moveBox2(-(fAngledScintillatorShortWidth +extra +tan(fScintAngle2)*(fAngledScintillatorLength +extra) -tan(fScintAngle3)*(fAngledScintillatorThickness +extra)/cos(fScintAngle2))/2.0 -cos(fScintAngle3)*halfThickness/cos(fScintAngle2), halfThickness*sin(fScintAngle3), 0);
+	G4ThreeVector moveBox2(-(fAngledScintillatorShortWidth +extra +tan(fScintAngle2)*(fAngledScintillatorLength +extra) -tan(fScintAngle3)*(fAngledScintillatorThickness +extra)/cos(fScintAngle2))/2.0 -cos(fScintAngle3)*halfThickness/cos(fScintAngle2), halfThickness*sin(fScintAngle3), 0);
 
-    G4SubtractionSolid* angledMylar = new G4SubtractionSolid("angledMylar", angledMylar1, box, rotateBox2, moveBox2);
+	G4SubtractionSolid* angledMylar = new G4SubtractionSolid("angledMylar", angledMylar1, box, rotateBox2, moveBox2);
 
-    G4SubtractionSolid* scintCut = AngledScintillator();
+	G4SubtractionSolid* scintCut = AngledScintillator();
 
-    G4RotationMatrix* rotateCut = new G4RotationMatrix;
-    G4ThreeVector moveCut(0, 0, 0);
+	G4RotationMatrix* rotateCut = new G4RotationMatrix;
+	G4ThreeVector moveCut(0, 0, 0);
 
-    G4SubtractionSolid* angledMylarWithCut = new G4SubtractionSolid("angledMylarWithCut", angledMylar, scintCut, rotateCut, moveCut);
+	G4SubtractionSolid* angledMylarWithCut = new G4SubtractionSolid("angledMylarWithCut", angledMylar, scintCut, rotateCut, moveCut);
 
-    return angledMylarWithCut;
+	return angledMylarWithCut;
 
 } //end ::angledMylar
 
 
 G4Trd* DetectionSystemSceptar::SquareScintillator() {
-    G4double halfLengthLongerX = fSquareScintillatorLength/2.0;
-    G4double halfLengthShorterX = halfLengthLongerX - tan(fScintAngle1)*fSquareScintillatorThickness;
-    G4double halfLengthY = fSquareScintillatorWidth/2.0;
-    G4double halfLengthZ = fSquareScintillatorThickness/2.0;
+	G4double halfLengthLongerX = fSquareScintillatorLength/2.0;
+	G4double halfLengthShorterX = halfLengthLongerX - tan(fScintAngle1)*fSquareScintillatorThickness;
+	G4double halfLengthY = fSquareScintillatorWidth/2.0;
+	G4double halfLengthZ = fSquareScintillatorThickness/2.0;
 
-    G4Trd* squareScintillator = new G4Trd("squareScintillator", halfLengthLongerX, halfLengthShorterX,halfLengthY, halfLengthY, halfLengthZ);
+	G4Trd* squareScintillator = new G4Trd("squareScintillator", halfLengthLongerX, halfLengthShorterX,halfLengthY, halfLengthY, halfLengthZ);
 
-    return squareScintillator;
+	return squareScintillator;
 } //end ::squareScintillator
 
 
 G4SubtractionSolid* DetectionSystemSceptar::AngledScintillator() {
-    G4double halfLengthNegX = fAngledScintillatorLongWidth/2.0;
-    G4double halfLengthPosX = fAngledScintillatorShortWidth/2.0;
-    G4double halfLengthZ = fAngledScintillatorLength/2.0;
-    G4double halfLengthY = fAngledScintillatorThickness/2.0;
+	G4double halfLengthNegX = fAngledScintillatorLongWidth/2.0;
+	G4double halfLengthPosX = fAngledScintillatorShortWidth/2.0;
+	G4double halfLengthZ = fAngledScintillatorLength/2.0;
+	G4double halfLengthY = fAngledScintillatorThickness/2.0;
 
-    G4Trd* scint = new G4Trd("scint", halfLengthNegX, halfLengthPosX, halfLengthY, halfLengthY, halfLengthZ);
+	G4Trd* scint = new G4Trd("scint", halfLengthNegX, halfLengthPosX, halfLengthY, halfLengthY, halfLengthZ);
 
-    G4double halfThickness = fAngledScintillatorThickness/(2.0*cos(fScintAngle3));
-    G4double halfLength = fAngledScintillatorLength;
+	G4double halfThickness = fAngledScintillatorThickness/(2.0*cos(fScintAngle3));
+	G4double halfLength = fAngledScintillatorLength;
 
-    G4Box* box = new G4Box("box", halfThickness, halfThickness, halfLength);
+	G4Box* box = new G4Box("box", halfThickness, halfThickness, halfLength);
 
-    G4RotationMatrix* rotateBox1 = new G4RotationMatrix;
-    rotateBox1->rotateY(fScintAngle2);
-    rotateBox1->rotateZ(-fScintAngle3);
+	G4RotationMatrix* rotateBox1 = new G4RotationMatrix;
+	rotateBox1->rotateY(fScintAngle2);
+	rotateBox1->rotateZ(-fScintAngle3);
 
-    G4ThreeVector moveBox1((fAngledScintillatorShortWidth +tan(fScintAngle2)*fAngledScintillatorLength -tan(fScintAngle3)*fAngledScintillatorThickness/cos(fScintAngle2))/2.0 +cos(fScintAngle3)*halfThickness/cos(fScintAngle2), halfThickness*sin(fScintAngle3), 0);
+	G4ThreeVector moveBox1((fAngledScintillatorShortWidth +tan(fScintAngle2)*fAngledScintillatorLength -tan(fScintAngle3)*fAngledScintillatorThickness/cos(fScintAngle2))/2.0 +cos(fScintAngle3)*halfThickness/cos(fScintAngle2), halfThickness*sin(fScintAngle3), 0);
 
-    G4SubtractionSolid* angledScint1 = new G4SubtractionSolid("angledScint1", scint, box, rotateBox1, moveBox1);
+	G4SubtractionSolid* angledScint1 = new G4SubtractionSolid("angledScint1", scint, box, rotateBox1, moveBox1);
 
-    G4RotationMatrix* rotateBox2 = new G4RotationMatrix;
-    rotateBox2->rotateY(-fScintAngle2);
-    rotateBox2->rotateZ(fScintAngle3);
+	G4RotationMatrix* rotateBox2 = new G4RotationMatrix;
+	rotateBox2->rotateY(-fScintAngle2);
+	rotateBox2->rotateZ(fScintAngle3);
 
-    G4ThreeVector moveBox2(-(fAngledScintillatorShortWidth +tan(fScintAngle2)*fAngledScintillatorLength -tan(fScintAngle3)*fAngledScintillatorThickness/cos(fScintAngle2))/2.0 -cos(fScintAngle3)*halfThickness/cos(fScintAngle2), halfThickness*sin(fScintAngle3), 0);
+	G4ThreeVector moveBox2(-(fAngledScintillatorShortWidth +tan(fScintAngle2)*fAngledScintillatorLength -tan(fScintAngle3)*fAngledScintillatorThickness/cos(fScintAngle2))/2.0 -cos(fScintAngle3)*halfThickness/cos(fScintAngle2), halfThickness*sin(fScintAngle3), 0);
 
-    G4SubtractionSolid* angledScint = new G4SubtractionSolid("angledScint", angledScint1, box, rotateBox2, moveBox2);
+	G4SubtractionSolid* angledScint = new G4SubtractionSolid("angledScint", angledScint1, box, rotateBox2, moveBox2);
 
-    return angledScint;
+	return angledScint;
 
 } //end ::angledScintillator
 
 
 G4SubtractionSolid* DetectionSystemSceptar::DelrinShell() {
-    G4Sphere* sphere = new G4Sphere("sphere", fDelrinInnerRadius, fDelrinOuterRadius, 0, 2.0*M_PI, 0, M_PI);
+	G4Sphere* sphere = new G4Sphere("sphere", fDelrinInnerRadius, fDelrinOuterRadius, 0, 2.0*M_PI, 0, M_PI);
 
-    G4Tubs* chopTub = new G4Tubs("chopTub", 0, fDelrinHoleRadius, fDelrinOuterRadius +1.0, 0, 2.0*M_PI);
+	G4Tubs* chopTub = new G4Tubs("chopTub", 0, fDelrinHoleRadius, fDelrinOuterRadius +1.0, 0, 2.0*M_PI);
 
-    G4RotationMatrix* rotateChopTub = new G4RotationMatrix;
-    rotateChopTub->rotateX(-M_PI/2.0);
+	G4RotationMatrix* rotateChopTub = new G4RotationMatrix;
+	rotateChopTub->rotateX(-M_PI/2.0);
 
-    G4ThreeVector moveNull(0.0,0.0,0.0);
+	G4ThreeVector moveNull(0.0,0.0,0.0);
 
-    G4SubtractionSolid* delrinShell = new G4SubtractionSolid("DelrinShell", sphere, chopTub, rotateChopTub, moveNull);
+	G4SubtractionSolid* delrinShell = new G4SubtractionSolid("DelrinShell", sphere, chopTub, rotateChopTub, moveNull);
 
-    return delrinShell;
+	return delrinShell;
 } //end ::DelrinShell
 
 
 G4SubtractionSolid* DetectionSystemSceptar::DelrinShell2() {
-    G4Sphere* sphere = new G4Sphere("sphere", fDelrin2InnerRadius, fDelrin2OuterRadius, 0, 2.0*M_PI, 0, M_PI);
+	G4Sphere* sphere = new G4Sphere("sphere", fDelrin2InnerRadius, fDelrin2OuterRadius, 0, 2.0*M_PI, 0, M_PI);
 
-    G4Tubs* chopTub = new G4Tubs("chopTub", 0, fDelrinHoleRadius, fDelrin2OuterRadius +1.0, 0, 2.0*M_PI);
+	G4Tubs* chopTub = new G4Tubs("chopTub", 0, fDelrinHoleRadius, fDelrin2OuterRadius +1.0, 0, 2.0*M_PI);
 
-    G4RotationMatrix* rotateChopTub = new G4RotationMatrix;
-    rotateChopTub->rotateX(-M_PI/2.0);
+	G4RotationMatrix* rotateChopTub = new G4RotationMatrix;
+	rotateChopTub->rotateX(-M_PI/2.0);
 
-    G4ThreeVector moveNull(0.0,0.0,0.0);
+	G4ThreeVector moveNull(0.0,0.0,0.0);
 
-    G4SubtractionSolid* delrinShell2 = new G4SubtractionSolid("DelrinShell2", sphere, chopTub, rotateChopTub, moveNull);
+	G4SubtractionSolid* delrinShell2 = new G4SubtractionSolid("DelrinShell2", sphere, chopTub, rotateChopTub, moveNull);
 
-    return delrinShell2;
+	return delrinShell2;
 } //end ::DelrinShell2
 
 
 G4SubtractionSolid* DetectionSystemSceptar::HevimetShell() {
-    G4Sphere* sphere = new G4Sphere("sphere", fHevimetInnerRadius, fHevimetOuterRadius,0, 2.0*M_PI, 0, M_PI);
+	G4Sphere* sphere = new G4Sphere("sphere", fHevimetInnerRadius, fHevimetOuterRadius,0, 2.0*M_PI, 0, M_PI);
 
-    G4Tubs* chopTub = new G4Tubs("chopTub", 0, fDelrinHoleRadius, fHevimetOuterRadius +1.0,0, 2.0*M_PI);
+	G4Tubs* chopTub = new G4Tubs("chopTub", 0, fDelrinHoleRadius, fHevimetOuterRadius +1.0,0, 2.0*M_PI);
 
-    G4RotationMatrix* rotateChopTub = new G4RotationMatrix;
-    rotateChopTub->rotateX(-M_PI/2.0);
+	G4RotationMatrix* rotateChopTub = new G4RotationMatrix;
+	rotateChopTub->rotateX(-M_PI/2.0);
 
-    G4ThreeVector moveNull(0.0,0.0,0.0);
+	G4ThreeVector moveNull(0.0,0.0,0.0);
 
-    G4SubtractionSolid* hevimetShell = new G4SubtractionSolid("HevimetShell", sphere, chopTub, rotateChopTub, moveNull);
+	G4SubtractionSolid* hevimetShell = new G4SubtractionSolid("HevimetShell", sphere, chopTub, rotateChopTub, moveNull);
 
-    return hevimetShell;
+	return hevimetShell;
 } //end ::DelrinShell2
 

--- a/src/DetectionSystemSodiumIodide.cc
+++ b/src/DetectionSystemSodiumIodide.cc
@@ -23,492 +23,492 @@
 #include "G4SystemOfUnits.hh" // new version geant4.10 requires units
 
 DetectionSystemSodiumIodide::DetectionSystemSodiumIodide() :
-    // LogicalVolumes
-    fDetectorVolumeLog(0),
-    fCrystalBlockLog(0),
-    fCanCylinderLog(0),
-    fCanFrontLidLog(0),
-    fCanBackLidLog(0),
-    fSealFrontLidLog(0),
-    fDiscFrontLidLog(0),
-    fPackingCylinderLog(0),
-    fPackingFrontLidLog(0)
+	// LogicalVolumes
+	fDetectorVolumeLog(0),
+	fCrystalBlockLog(0),
+	fCanCylinderLog(0),
+	fCanFrontLidLog(0),
+	fCanBackLidLog(0),
+	fSealFrontLidLog(0),
+	fDiscFrontLidLog(0),
+	fPackingCylinderLog(0),
+	fPackingFrontLidLog(0)
 { 
 
-    // NaI Crystal and Can Physical Properties
-    // From: Scintillation Spectrometry gamma-ray catalogue - R. L. Heath, 1964
+	// NaI Crystal and Can Physical Properties
+	// From: Scintillation Spectrometry gamma-ray catalogue - R. L. Heath, 1964
 
 
 
-    /////////////////////////////////////////////////////////////////////
-    //  0.019"
-    //  "can" - Al Container
-    //
-    //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-    //% 0.040"
-    //% "seal" - Compressed Neoprene Rubber
-    //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-    //-------------------------------------------------------------------
-    //- 0.006"
-    //- "disc" - Polyethylene Disc
-    //-------------------------------------------------------------------
-    /////////////////////////////////////////////////////////////////////
-    //- 0.0625"
-    //- "packing" - Packed Aluminum Oxide
-    /////////////////////////////////////////////////////////////////////
-    //
-    //
-    //  NaI Crystal
-    //
-    //
-    //
-    //
-    //
+	/////////////////////////////////////////////////////////////////////
+	//  0.019"
+	//  "can" - Al Container
+	//
+	//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+	//% 0.040"
+	//% "seal" - Compressed Neoprene Rubber
+	//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+	//-------------------------------------------------------------------
+	//- 0.006"
+	//- "disc" - Polyethylene Disc
+	//-------------------------------------------------------------------
+	/////////////////////////////////////////////////////////////////////
+	//- 0.0625"
+	//- "packing" - Packed Aluminum Oxide
+	/////////////////////////////////////////////////////////////////////
+	//
+	//
+	//  NaI Crystal
+	//
+	//
+	//
+	//
+	//
 
 
-    fDetailViewEndAngle	 	= 360.0*deg;
-    fCrystalMaterial          = "G4_SODIUM_IODIDE";
-    fCanMaterial              = "G4_Al";
-    fSealMaterial             = "G4_RUBBER_NEOPRENE";
-    fDiscMaterial             = "G4_POLYETHYLENE";
-    fPackingMaterial          = "G4_ALUMINUM_OXIDE";
+	fDetailViewEndAngle	 	= 360.0*deg;
+	fCrystalMaterial          = "G4_SODIUM_IODIDE";
+	fCanMaterial              = "G4_Al";
+	fSealMaterial             = "G4_RUBBER_NEOPRENE";
+	fDiscMaterial             = "G4_POLYETHYLENE";
+	fPackingMaterial          = "G4_ALUMINUM_OXIDE";
 
-    fCrystalLengthZ           = 3.0*inch2cm*cm;
-    fCrystalInnerRadius 		= 0.0*cm;
-    fCrystalOuterRadius 		= 1.5*inch2cm*cm;
+	fCrystalLengthZ           = 3.0*inch2cm*cm;
+	fCrystalInnerRadius 		= 0.0*cm;
+	fCrystalOuterRadius 		= 1.5*inch2cm*cm;
 
-    fPackingLengthZ           = fCrystalLengthZ;
-    fPackingInnerRadius 		= fCrystalOuterRadius;
-    fPackingOuterRadius 		= 0.0625*inch2cm*cm + fCrystalOuterRadius;
+	fPackingLengthZ           = fCrystalLengthZ;
+	fPackingInnerRadius 		= fCrystalOuterRadius;
+	fPackingOuterRadius 		= 0.0625*inch2cm*cm + fCrystalOuterRadius;
 
-    fPackingLidInnerRadius    = 0.0*cm;
-    fPackingLidOuterRadius 	= fPackingOuterRadius;
-    fPackingFrontLidThickness	= 0.0625*inch2cm*cm;
+	fPackingLidInnerRadius    = 0.0*cm;
+	fPackingLidOuterRadius 	= fPackingOuterRadius;
+	fPackingFrontLidThickness	= 0.0625*inch2cm*cm;
 
-    fDiscLidInnerRadius       = 0.0*cm;
-    fDiscLidOuterRadius       = fPackingLidOuterRadius;
-    fDiscFrontLidThickness	= 0.006*inch2cm*cm;
+	fDiscLidInnerRadius       = 0.0*cm;
+	fDiscLidOuterRadius       = fPackingLidOuterRadius;
+	fDiscFrontLidThickness	= 0.006*inch2cm*cm;
 
-    fSealLidInnerRadius       = 0.0*cm;
-    fSealLidOuterRadius       = fPackingLidOuterRadius;
-    fSealFrontLidThickness	= 0.04*inch2cm*cm;
+	fSealLidInnerRadius       = 0.0*cm;
+	fSealLidOuterRadius       = fPackingLidOuterRadius;
+	fSealFrontLidThickness	= 0.04*inch2cm*cm;
 
-    fCanLengthZ                = fCrystalLengthZ +
-            fPackingFrontLidThickness +
-            fDiscFrontLidThickness +
-            fSealFrontLidThickness;
-    fCanInnerRadius            = fPackingOuterRadius;
-    fCanOuterRadius            = 0.019*inch2cm*cm + fPackingOuterRadius;
+	fCanLengthZ                = fCrystalLengthZ +
+		fPackingFrontLidThickness +
+		fDiscFrontLidThickness +
+		fSealFrontLidThickness;
+	fCanInnerRadius            = fPackingOuterRadius;
+	fCanOuterRadius            = 0.019*inch2cm*cm + fPackingOuterRadius;
 
-    fCanLidInnerRadius        = 0.0*cm;
-    fCanLidOuterRadius        = fCanOuterRadius;
-    fCanFrontLidThickness     = 0.019*inch2cm*cm;
-    fCanBackLidThickness      = 0.019*inch2cm*cm;
+	fCanLidInnerRadius        = 0.0*cm;
+	fCanLidOuterRadius        = fCanOuterRadius;
+	fCanFrontLidThickness     = 0.019*inch2cm*cm;
+	fCanBackLidThickness      = 0.019*inch2cm*cm;
 
 
-    fDetectorLengthZ           = fCrystalLengthZ +
-            fPackingFrontLidThickness +
-            fDiscFrontLidThickness +
-            fSealFrontLidThickness +
-            fCanFrontLidThickness +
-            fCanBackLidThickness;
+	fDetectorLengthZ           = fCrystalLengthZ +
+		fPackingFrontLidThickness +
+		fDiscFrontLidThickness +
+		fSealFrontLidThickness +
+		fCanFrontLidThickness +
+		fCanBackLidThickness;
 }
 
 DetectionSystemSodiumIodide::~DetectionSystemSodiumIodide() {
-    // LogicalVolumes
-    delete fDetectorVolumeLog;
-    delete fCrystalBlockLog;
-    delete fCanCylinderLog;
-    delete fCanFrontLidLog;
-    delete fCanBackLidLog;
-    delete fSealFrontLidLog;
-    delete fDiscFrontLidLog;
-    delete fPackingCylinderLog;
-    delete fPackingFrontLidLog;
+	// LogicalVolumes
+	delete fDetectorVolumeLog;
+	delete fCrystalBlockLog;
+	delete fCanCylinderLog;
+	delete fCanFrontLidLog;
+	delete fCanBackLidLog;
+	delete fSealFrontLidLog;
+	delete fDiscFrontLidLog;
+	delete fPackingCylinderLog;
+	delete fPackingFrontLidLog;
 
 }
 
 
 G4int DetectionSystemSodiumIodide::Build() {
-    // Build assembly volume
-    fAssembly = new G4AssemblyVolume();
+	// Build assembly volume
+	fAssembly = new G4AssemblyVolume();
 
-    G4cout << "BuildCrystalVolume" << G4endl;
-    BuildCrystalVolume();
-    G4cout << "BuildAluminumCanVolume" << G4endl;
-    BuildAluminumCanVolume();
-    G4cout << "BuildPackingVolume" << G4endl;
-    BuildPackingVolume();
-    G4cout << "BuildDiscVolume" << G4endl;
-    BuildDiscVolume();
-    G4cout << "BuildSealVolume" << G4endl;
-    BuildSealVolume();
+	G4cout<<"BuildCrystalVolume"<<G4endl;
+	BuildCrystalVolume();
+	G4cout<<"BuildAluminumCanVolume"<<G4endl;
+	BuildAluminumCanVolume();
+	G4cout<<"BuildPackingVolume"<<G4endl;
+	BuildPackingVolume();
+	G4cout<<"BuildDiscVolume"<<G4endl;
+	BuildDiscVolume();
+	G4cout<<"BuildSealVolume"<<G4endl;
+	BuildSealVolume();
 
-    return 1;
+	return 1;
 }
 
 G4int DetectionSystemSodiumIodide::PlaceDetector(G4LogicalVolume* expHallLog, G4ThreeVector move, G4RotationMatrix* rotate, G4int detectorNumber) {
-    G4int detectorCopyID = 0;
+	G4int detectorCopyID = 0;
 
-    G4cout << "SodiumIodide Detector Number = " << detectorNumber << G4endl;
+	G4cout<<"SodiumIodide Detector Number = "<<detectorNumber<<G4endl;
 
-    fCopyNumber = detectorCopyID + detectorNumber;
+	fCopyNumber = detectorCopyID + detectorNumber;
 
-    fAssembly->MakeImprint(expHallLog, move, rotate, fCopyNumber);
+	fAssembly->MakeImprint(expHallLog, move, rotate, fCopyNumber);
 
-    return 1;
+	return 1;
 }
 
 G4int DetectionSystemSodiumIodide::BuildCrystalVolume() {
-    G4Material* material = G4Material::GetMaterial(fCrystalMaterial);
-    if( !material ) {
-        G4cout << " ----> Material " << fCrystalMaterial << " not found, cannot build the detector shell! " << G4endl;
-        return 0;
-    }
+	G4Material* material = G4Material::GetMaterial(fCrystalMaterial);
+	if(!material) {
+		G4cout<<" ----> Material "<<fCrystalMaterial<<" not found, cannot build the detector shell! "<<G4endl;
+		return 0;
+	}
 
-    // Set visualization attributes
-    G4VisAttributes* visAtt = new G4VisAttributes(G4Colour(0.2,1.0,0.3));
-    visAtt->SetVisibility(true);
+	// Set visualization attributes
+	G4VisAttributes* visAtt = new G4VisAttributes(G4Colour(0.2,1.0,0.3));
+	visAtt->SetVisibility(true);
 
-    G4Tubs* crystalBlock = BuildCrystal();
+	G4Tubs* crystalBlock = BuildCrystal();
 
-    // Define rotation and movement objects
-    G4ThreeVector direction 	= G4ThreeVector(0,0,1);
-    G4double zPosition		= ( (fCanFrontLidThickness + fSealFrontLidThickness + fDiscFrontLidThickness + fPackingFrontLidThickness) - (fCanBackLidThickness) )/2.0;
-    G4ThreeVector move 		= zPosition * direction;
-    G4RotationMatrix* rotate = new G4RotationMatrix;
+	// Define rotation and movement objects
+	G4ThreeVector direction 	= G4ThreeVector(0,0,1);
+	G4double zPosition		= ((fCanFrontLidThickness + fSealFrontLidThickness + fDiscFrontLidThickness + fPackingFrontLidThickness) - (fCanBackLidThickness))/2.0;
+	G4ThreeVector move 		= zPosition * direction;
+	G4RotationMatrix* rotate = new G4RotationMatrix;
 
-    //logical volume
-    if(fCrystalBlockLog == NULL) {
-        fCrystalBlockLog = new G4LogicalVolume(crystalBlock, material, "sodiumIodideCrystalBlockLog", 0, 0, 0);
-        fCrystalBlockLog->SetVisAttributes(visAtt);
-    }
+	//logical volume
+	if(fCrystalBlockLog == nullptr) {
+		fCrystalBlockLog = new G4LogicalVolume(crystalBlock, material, "sodiumIodideCrystalBlockLog", 0, 0, 0);
+		fCrystalBlockLog->SetVisAttributes(visAtt);
+	}
 
-    fAssembly->AddPlacedVolume(fCrystalBlockLog, move, rotate);
+	fAssembly->AddPlacedVolume(fCrystalBlockLog, move, rotate);
 
-    return 1;
+	return 1;
 }
 
 G4int DetectionSystemSodiumIodide::BuildAluminumCanVolume() {
-    G4Material* material = G4Material::GetMaterial(fCanMaterial);
-    if( !material ) {
-        G4cout << " ----> Material " << fCanMaterial << " not found, cannot build the detector shell! " << G4endl;
-        return 0;
-    }
+	G4Material* material = G4Material::GetMaterial(fCanMaterial);
+	if(!material) {
+		G4cout<<" ----> Material "<<fCanMaterial<<" not found, cannot build the detector shell! "<<G4endl;
+		return 0;
+	}
 
-    // Set visualization attributes
-    G4VisAttributes* visAtt = new G4VisAttributes(G4Colour(0.6,0.6,0.6));
-    visAtt->SetVisibility(true);
+	// Set visualization attributes
+	G4VisAttributes* visAtt = new G4VisAttributes(G4Colour(0.6,0.6,0.6));
+	visAtt->SetVisibility(true);
 
-    G4ThreeVector direction =  G4ThreeVector(0,0,1);
-    G4double zPosition;
-    G4ThreeVector move;
-    G4RotationMatrix* rotate = new G4RotationMatrix;
+	G4ThreeVector direction =  G4ThreeVector(0,0,1);
+	G4double zPosition;
+	G4ThreeVector move;
+	G4RotationMatrix* rotate = new G4RotationMatrix;
 
-    /////////////////////////////////////////////////////////////////////
-    // Build and Place Aluminum Can
-    /////////////////////////////////////////////////////////////////////
-    G4Tubs* canCylinder = BuildAluminumCan();
+	/////////////////////////////////////////////////////////////////////
+	// Build and Place Aluminum Can
+	/////////////////////////////////////////////////////////////////////
+	G4Tubs* canCylinder = BuildAluminumCan();
 
-    //logical volume
-    if(fCanCylinderLog == NULL) {
-        fCanCylinderLog = new G4LogicalVolume(canCylinder, material, "canCylinderLog", 0, 0, 0);
-        fCanCylinderLog->SetVisAttributes(visAtt);
-    }
+	//logical volume
+	if(fCanCylinderLog == nullptr) {
+		fCanCylinderLog = new G4LogicalVolume(canCylinder, material, "canCylinderLog", 0, 0, 0);
+		fCanCylinderLog->SetVisAttributes(visAtt);
+	}
 
-    // place front canLid
-    zPosition 	= 0;
-    move 		= zPosition * direction;
+	// place front canLid
+	zPosition 	= 0;
+	move 		= zPosition * direction;
 
-    //add physical cylinder
-    fAssembly->AddPlacedVolume(fCanCylinderLog, move, rotate);
+	//add physical cylinder
+	fAssembly->AddPlacedVolume(fCanCylinderLog, move, rotate);
 
-    /////////////////////////////////////////////////////////////////////
-    // Build and Place Aluminum Front Lid
-    /////////////////////////////////////////////////////////////////////
-    G4Tubs* canFrontLid = BuildAluminumCanFrontLid();
+	/////////////////////////////////////////////////////////////////////
+	// Build and Place Aluminum Front Lid
+	/////////////////////////////////////////////////////////////////////
+	G4Tubs* canFrontLid = BuildAluminumCanFrontLid();
 
-    // logical volume
-    if( fCanFrontLidLog == NULL ) {
-        fCanFrontLidLog = new G4LogicalVolume(canFrontLid, material, "canFrontLidLog", 0, 0, 0);
-        fCanFrontLidLog->SetVisAttributes(visAtt);
-    }
+	// logical volume
+	if(fCanFrontLidLog == nullptr) {
+		fCanFrontLidLog = new G4LogicalVolume(canFrontLid, material, "canFrontLidLog", 0, 0, 0);
+		fCanFrontLidLog->SetVisAttributes(visAtt);
+	}
 
-    // place front canLid
+	// place front canLid
 
-    zPosition 	= -(fDetectorLengthZ/2.0) + (fCanFrontLidThickness/2.0);
-    move 		= zPosition * direction;
+	zPosition 	= -(fDetectorLengthZ/2.0) + (fCanFrontLidThickness/2.0);
+	move 		= zPosition * direction;
 
-    //add physical front canLid
-    fAssembly->AddPlacedVolume(fCanFrontLidLog, move, rotate);
-    
-    /////////////////////////////////////////////////////////////////////
-    // Build and Place Aluminum Back Lid
-    /////////////////////////////////////////////////////////////////////
-    G4Tubs* canBackLid = BuildAluminumCanBackLid();
-    
-    // logical volume
-    if(fCanBackLidLog == NULL) {
-        fCanBackLidLog = new G4LogicalVolume(canBackLid, material, "canBackLidLog", 0, 0, 0);
-        fCanBackLidLog->SetVisAttributes(visAtt);
-    }
+	//add physical front canLid
+	fAssembly->AddPlacedVolume(fCanFrontLidLog, move, rotate);
 
-    // place back canLid
-    zPosition 	= (fDetectorLengthZ/2.0) - (fCanBackLidThickness/2.0);
-    move 		= zPosition * direction;
+	/////////////////////////////////////////////////////////////////////
+	// Build and Place Aluminum Back Lid
+	/////////////////////////////////////////////////////////////////////
+	G4Tubs* canBackLid = BuildAluminumCanBackLid();
 
-    // add physical back canLid
-    fAssembly->AddPlacedVolume(fCanBackLidLog, move, rotate);
+	// logical volume
+	if(fCanBackLidLog == nullptr) {
+		fCanBackLidLog = new G4LogicalVolume(canBackLid, material, "canBackLidLog", 0, 0, 0);
+		fCanBackLidLog->SetVisAttributes(visAtt);
+	}
 
-    return 1;
+	// place back canLid
+	zPosition 	= (fDetectorLengthZ/2.0) - (fCanBackLidThickness/2.0);
+	move 		= zPosition * direction;
+
+	// add physical back canLid
+	fAssembly->AddPlacedVolume(fCanBackLidLog, move, rotate);
+
+	return 1;
 }
 
 G4int DetectionSystemSodiumIodide::BuildPackingVolume() {
-    G4Material* material = G4Material::GetMaterial(fPackingMaterial);
-    if( !material ) {
-        G4cout << " ----> Material " << fPackingMaterial << " not found, cannot build the detector shell! " << G4endl;
-        return 0;
-    }
+	G4Material* material = G4Material::GetMaterial(fPackingMaterial);
+	if(!material) {
+		G4cout<<" ----> Material "<<fPackingMaterial<<" not found, cannot build the detector shell! "<<G4endl;
+		return 0;
+	}
 
-    // Set visualization attributes
-    G4VisAttributes* visAtt = new G4VisAttributes(G4Colour(1.0,0.0,0.0));
-    visAtt->SetVisibility(true);
+	// Set visualization attributes
+	G4VisAttributes* visAtt = new G4VisAttributes(G4Colour(1.0,0.0,0.0));
+	visAtt->SetVisibility(true);
 
-    G4ThreeVector direction =  G4ThreeVector(0,0,1);
-    G4double zPosition;
-    G4ThreeVector move;
-    G4RotationMatrix* rotate = new G4RotationMatrix;
+	G4ThreeVector direction =  G4ThreeVector(0,0,1);
+	G4double zPosition;
+	G4ThreeVector move;
+	G4RotationMatrix* rotate = new G4RotationMatrix;
 
-    /////////////////////////////////////////////////////////////////////
-    // Build and Place Packing
-    /////////////////////////////////////////////////////////////////////
-    G4Tubs* packingCylinder = BuildPacking();
+	/////////////////////////////////////////////////////////////////////
+	// Build and Place Packing
+	/////////////////////////////////////////////////////////////////////
+	G4Tubs* packingCylinder = BuildPacking();
 
-    //logical volume
-    if(fPackingCylinderLog == NULL) {
-        fPackingCylinderLog = new G4LogicalVolume(packingCylinder, material, "packingCylinderLog", 0, 0, 0);
-        fPackingCylinderLog->SetVisAttributes(visAtt);
-    }
+	//logical volume
+	if(fPackingCylinderLog == nullptr) {
+		fPackingCylinderLog = new G4LogicalVolume(packingCylinder, material, "packingCylinderLog", 0, 0, 0);
+		fPackingCylinderLog->SetVisAttributes(visAtt);
+	}
 
-    // place cylinder
-    zPosition 	= ( (fCanFrontLidThickness + fSealFrontLidThickness + fDiscFrontLidThickness + fPackingFrontLidThickness) - (fCanBackLidThickness) )/2.0;
-    move          = zPosition * direction;
+	// place cylinder
+	zPosition 	= ((fCanFrontLidThickness + fSealFrontLidThickness + fDiscFrontLidThickness + fPackingFrontLidThickness) - (fCanBackLidThickness))/2.0;
+	move          = zPosition * direction;
 
-    //add physical cylinder
-    fAssembly->AddPlacedVolume(fPackingCylinderLog, move, rotate);
+	//add physical cylinder
+	fAssembly->AddPlacedVolume(fPackingCylinderLog, move, rotate);
 
-    /////////////////////////////////////////////////////////////////////
-    // Build and Place Front Lid
-    /////////////////////////////////////////////////////////////////////
-    G4Tubs* packingFrontLid = BuildPackingFrontLid();
+	/////////////////////////////////////////////////////////////////////
+	// Build and Place Front Lid
+	/////////////////////////////////////////////////////////////////////
+	G4Tubs* packingFrontLid = BuildPackingFrontLid();
 
-    // logical volume
-    if(fPackingFrontLidLog == NULL) {
-        fPackingFrontLidLog = new G4LogicalVolume(packingFrontLid, material, "packingFrontLidLog", 0, 0, 0);
-        fPackingFrontLidLog->SetVisAttributes(visAtt);
-    }
+	// logical volume
+	if(fPackingFrontLidLog == nullptr) {
+		fPackingFrontLidLog = new G4LogicalVolume(packingFrontLid, material, "packingFrontLidLog", 0, 0, 0);
+		fPackingFrontLidLog->SetVisAttributes(visAtt);
+	}
 
-    // place front packingLid
-    zPosition 	= -(fDetectorLengthZ/2.0) + (fCanFrontLidThickness + fSealFrontLidThickness + fDiscFrontLidThickness + (fPackingFrontLidThickness/2.0));
-    move 		= zPosition * direction;
+	// place front packingLid
+	zPosition 	= -(fDetectorLengthZ/2.0) + (fCanFrontLidThickness + fSealFrontLidThickness + fDiscFrontLidThickness + (fPackingFrontLidThickness/2.0));
+	move 		= zPosition * direction;
 
-    //add physical front packingLid
-    fAssembly->AddPlacedVolume(fPackingFrontLidLog, move, rotate);
+	//add physical front packingLid
+	fAssembly->AddPlacedVolume(fPackingFrontLidLog, move, rotate);
 
-    return 1;
+	return 1;
 }
 
 G4int DetectionSystemSodiumIodide::BuildDiscVolume() {
-    G4Material* material = G4Material::GetMaterial(fDiscMaterial);
-    if( !material ) {
-        G4cout << " ----> Material " << fDiscMaterial << " not found, cannot build the detector shell! " << G4endl;
-        return 0;
-    }
+	G4Material* material = G4Material::GetMaterial(fDiscMaterial);
+	if(!material) {
+		G4cout<<" ----> Material "<<fDiscMaterial<<" not found, cannot build the detector shell! "<<G4endl;
+		return 0;
+	}
 
-    // Set visualization attributes
-    G4VisAttributes* visAtt = new G4VisAttributes(G4Colour(0.0,0.0,1.0));
-    visAtt->SetVisibility(true);
+	// Set visualization attributes
+	G4VisAttributes* visAtt = new G4VisAttributes(G4Colour(0.0,0.0,1.0));
+	visAtt->SetVisibility(true);
 
-    G4ThreeVector direction =  G4ThreeVector(0,0,1);
-    G4double zPosition;
-    G4ThreeVector move;
-    G4RotationMatrix* rotate = new G4RotationMatrix;
+	G4ThreeVector direction =  G4ThreeVector(0,0,1);
+	G4double zPosition;
+	G4ThreeVector move;
+	G4RotationMatrix* rotate = new G4RotationMatrix;
 
-    /////////////////////////////////////////////////////////////////////
-    // Build and Place Front Lid
-    /////////////////////////////////////////////////////////////////////
-    G4Tubs* discFrontLid = BuildDiscFrontLid();
+	/////////////////////////////////////////////////////////////////////
+	// Build and Place Front Lid
+	/////////////////////////////////////////////////////////////////////
+	G4Tubs* discFrontLid = BuildDiscFrontLid();
 
-    // logical volume
-    if(fDiscFrontLidLog == NULL) {
-        fDiscFrontLidLog = new G4LogicalVolume(discFrontLid, material, "discFrontLidLog", 0, 0, 0);
-        fDiscFrontLidLog->SetVisAttributes(visAtt);
-    }
+	// logical volume
+	if(fDiscFrontLidLog == nullptr) {
+		fDiscFrontLidLog = new G4LogicalVolume(discFrontLid, material, "discFrontLidLog", 0, 0, 0);
+		fDiscFrontLidLog->SetVisAttributes(visAtt);
+	}
 
-    // place front discLid
-    zPosition 	= -(fDetectorLengthZ/2.0) + (fCanFrontLidThickness + fSealFrontLidThickness + (fDiscFrontLidThickness/2.0));
-    move 		= zPosition * direction;
+	// place front discLid
+	zPosition 	= -(fDetectorLengthZ/2.0) + (fCanFrontLidThickness + fSealFrontLidThickness + (fDiscFrontLidThickness/2.0));
+	move 		= zPosition * direction;
 
-    //add physical front discLid
-    fAssembly->AddPlacedVolume(fDiscFrontLidLog, move, rotate);
+	//add physical front discLid
+	fAssembly->AddPlacedVolume(fDiscFrontLidLog, move, rotate);
 
-    return 1;
+	return 1;
 }
 
 G4int DetectionSystemSodiumIodide::BuildSealVolume() {
-    G4Material* material = G4Material::GetMaterial(fSealMaterial);
-    if( !material ) {
-        G4cout << " ----> Material " << fSealMaterial << " not found, cannot build the detector shell! " << G4endl;
-        return 0;
-    }
+	G4Material* material = G4Material::GetMaterial(fSealMaterial);
+	if(!material) {
+		G4cout<<" ----> Material "<<fSealMaterial<<" not found, cannot build the detector shell! "<<G4endl;
+		return 0;
+	}
 
-    // Set visualization attributes
-    G4VisAttributes* visAtt = new G4VisAttributes(G4Colour(0.0,0.0,0.0));
-    visAtt->SetVisibility(true);
+	// Set visualization attributes
+	G4VisAttributes* visAtt = new G4VisAttributes(G4Colour(0.0,0.0,0.0));
+	visAtt->SetVisibility(true);
 
-    G4ThreeVector direction =  G4ThreeVector(0,0,1);
-    G4double zPosition;
-    G4ThreeVector move;
-    G4RotationMatrix* rotate = new G4RotationMatrix;
+	G4ThreeVector direction =  G4ThreeVector(0,0,1);
+	G4double zPosition;
+	G4ThreeVector move;
+	G4RotationMatrix* rotate = new G4RotationMatrix;
 
-    /////////////////////////////////////////////////////////////////////
-    // Build and Place Front Lid
-    /////////////////////////////////////////////////////////////////////
-    G4Tubs* sealFrontLid = BuildSealFrontLid();
+	/////////////////////////////////////////////////////////////////////
+	// Build and Place Front Lid
+	/////////////////////////////////////////////////////////////////////
+	G4Tubs* sealFrontLid = BuildSealFrontLid();
 
-    // logical volume
-    if(fSealFrontLidLog == NULL) {
-        fSealFrontLidLog = new G4LogicalVolume(sealFrontLid, material, "sealFrontLidLog", 0, 0, 0);
-        fSealFrontLidLog->SetVisAttributes(visAtt);
-    }
+	// logical volume
+	if(fSealFrontLidLog == nullptr) {
+		fSealFrontLidLog = new G4LogicalVolume(sealFrontLid, material, "sealFrontLidLog", 0, 0, 0);
+		fSealFrontLidLog->SetVisAttributes(visAtt);
+	}
 
-    // place front sealLid
-    zPosition 	= -(fDetectorLengthZ/2.0) + (fCanFrontLidThickness + (fSealFrontLidThickness/2.0));
-    move 		= zPosition * direction;
+	// place front sealLid
+	zPosition 	= -(fDetectorLengthZ/2.0) + (fCanFrontLidThickness + (fSealFrontLidThickness/2.0));
+	move 		= zPosition * direction;
 
-    //add physical front sealLid
-    fAssembly->AddPlacedVolume(fSealFrontLidLog, move, rotate);
+	//add physical front sealLid
+	fAssembly->AddPlacedVolume(fSealFrontLidLog, move, rotate);
 
-    return 1;
+	return 1;
 }
 
 ///////////////////////////////////////////////////////////////////////
 // Methods used to build shapes
 ///////////////////////////////////////////////////////////////////////
 G4Tubs* DetectionSystemSodiumIodide::BuildCrystal() {
-    G4double startPhi = 0.0;
-    G4double endPhi = fDetailViewEndAngle;
+	G4double startPhi = 0.0;
+	G4double endPhi = fDetailViewEndAngle;
 
-    G4double innerRadius = fCrystalInnerRadius;
-    G4double outerRadius = fCrystalOuterRadius;
-    G4double halfLengthZ = (fCrystalLengthZ)/2.0;
+	G4double innerRadius = fCrystalInnerRadius;
+	G4double outerRadius = fCrystalOuterRadius;
+	G4double halfLengthZ = (fCrystalLengthZ)/2.0;
 
-    G4Tubs* crystalBlock = new G4Tubs("crystalBlock", innerRadius, outerRadius, halfLengthZ, startPhi, endPhi);
+	G4Tubs* crystalBlock = new G4Tubs("crystalBlock", innerRadius, outerRadius, halfLengthZ, startPhi, endPhi);
 
-    return crystalBlock;
+	return crystalBlock;
 }//end ::BuildCrystal
 
 
 G4Tubs* DetectionSystemSodiumIodide::BuildAluminumCan() {
-    G4double startPhi = 0.0;
-    G4double endPhi = fDetailViewEndAngle;
+	G4double startPhi = 0.0;
+	G4double endPhi = fDetailViewEndAngle;
 
-    G4double innerRadius 	= fCanInnerRadius;
-    G4double outerRadius 	= fCanOuterRadius;
-    G4double halfLengthZ 	= fCanLengthZ/2.0;
+	G4double innerRadius 	= fCanInnerRadius;
+	G4double outerRadius 	= fCanOuterRadius;
+	G4double halfLengthZ 	= fCanLengthZ/2.0;
 
-    G4Tubs* canCylinder = new G4Tubs("canCylinder", innerRadius, outerRadius, halfLengthZ, startPhi, endPhi);
+	G4Tubs* canCylinder = new G4Tubs("canCylinder", innerRadius, outerRadius, halfLengthZ, startPhi, endPhi);
 
-    return canCylinder;
+	return canCylinder;
 }//end ::BuildAluminumCan
 
 G4Tubs* DetectionSystemSodiumIodide::BuildAluminumCanFrontLid() {
-    G4double startPhi = 0.0;
-    G4double endPhi = fDetailViewEndAngle;
+	G4double startPhi = 0.0;
+	G4double endPhi = fDetailViewEndAngle;
 
-    G4double innerRadius = fCanLidInnerRadius;
-    G4double outerRadius = fCanLidOuterRadius;
-    G4double halfLengthZ = fCanFrontLidThickness/2.0;
+	G4double innerRadius = fCanLidInnerRadius;
+	G4double outerRadius = fCanLidOuterRadius;
+	G4double halfLengthZ = fCanFrontLidThickness/2.0;
 
-    G4Tubs* canLid = new G4Tubs("canLid", innerRadius, outerRadius, halfLengthZ, startPhi, endPhi);
+	G4Tubs* canLid = new G4Tubs("canLid", innerRadius, outerRadius, halfLengthZ, startPhi, endPhi);
 
-    return canLid;
+	return canLid;
 }//end ::BuildAluminumFrontLid
 
 G4Tubs* DetectionSystemSodiumIodide::BuildAluminumCanBackLid() {
-    G4double startPhi = 0.0;
-    G4double endPhi = fDetailViewEndAngle;
+	G4double startPhi = 0.0;
+	G4double endPhi = fDetailViewEndAngle;
 
-    G4double innerRadius = fCanLidInnerRadius;
-    G4double outerRadius = fCanLidOuterRadius;
-    G4double halfLengthZ = fCanBackLidThickness/2.0;
+	G4double innerRadius = fCanLidInnerRadius;
+	G4double outerRadius = fCanLidOuterRadius;
+	G4double halfLengthZ = fCanBackLidThickness/2.0;
 
-    G4Tubs* canLid = new G4Tubs("canLid", innerRadius, outerRadius, halfLengthZ, startPhi, endPhi);
+	G4Tubs* canLid = new G4Tubs("canLid", innerRadius, outerRadius, halfLengthZ, startPhi, endPhi);
 
-    return canLid;
+	return canLid;
 }//end ::BuildAluminumBackLid
 
 G4Tubs* DetectionSystemSodiumIodide::BuildPacking() {
-    G4double startPhi = 0.0;
-    G4double endPhi = fDetailViewEndAngle;
+	G4double startPhi = 0.0;
+	G4double endPhi = fDetailViewEndAngle;
 
-    G4double innerRadius 	= fPackingInnerRadius;
-    G4double outerRadius 	= fPackingOuterRadius;
-    G4double halfLengthZ 	= fPackingLengthZ/2.0;
+	G4double innerRadius 	= fPackingInnerRadius;
+	G4double outerRadius 	= fPackingOuterRadius;
+	G4double halfLengthZ 	= fPackingLengthZ/2.0;
 
-    G4Tubs* packingCylinder = new G4Tubs("packingCylinder", innerRadius, outerRadius, halfLengthZ, startPhi, endPhi);
+	G4Tubs* packingCylinder = new G4Tubs("packingCylinder", innerRadius, outerRadius, halfLengthZ, startPhi, endPhi);
 
-    return packingCylinder;
+	return packingCylinder;
 }//end ::BuildPacking
 
 G4Tubs* DetectionSystemSodiumIodide::BuildPackingFrontLid() {
-    G4double startPhi = 0.0;
-    G4double endPhi = fDetailViewEndAngle;
+	G4double startPhi = 0.0;
+	G4double endPhi = fDetailViewEndAngle;
 
-    G4double innerRadius = fPackingLidInnerRadius;
-    G4double outerRadius = fPackingLidOuterRadius;
-    G4double halfLengthZ = fPackingFrontLidThickness/2.0;
+	G4double innerRadius = fPackingLidInnerRadius;
+	G4double outerRadius = fPackingLidOuterRadius;
+	G4double halfLengthZ = fPackingFrontLidThickness/2.0;
 
-    G4Tubs* packingLid = new G4Tubs("packingLid", innerRadius, outerRadius, halfLengthZ, startPhi, endPhi);
+	G4Tubs* packingLid = new G4Tubs("packingLid", innerRadius, outerRadius, halfLengthZ, startPhi, endPhi);
 
-    return packingLid;
+	return packingLid;
 }//end ::BuildPackingFrontLid
 
 G4Tubs* DetectionSystemSodiumIodide::BuildDiscFrontLid() {
-    G4double startPhi = 0.0;
-    G4double endPhi = fDetailViewEndAngle;
+	G4double startPhi = 0.0;
+	G4double endPhi = fDetailViewEndAngle;
 
-    G4double innerRadius = fDiscLidInnerRadius;
-    G4double outerRadius = fDiscLidOuterRadius;
-    G4double halfLengthZ = fDiscFrontLidThickness/2.0;
+	G4double innerRadius = fDiscLidInnerRadius;
+	G4double outerRadius = fDiscLidOuterRadius;
+	G4double halfLengthZ = fDiscFrontLidThickness/2.0;
 
-    G4Tubs* discLid = new G4Tubs("discLid", innerRadius, outerRadius, halfLengthZ, startPhi, endPhi);
+	G4Tubs* discLid = new G4Tubs("discLid", innerRadius, outerRadius, halfLengthZ, startPhi, endPhi);
 
-    return discLid;
+	return discLid;
 }//end ::BuildDiscFrontLid
 
 G4Tubs* DetectionSystemSodiumIodide::BuildSealFrontLid() {
-    G4double startPhi = 0.0;
-    G4double endPhi = fDetailViewEndAngle;
+	G4double startPhi = 0.0;
+	G4double endPhi = fDetailViewEndAngle;
 
-    G4double innerRadius = fSealLidInnerRadius;
-    G4double outerRadius = fSealLidOuterRadius;
-    G4double halfLengthZ = fSealFrontLidThickness/2.0;
+	G4double innerRadius = fSealLidInnerRadius;
+	G4double outerRadius = fSealLidOuterRadius;
+	G4double halfLengthZ = fSealFrontLidThickness/2.0;
 
-    G4Tubs* sealLid = new G4Tubs("sealLid", innerRadius, outerRadius, halfLengthZ, startPhi, endPhi);
+	G4Tubs* sealLid = new G4Tubs("sealLid", innerRadius, outerRadius, halfLengthZ, startPhi, endPhi);
 
-    return sealLid;
+	return sealLid;
 }//end ::BuildSealFrontLid
 
 //Calculate a direction vector from spherical theta & phi components
 G4ThreeVector DetectionSystemSodiumIodide::GetDirectionXYZ(G4double theta, G4double phi) {
-    G4double x,y,z;
-    x = sin(theta) * cos(phi);
-    y = sin(theta) * sin(phi);
-    z = cos(theta);
+	G4double x,y,z;
+	x = sin(theta) * cos(phi);
+	y = sin(theta) * sin(phi);
+	z = cos(theta);
 
-    G4ThreeVector direction = G4ThreeVector(x,y,z);
+	G4ThreeVector direction = G4ThreeVector(x,y,z);
 
-    return direction;
+	return direction;
 }//end ::GetDirection
 

--- a/src/DetectionSystemSpice.cc
+++ b/src/DetectionSystemSpice.cc
@@ -218,7 +218,7 @@ G4int DetectionSystemSpice::BuildPlaceSiliconWafer(G4LogicalVolume* ExpHallLog)
 
 	for(int sec=0;sec<this->fSiDetPhiSegments;sec++){
 		std::stringstream temp;
-		temp << "SiSegmentPhys" <<r*12+sec;
+		temp<<"SiSegmentPhys_"<<r<<"_"<<sec;
 		new G4PVPlacement(rotsec[sec],G4ThreeVector(0,0,0), fSiSegmentLog, temp.str(),  siDetMotherLog, false, 0);
 	}	
   }

--- a/src/DetectionSystemSpice.cc
+++ b/src/DetectionSystemSpice.cc
@@ -20,7 +20,7 @@
 #include "G4PVReplica.hh"
 #include "G4PVDivision.hh"
 
-
+#include "G4SystemOfUnits.hh"
 
 #include "G4VisAttributes.hh"
 #include "G4Colour.hh"
@@ -28,62 +28,60 @@
 #include "DetectionSystemSpice.hh"
 #include "HistoManager.hh" // for spice histogram array when placing detector
 
-using namespace CLHEP;
-
 DetectionSystemSpice::DetectionSystemSpice() 
 {
-    /////////////////////////////////////////////////////////////////////
-    // SPICE Physical Properties
-    /////////////////////////////////////////////////////////////////////
+	/////////////////////////////////////////////////////////////////////
+	// SPICE Physical Properties
+	/////////////////////////////////////////////////////////////////////
 	//-----------------------------//
-    // Materials     			   //
-    //-----------------------------//
-    this->fWaferMaterial          = "Silicon";
-  	this->fDetectorMountMaterial = "Aluminum"; // CHECK ?
-  	this->fAnnularClampMaterial  = "Peek"; // CHECK ?
-  
+	// Materials     			   //
+	//-----------------------------//
+	fWaferMaterial          = "Silicon";
+	fDetectorMountMaterial = "Aluminum"; // CHECK ?
+	fAnnularClampMaterial  = "Peek"; // CHECK ?
+
 	// ----------------------------
 	// Dimensions of Detector Mount
 	// ----------------------------
-	this->fDetectorMountLength = 148*mm;
-	this->fDetectorMountWidth = 130*mm;
-	this->fDetectorMountThickness = 8*mm;
-	this->fDetectorMountInnerRadius = 52.8*mm;
-	this->fDetectorMountLipRadius = 48.3*mm;
-	this->fDetectorMountLipThickness = 1*mm;
-	this->fDetectorMountAngularOffset = 0*deg;
-	
-	
-	this->fDetectorToTargetDistance = ApparatusSpiceTargetChamber::fTargetChamberDistanceFromTarget +117.6*mm;
-	this->fDetectorThickness = 6*mm;
+	fDetectorMountLength = 148*mm;
+	fDetectorMountWidth = 130*mm;
+	fDetectorMountThickness = 8*mm;
+	fDetectorMountInnerRadius = 52.8*mm;
+	fDetectorMountLipRadius = 48.3*mm;
+	fDetectorMountLipThickness = 1*mm;
+	fDetectorMountAngularOffset = 0*deg;
+
+
+	fDetectorToTargetDistance = ApparatusSpiceTargetChamber::fTargetChamberDistanceFromTarget +117.6*mm;
+	fDetectorThickness = 6*mm;
 
 	// ---------------------------
 	// Dimensions of Annular Clamp
 	// ---------------------------
-	this->fAnnularClampThickness = 2*mm;
-	this->fAnnularClampLength = 19.2*mm;
-	this->fAnnularClampWidth = 20*mm;
-	this->fAnnularClampPlaneOffset = 47.8*mm; //from beam line to first edge  
+	fAnnularClampThickness = 2*mm;
+	fAnnularClampLength = 19.2*mm;
+	fAnnularClampWidth = 20*mm;
+	fAnnularClampPlaneOffset = 47.8*mm; //from beam line to first edge  
 
-    //-----------------------------//
-    // parameters for the annular  //
-    // planar detector crystal     //
-    //-----------------------------//
-    this->fSiDetCrystalOuterDiameter = 102.*mm;
-    this->fSiDetCrystalInnerDiameter = 10.*mm;
-    this->fSiDetCrystalActiveInnerDiameter = 16.0*mm;
-    this->fSiDetCrystalActiveOuterDiameter = 94.0*mm;
-    this->fSiDetRingRadii = 3.9*mm;
-    this->fSiDetCrystalThickness = 6.15*mm;
-    this->fSiDetRadialSegments = 10;
-    this->fSiDetPhiSegments = 12;
+	//-----------------------------//
+	// parameters for the annular  //
+	// planar detector crystal     //
+	//-----------------------------//
+	fSiDetCrystalOuterDiameter = 102.*mm;
+	fSiDetCrystalInnerDiameter = 10.*mm;
+	fSiDetCrystalActiveInnerDiameter = 16.0*mm;
+	fSiDetCrystalActiveOuterDiameter = 94.0*mm;
+	fSiDetRingRadii = 3.9*mm;
+	fSiDetCrystalThickness = 6.15*mm;
+	fSiDetRadialSegments = 10;
+	fSiDetPhiSegments = 12;
 
-    //-----------------------------//
-    // parameters for guard ring   //
-    //-----------------------------//
-    this->fSiDetGuardRingOuterDiameter = 102*mm;
-    this->fSiDetGuardRingInnerDiameter = 10*mm;
-    
+	//-----------------------------//
+	// parameters for guard ring   //
+	//-----------------------------//
+	fSiDetGuardRingOuterDiameter = 102*mm;
+	fSiDetGuardRingInnerDiameter = 10*mm;
+
 }
 
 DetectionSystemSpice::~DetectionSystemSpice()
@@ -100,52 +98,52 @@ DetectionSystemSpice::~DetectionSystemSpice()
 G4int DetectionSystemSpice::BuildPlace(G4LogicalVolume* ExpHallLog)
 {
 	BuildPlaceSiliconWafer(ExpHallLog);  
-	
+
 	BuildDetectorMount();
 	PlaceDetectorMount(ExpHallLog);
 
 	BuildAnnularClamps();
 	PlaceAnnularClamps(ExpHallLog);
-  
-  return 1;
+
+	return 1;
 } // end Build
 
 
 
 void DetectionSystemSpice::PlaceDetectorMount(G4LogicalVolume* exp_hall_log)
 {
-  G4double annularDetectorDistance = this->fDetectorToTargetDistance;
-  G4ThreeVector pos(0,0,-annularDetectorDistance); 
-  G4double detector_mount_gap = this->fDetectorMountThickness 
-    - this->fDetectorMountLipThickness - this->fDetectorThickness;
+	G4double annularDetectorDistance = fDetectorToTargetDistance;
+	G4ThreeVector pos(0,0,-annularDetectorDistance); 
+	G4double detector_mount_gap = fDetectorMountThickness 
+		- fDetectorMountLipThickness - fDetectorThickness;
 
-  G4double z_offset = - this->fDetectorMountThickness/2. + detector_mount_gap ;
-  G4ThreeVector offset(0, 0, z_offset);
+	G4double z_offset = - fDetectorMountThickness/2. + detector_mount_gap ;
+	G4ThreeVector offset(0, 0, z_offset);
 
-  pos = pos + offset ; 
-  G4RotationMatrix* rotate = new G4RotationMatrix(this->fDetectorMountAngularOffset, 0, 0);
-  fDetectorMountPhys = new G4PVPlacement(rotate, pos, fDetectorMountLog,
-	"detector_mount", exp_hall_log, false, 0);
+	pos = pos + offset ; 
+	G4RotationMatrix* rotate = new G4RotationMatrix(fDetectorMountAngularOffset, 0, 0);
+	fDetectorMountPhys = new G4PVPlacement(rotate, pos, fDetectorMountLog,
+			"detector_mount", exp_hall_log, false, 0);
 
 } // end::PlaceDetectorMount()
 
 void DetectionSystemSpice::PlaceAnnularClamps(G4LogicalVolume* exp_hall_log) {
-    G4double annularDetectorDistance = this->fDetectorToTargetDistance;
-  G4ThreeVector pos(0,0,-annularDetectorDistance); 
-  G4double z_offset = this->fAnnularClampThickness/2. ;
-  G4double x_offset = (this->fAnnularClampPlaneOffset
-		       + this->fAnnularClampLength/2.) 
-    * cos(this->fDetectorMountAngularOffset + 45*deg);
-  G4double y_offset = (this->fAnnularClampPlaneOffset
-		       + this->fAnnularClampLength/2.)
-    * sin(this->fDetectorMountAngularOffset + 45*deg);
-  G4ThreeVector offset(-x_offset, -y_offset, z_offset);
- 
-  pos = pos + offset ; 	 
-  G4RotationMatrix* rotate = new G4RotationMatrix(this->fDetectorMountAngularOffset + 45*deg, 0, 0);
-  fAnnularClampPhys = new G4PVPlacement(rotate, pos, fAnnularClampLog,"annular_clamp", exp_hall_log,
-					 false,0);
-  
+	G4double annularDetectorDistance = fDetectorToTargetDistance;
+	G4ThreeVector pos(0,0,-annularDetectorDistance); 
+	G4double z_offset = fAnnularClampThickness/2. ;
+	G4double x_offset = (fAnnularClampPlaneOffset
+			+ fAnnularClampLength/2.) 
+		* cos(fDetectorMountAngularOffset + 45*deg);
+	G4double y_offset = (fAnnularClampPlaneOffset
+			+ fAnnularClampLength/2.)
+		* sin(fDetectorMountAngularOffset + 45*deg);
+	G4ThreeVector offset(-x_offset, -y_offset, z_offset);
+
+	pos = pos + offset ; 	 
+	G4RotationMatrix* rotate = new G4RotationMatrix(fDetectorMountAngularOffset + 45*deg, 0, 0);
+	fAnnularClampPhys = new G4PVPlacement(rotate, pos, fAnnularClampLog,"annular_clamp", exp_hall_log,
+			false,0);
+
 } // end::PlaceAnnularClamps()
 
 //---------------------------------------------------------//
@@ -155,197 +153,197 @@ void DetectionSystemSpice::PlaceAnnularClamps(G4LogicalVolume* exp_hall_log) {
 
 G4int DetectionSystemSpice::BuildPlaceSiliconWafer(G4LogicalVolume* ExpHallLog) 
 {
-   // Define the material, return error if not found
-  G4Material* material = G4Material::GetMaterial(this->fWaferMaterial);
-  if( !material ) {
-  	G4cout << " ----> Material " << this->fWaferMaterial<< " not found, cannot build the SPICE detecto! " << G4endl;
-        return 0;
-  }
-  G4Material* matWorld = G4Material::GetMaterial("Vacuum");
-  if( !matWorld ) {
-	 G4cout << " ----> Material Vacuum not found! " << G4endl;
-	 return 0;
-  }
-  
-  // Set visualization attributes
-  G4VisAttributes* vis_att = new G4VisAttributes(G4Colour(0.0,1.0,1.0));
-  vis_att->SetVisibility(true);  
-  G4VisAttributes* vis_att_hid = new G4VisAttributes(G4Colour(0.0,1.0,1.0));
-  vis_att_hid->SetVisibility(false);
+	// Define the material, return error if not found
+	G4Material* material = G4Material::GetMaterial(fWaferMaterial);
+	if(!material) {
+		G4cout<<" ----> Material "<<fWaferMaterial<< " not found, cannot build the SPICE detecto! "<<G4endl;
+		return 0;
+	}
+	G4Material* matWorld = G4Material::GetMaterial("Vacuum");
+	if(!matWorld) {
+		G4cout<<" ----> Material Vacuum not found! "<<G4endl;
+		return 0;
+	}
 
-  // Define rotation and movement objects
-  G4RotationMatrix* rotate = new G4RotationMatrix;
- 
-  G4double tube_dPhi = 2.* M_PI * rad;
-  
-  // Detector crystal mother
-  G4Tubs* siDetMother = new G4Tubs("siDetMother",(this->fSiDetGuardRingInnerDiameter)/2.0,(this->fSiDetGuardRingOuterDiameter)/2.0 ,(this->fSiDetCrystalThickness)/2.0,0, tube_dPhi);
-  G4LogicalVolume* siDetMotherLog = new G4LogicalVolume(siDetMother, matWorld, "fDetActiveLog", 0,0,0);  
-  siDetMotherLog->SetVisAttributes(vis_att_hid);
-  fSiliLog.push_back(siDetMotherLog);
-  
-  //Guard Rings
-  //Solids
-  G4Tubs* siDetInnerGuardRing = new G4Tubs("siDetInnerGuardRing",(this->fSiDetGuardRingInnerDiameter)/2.0,(this->fSiDetCrystalActiveInnerDiameter)/2.0 ,(this->fSiDetCrystalThickness)/2.0,0, tube_dPhi);
-  G4Tubs* siDetOuterGuardRing = new G4Tubs("siDetOuterGuardRing",(this->fSiDetCrystalActiveOuterDiameter)/2.0,(this->fSiDetGuardRingOuterDiameter)/2.0 ,(this->fSiDetCrystalThickness)/2.0,0, tube_dPhi); 
-  //Logical
-  G4LogicalVolume* fInnerGuardRingLog = new G4LogicalVolume(siDetInnerGuardRing, material, "fInnerGuardRingLog", 0,0,0);  
-  fInnerGuardRingLog->SetVisAttributes(vis_att);
-  fSiliLog.push_back(fInnerGuardRingLog);
-  G4LogicalVolume* fOuterGuardRingLog = new G4LogicalVolume(siDetOuterGuardRing, material, "fOuterGuardRingLog", 0,0,0);  
-  fOuterGuardRingLog->SetVisAttributes(vis_att);
-  fSiliLog.push_back(fOuterGuardRingLog);
-  //Place physical
-  new G4PVPlacement(rotate,G4ThreeVector(0,0,0), fInnerGuardRingLog, "SiLiInnerGuard",  siDetMotherLog, false, 0);
-  new G4PVPlacement(rotate,G4ThreeVector(0,0,0), fOuterGuardRingLog, "SiLiOuterGuard",  siDetMotherLog, false, 0);
+	// Set visualization attributes
+	G4VisAttributes* vis_att = new G4VisAttributes(G4Colour(0.0,1.0,1.0));
+	vis_att->SetVisibility(true);  
+	G4VisAttributes* vis_att_hid = new G4VisAttributes(G4Colour(0.0,1.0,1.0));
+	vis_att_hid->SetVisibility(false);
 
-  G4double divided_tube_dPhi = tube_dPhi/this->fSiDetPhiSegments;
-  
-  //Prepare rotation matrices 
-  std::vector<G4RotationMatrix*> rotsec;
-  G4double phioffset=180*deg;
-  for(int sec=0;sec<this->fSiDetPhiSegments;sec++){
-        G4RotationMatrix* rot = new G4RotationMatrix;
-	rot->rotateZ(phioffset - 30*deg*sec);
-	rotsec.push_back(rot);
-  }
-  
-  for(int r=0;r<this->fSiDetRadialSegments;r++){
-	G4Tubs* siDetSegment = new G4Tubs("siDetSegment",(this->fSiDetCrystalActiveInnerDiameter/2.0)+(this->fSiDetRingRadii*(r)),(this->fSiDetCrystalActiveInnerDiameter/2.0)+(this->fSiDetRingRadii*(r+1)),(this->fSiDetCrystalThickness)/2.0,0,divided_tube_dPhi);
-	G4LogicalVolume* fSiSegmentLog =new G4LogicalVolume(siDetSegment, material, "fSiSegmentLog", 0,0,0);
-	fSiSegmentLog->SetVisAttributes(vis_att);
-	fSiliLog.push_back(fSiSegmentLog);
+	// Define rotation and movement objects
+	G4RotationMatrix* rotate = new G4RotationMatrix;
 
-	for(int sec=0;sec<this->fSiDetPhiSegments;sec++){
-		std::stringstream temp;
-		temp<<"SiSegmentPhys_"<<r<<"_"<<sec;
-		new G4PVPlacement(rotsec[sec],G4ThreeVector(0,0,0), fSiSegmentLog, temp.str(),  siDetMotherLog, false, 0);
-	}	
-  }
+	G4double tube_dPhi = 2.* M_PI * rad;
 
-  G4ThreeVector direction 	= G4ThreeVector(0,0,1);
-  G4double z_position		= -(this->fSiDetCrystalThickness/2.)-this->fDetectorToTargetDistance;
-  G4ThreeVector move 		= z_position * direction;
-  
-  new G4PVPlacement(rotate,move, siDetMotherLog, "SiLiDetActive",  ExpHallLog, false, 0);
+	// Detector crystal mother
+	G4Tubs* siDetMother = new G4Tubs("siDetMother",(fSiDetGuardRingInnerDiameter)/2.0,(fSiDetGuardRingOuterDiameter)/2.0 ,(fSiDetCrystalThickness)/2.0,0, tube_dPhi);
+	G4LogicalVolume* siDetMotherLog = new G4LogicalVolume(siDetMother, matWorld, "fDetActiveLog", 0,0,0);  
+	siDetMotherLog->SetVisAttributes(vis_att_hid);
+	fSiliLog.push_back(siDetMotherLog);
 
-//   //// Alternate construction using recommended G4PVReplica class should actually be more efficient but causes particles volumes that arent observed with the simple above method.
-//   G4Tubs* siDetActiveArea = new G4Tubs("siDetActiveArea",(this->fSiDetCrystalActiveInnerDiameter)/2.0,(this->fSiDetCrystalActiveOuterDiameter)/2.0 ,(this->fSiDetCrystalThickness)/2.0,0, tube_dPhi);
-//   G4Tubs* siDetSector = new G4Tubs("siDetSector",(this->fSiDetCrystalActiveInnerDiameter)/2.0,(this->fSiDetCrystalActiveOuterDiameter)/2.0 ,(this->fSiDetCrystalThickness)/2.0,0,divided_tube_dPhi);
-//   G4Tubs* siDetSegment = new G4Tubs("siDetSegment",(this->fSiDetCrystalActiveInnerDiameter)/2.0,((this->fSiDetCrystalActiveInnerDiameter)/2.0)+(this->fSiDetRingRadii),(this->fSiDetCrystalThickness)/2.0,0,divided_tube_dPhi);
-//   G4LogicalVolume* fDetActiveLog = new G4LogicalVolume(siDetActiveArea, matWorld, "fDetActiveLog", 0,0,0);  
-//   fDetActiveLog->SetVisAttributes(vis_att_hid);
-//   G4LogicalVolume* fSiSectorLog = new G4LogicalVolume(siDetSector, matWorld, "fSiSectorLog", 0,0,0);  
-//   fSiSectorLog->SetVisAttributes(vis_att_hid);
-//   G4LogicalVolume* fSiSegmentLog = new G4LogicalVolume(siDetSegment, material, "fSiSegmentLog", 0,0,0);  
-//   fSiSegmentLog->SetVisAttributes(vis_att);
-//   new G4PVReplica("SiSectorPhys", fSiSectorLog, fDetActiveLog, kPhi, this->fSiDetPhiSegments, divided_tube_dPhi);
-//   new G4PVReplica("SiSegmentPhys", fSiSegmentLog, fSiSectorLog, kRho, this->fSiDetRadialSegments, this->fSiDetRingRadii,this->fSiDetCrystalActiveInnerDiameter/2.0);
-//   ////A quirk of G4PVReplica, cannot sub-divide a kRho so the order is important
-//   new G4PVPlacement(rotate,move, fDetActiveLog, "SiLiDetActive",  ExpHallLog, false, 0);
+	//Guard Rings
+	//Solids
+	G4Tubs* siDetInnerGuardRing = new G4Tubs("siDetInnerGuardRing",(fSiDetGuardRingInnerDiameter)/2.0,(fSiDetCrystalActiveInnerDiameter)/2.0 ,(fSiDetCrystalThickness)/2.0,0, tube_dPhi);
+	G4Tubs* siDetOuterGuardRing = new G4Tubs("siDetOuterGuardRing",(fSiDetCrystalActiveOuterDiameter)/2.0,(fSiDetGuardRingOuterDiameter)/2.0 ,(fSiDetCrystalThickness)/2.0,0, tube_dPhi); 
+	//Logical
+	G4LogicalVolume* fInnerGuardRingLog = new G4LogicalVolume(siDetInnerGuardRing, material, "fInnerGuardRingLog", 0,0,0);  
+	fInnerGuardRingLog->SetVisAttributes(vis_att);
+	fSiliLog.push_back(fInnerGuardRingLog);
+	G4LogicalVolume* fOuterGuardRingLog = new G4LogicalVolume(siDetOuterGuardRing, material, "fOuterGuardRingLog", 0,0,0);  
+	fOuterGuardRingLog->SetVisAttributes(vis_att);
+	fSiliLog.push_back(fOuterGuardRingLog);
+	//Place physical
+	new G4PVPlacement(rotate,G4ThreeVector(0,0,0), fInnerGuardRingLog, "SiLiInnerGuard",  siDetMotherLog, false, 0);
+	new G4PVPlacement(rotate,G4ThreeVector(0,0,0), fOuterGuardRingLog, "SiLiOuterGuard",  siDetMotherLog, false, 0);
 
-//   //// Other alternate which incorporates guard rings and should be even better, but causes more geometry warnings
-//   G4Tubs* siDetActiveArea = new G4Tubs("siDetActiveArea",(this->fSiDetGuardRingInnerDiameter)/2.0,(this->fSiDetGuardRingOuterDiameter)/2.0 ,(this->fSiDetCrystalThickness)/2.0,0, tube_dPhi);
-//   G4Tubs* siDetSector = new G4Tubs("siDetSector",(this->fSiDetGuardRingInnerDiameter)/2.0,(this->fSiDetGuardRingOuterDiameter)/2.0 ,(this->fSiDetCrystalThickness)/2.0,0,divided_tube_dPhi);
-//   G4Tubs* siDetSegment = new G4Tubs("siDetSegment",(this->fSiDetCrystalActiveInnerDiameter)/2.0,((this->fSiDetCrystalActiveInnerDiameter)/2.0)+(this->fSiDetRingRadii),(this->fSiDetCrystalThickness)/2.0,0,divided_tube_dPhi);
-//   G4LogicalVolume* fDetActiveLog = new G4LogicalVolume(siDetActiveArea, material, "fDetActiveLog", 0,0,0);  
-//   fDetActiveLog->SetVisAttributes(vis_att);
-//   G4LogicalVolume* fSiSectorLog = new G4LogicalVolume(siDetSector, material, "fSiSectorLog", 0,0,0);  
-//   fSiSectorLog->SetVisAttributes(vis_att_hid);
-//   G4LogicalVolume* fSiSegmentLog = new G4LogicalVolume(siDetSegment, material, "fSiSegmentLog", 0,0,0);  
-//   fSiSegmentLog->SetVisAttributes(vis_att);
-//   new G4PVReplica("SiSectorPhys", fSiSectorLog, fDetActiveLog, kPhi, 12, divided_tube_dPhi);
-//   new G4PVDivision("SiSegmentPhys",fSiSegmentLog,fSiSectorLog,kRho,10,this->fSiDetRingRadii,(this->fSiDetCrystalActiveInnerDiameter-this->fSiDetGuardRingInnerDiameter)/2.);
-//   G4VPhysicalVolume* PlaceActice = new G4PVPlacement(rotate,move, fDetActiveLog, "SiLiDetActive",  ExpHallLog, false, 0);
-  
-  
-  return 1;
+	G4double divided_tube_dPhi = tube_dPhi/fSiDetPhiSegments;
+
+	//Prepare rotation matrices 
+	std::vector<G4RotationMatrix*> rotsec;
+	G4double phioffset=180*deg;
+	for(int sec=0;sec<fSiDetPhiSegments;sec++){
+		G4RotationMatrix* rot = new G4RotationMatrix;
+		rot->rotateZ(phioffset - 30*deg*sec);
+		rotsec.push_back(rot);
+	}
+
+	for(int r=0;r<fSiDetRadialSegments;r++){
+		G4Tubs* siDetSegment = new G4Tubs("siDetSegment",(fSiDetCrystalActiveInnerDiameter/2.0)+(fSiDetRingRadii*(r)),(fSiDetCrystalActiveInnerDiameter/2.0)+(fSiDetRingRadii*(r+1)),(fSiDetCrystalThickness)/2.0,0,divided_tube_dPhi);
+		G4LogicalVolume* fSiSegmentLog =new G4LogicalVolume(siDetSegment, material, "fSiSegmentLog", 0,0,0);
+		fSiSegmentLog->SetVisAttributes(vis_att);
+		fSiliLog.push_back(fSiSegmentLog);
+
+		for(int sec=0;sec<fSiDetPhiSegments;sec++){
+			std::stringstream temp;
+			temp<<"SiSegmentPhys_"<<r<<"_"<<sec;
+			new G4PVPlacement(rotsec[sec],G4ThreeVector(0,0,0), fSiSegmentLog, temp.str(),  siDetMotherLog, false, 0);
+		}	
+	}
+
+	G4ThreeVector direction 	= G4ThreeVector(0,0,1);
+	G4double z_position		= -(fSiDetCrystalThickness/2.)-fDetectorToTargetDistance;
+	G4ThreeVector move 		= z_position * direction;
+
+	new G4PVPlacement(rotate,move, siDetMotherLog, "SiLiDetActive",  ExpHallLog, false, 0);
+
+	//   //// Alternate construction using recommended G4PVReplica class should actually be more efficient but causes particles volumes that arent observed with the simple above method.
+	//   G4Tubs* siDetActiveArea = new G4Tubs("siDetActiveArea",(fSiDetCrystalActiveInnerDiameter)/2.0,(fSiDetCrystalActiveOuterDiameter)/2.0 ,(fSiDetCrystalThickness)/2.0,0, tube_dPhi);
+	//   G4Tubs* siDetSector = new G4Tubs("siDetSector",(fSiDetCrystalActiveInnerDiameter)/2.0,(fSiDetCrystalActiveOuterDiameter)/2.0 ,(fSiDetCrystalThickness)/2.0,0,divided_tube_dPhi);
+	//   G4Tubs* siDetSegment = new G4Tubs("siDetSegment",(fSiDetCrystalActiveInnerDiameter)/2.0,((fSiDetCrystalActiveInnerDiameter)/2.0)+(fSiDetRingRadii),(fSiDetCrystalThickness)/2.0,0,divided_tube_dPhi);
+	//   G4LogicalVolume* fDetActiveLog = new G4LogicalVolume(siDetActiveArea, matWorld, "fDetActiveLog", 0,0,0);  
+	//   fDetActiveLog->SetVisAttributes(vis_att_hid);
+	//   G4LogicalVolume* fSiSectorLog = new G4LogicalVolume(siDetSector, matWorld, "fSiSectorLog", 0,0,0);  
+	//   fSiSectorLog->SetVisAttributes(vis_att_hid);
+	//   G4LogicalVolume* fSiSegmentLog = new G4LogicalVolume(siDetSegment, material, "fSiSegmentLog", 0,0,0);  
+	//   fSiSegmentLog->SetVisAttributes(vis_att);
+	//   new G4PVReplica("SiSectorPhys", fSiSectorLog, fDetActiveLog, kPhi, fSiDetPhiSegments, divided_tube_dPhi);
+	//   new G4PVReplica("SiSegmentPhys", fSiSegmentLog, fSiSectorLog, kRho, fSiDetRadialSegments, fSiDetRingRadii,fSiDetCrystalActiveInnerDiameter/2.0);
+	//   ////A quirk of G4PVReplica, cannot sub-divide a kRho so the order is important
+	//   new G4PVPlacement(rotate,move, fDetActiveLog, "SiLiDetActive",  ExpHallLog, false, 0);
+
+	//   //// Other alternate which incorporates guard rings and should be even better, but causes more geometry warnings
+	//   G4Tubs* siDetActiveArea = new G4Tubs("siDetActiveArea",(fSiDetGuardRingInnerDiameter)/2.0,(fSiDetGuardRingOuterDiameter)/2.0 ,(fSiDetCrystalThickness)/2.0,0, tube_dPhi);
+	//   G4Tubs* siDetSector = new G4Tubs("siDetSector",(fSiDetGuardRingInnerDiameter)/2.0,(fSiDetGuardRingOuterDiameter)/2.0 ,(fSiDetCrystalThickness)/2.0,0,divided_tube_dPhi);
+	//   G4Tubs* siDetSegment = new G4Tubs("siDetSegment",(fSiDetCrystalActiveInnerDiameter)/2.0,((fSiDetCrystalActiveInnerDiameter)/2.0)+(fSiDetRingRadii),(fSiDetCrystalThickness)/2.0,0,divided_tube_dPhi);
+	//   G4LogicalVolume* fDetActiveLog = new G4LogicalVolume(siDetActiveArea, material, "fDetActiveLog", 0,0,0);  
+	//   fDetActiveLog->SetVisAttributes(vis_att);
+	//   G4LogicalVolume* fSiSectorLog = new G4LogicalVolume(siDetSector, material, "fSiSectorLog", 0,0,0);  
+	//   fSiSectorLog->SetVisAttributes(vis_att_hid);
+	//   G4LogicalVolume* fSiSegmentLog = new G4LogicalVolume(siDetSegment, material, "fSiSegmentLog", 0,0,0);  
+	//   fSiSegmentLog->SetVisAttributes(vis_att);
+	//   new G4PVReplica("SiSectorPhys", fSiSectorLog, fDetActiveLog, kPhi, 12, divided_tube_dPhi);
+	//   new G4PVDivision("SiSegmentPhys",fSiSegmentLog,fSiSectorLog,kRho,10,fSiDetRingRadii,(fSiDetCrystalActiveInnerDiameter-fSiDetGuardRingInnerDiameter)/2.);
+	//   G4VPhysicalVolume* PlaceActice = new G4PVPlacement(rotate,move, fDetActiveLog, "SiLiDetActive",  ExpHallLog, false, 0);
+
+
+	return 1;
 }
 
 void DetectionSystemSpice::BuildDetectorMount() {
 
-  // ** Visualisation
-  G4VisAttributes* vis_att = new G4VisAttributes(G4Colour(AL_COL));
-  vis_att->SetVisibility(true);
-  
-  // ** Dimensions
-  // Box
-  G4double box_half_width = this->fDetectorMountWidth/2.;
-  G4double box_half_length = this->fDetectorMountLength/2.;
-  G4double box_half_thickness = this->fDetectorMountThickness/2.;
-  // Inner Radius
-  G4double lip_radius = this->fDetectorMountLipRadius;
-  //G4double lip_half_thickness = this->fDetectorMountLipThickness/2.;
-  G4double box_cut_radius = this->fDetectorMountInnerRadius;
-  // Annular Clamp
-  G4double clamp_half_thickness = this->fAnnularClampThickness;
-  G4double clamp_half_width = this->fAnnularClampWidth/2.;
-  G4double clamp_half_length = this->fAnnularClampLength/2.;
-  
-  // ** Shapes
-  G4Box* mount_box = new G4Box("mount_box", box_half_width, box_half_length, box_half_thickness);
-  G4Tubs* inner_radius_cut = new G4Tubs("inner_radius_cut", 0, lip_radius, 2*box_half_thickness, 0, 360*deg);
-  G4Tubs* lip_cut = new G4Tubs("lip_cut", 0, box_cut_radius, box_half_thickness, 0, 360*deg);
-  G4Box* annular_clamp = new G4Box("annular_clamp", clamp_half_width, clamp_half_length, clamp_half_thickness);
-  
-  G4SubtractionSolid* detector_mount_pre = new G4SubtractionSolid("detector_mount_pre", mount_box, inner_radius_cut);
-  G4ThreeVector trans(0, 0, this->fDetectorMountLipThickness);
-  G4SubtractionSolid* detector_mount = new G4SubtractionSolid("detector_mount", detector_mount_pre, lip_cut, 0, trans);
-  
-  G4double plane_offset = (this->fAnnularClampPlaneOffset + clamp_half_length) / sqrt(2.);
-  G4double z_offset = box_half_thickness;
-  G4ThreeVector move(plane_offset, plane_offset, z_offset);
-  G4RotationMatrix* rotate = new G4RotationMatrix(45*deg, 0, 0);
-  G4SubtractionSolid* detector_mount2 = new G4SubtractionSolid("detector_mount2", detector_mount, annular_clamp, rotate, move);
-  move.setX(-plane_offset);
-  rotate->rotateZ(90*deg);
-  G4SubtractionSolid* detector_mount3 = new G4SubtractionSolid("detector_mount3", detector_mount2, annular_clamp, rotate, move);
-  move.setY(-plane_offset);
-  rotate->rotateZ(90*deg);
-  G4SubtractionSolid* detector_mount4 = new G4SubtractionSolid("detector_mount4", detector_mount3, annular_clamp, rotate, move);
-  move.setX(plane_offset);
-  rotate->rotateZ(90*deg);
-  G4SubtractionSolid* detector_mount5 = new G4SubtractionSolid("detector_mount5", detector_mount4, annular_clamp, rotate, move);
-  
-  // ** Logical
-  G4Material* DetectorMountMaterial = G4Material::GetMaterial(fDetectorMountMaterial);
-  fDetectorMountLog = new G4LogicalVolume(detector_mount5, DetectorMountMaterial, "fDetectorMountLog", 0, 0, 0);
-  fDetectorMountLog->SetVisAttributes(vis_att);
-  
-    //this->fAssembly->AddPlacedVolume(fDetectorMountLog, move, rotate); CHECK!!
-    
+	// ** Visualisation
+	G4VisAttributes* vis_att = new G4VisAttributes(G4Colour(AL_COL));
+	vis_att->SetVisibility(true);
+
+	// ** Dimensions
+	// Box
+	G4double box_half_width = fDetectorMountWidth/2.;
+	G4double box_half_length = fDetectorMountLength/2.;
+	G4double box_half_thickness = fDetectorMountThickness/2.;
+	// Inner Radius
+	G4double lip_radius = fDetectorMountLipRadius;
+	//G4double lip_half_thickness = fDetectorMountLipThickness/2.;
+	G4double box_cut_radius = fDetectorMountInnerRadius;
+	// Annular Clamp
+	G4double clamp_half_thickness = fAnnularClampThickness;
+	G4double clamp_half_width = fAnnularClampWidth/2.;
+	G4double clamp_half_length = fAnnularClampLength/2.;
+
+	// ** Shapes
+	G4Box* mount_box = new G4Box("mount_box", box_half_width, box_half_length, box_half_thickness);
+	G4Tubs* inner_radius_cut = new G4Tubs("inner_radius_cut", 0, lip_radius, 2*box_half_thickness, 0, 360*deg);
+	G4Tubs* lip_cut = new G4Tubs("lip_cut", 0, box_cut_radius, box_half_thickness, 0, 360*deg);
+	G4Box* annular_clamp = new G4Box("annular_clamp", clamp_half_width, clamp_half_length, clamp_half_thickness);
+
+	G4SubtractionSolid* detector_mount_pre = new G4SubtractionSolid("detector_mount_pre", mount_box, inner_radius_cut);
+	G4ThreeVector trans(0, 0, fDetectorMountLipThickness);
+	G4SubtractionSolid* detector_mount = new G4SubtractionSolid("detector_mount", detector_mount_pre, lip_cut, 0, trans);
+
+	G4double plane_offset = (fAnnularClampPlaneOffset + clamp_half_length) / sqrt(2.);
+	G4double z_offset = box_half_thickness;
+	G4ThreeVector move(plane_offset, plane_offset, z_offset);
+	G4RotationMatrix* rotate = new G4RotationMatrix(45*deg, 0, 0);
+	G4SubtractionSolid* detector_mount2 = new G4SubtractionSolid("detector_mount2", detector_mount, annular_clamp, rotate, move);
+	move.setX(-plane_offset);
+	rotate->rotateZ(90*deg);
+	G4SubtractionSolid* detector_mount3 = new G4SubtractionSolid("detector_mount3", detector_mount2, annular_clamp, rotate, move);
+	move.setY(-plane_offset);
+	rotate->rotateZ(90*deg);
+	G4SubtractionSolid* detector_mount4 = new G4SubtractionSolid("detector_mount4", detector_mount3, annular_clamp, rotate, move);
+	move.setX(plane_offset);
+	rotate->rotateZ(90*deg);
+	G4SubtractionSolid* detector_mount5 = new G4SubtractionSolid("detector_mount5", detector_mount4, annular_clamp, rotate, move);
+
+	// ** Logical
+	G4Material* DetectorMountMaterial = G4Material::GetMaterial(fDetectorMountMaterial);
+	fDetectorMountLog = new G4LogicalVolume(detector_mount5, DetectorMountMaterial, "fDetectorMountLog", 0, 0, 0);
+	fDetectorMountLog->SetVisAttributes(vis_att);
+
+	//fAssembly->AddPlacedVolume(fDetectorMountLog, move, rotate); CHECK!!
+
 } // end::BuildDetectorMount()
 
 void DetectionSystemSpice::BuildAnnularClamps() {
 
-  // ** Visualisation
-  G4VisAttributes* vis_att = new G4VisAttributes(G4Colour(PEEK_COL));
-  vis_att->SetVisibility(true);
-  
-  // ** Dimensions
-  G4double clamp_half_length = this->fAnnularClampLength/2.;
-  G4double clamp_half_width = this->fAnnularClampWidth/2.;
-  G4double clamp_half_thickness = this->fAnnularClampThickness/2.;
-  // Distance
-  G4double beam_clamp_distance = this->fAnnularClampPlaneOffset + clamp_half_length;
-  
-  // ** Shapes
-  G4Box* annular_clamp = new G4Box("annular_clamp", clamp_half_width, clamp_half_length, clamp_half_thickness);
-  
-  G4ThreeVector move(2*beam_clamp_distance, 0, 0);
-  G4UnionSolid* double_clamps = new G4UnionSolid("double_clamps", annular_clamp, annular_clamp, 0, move);
-  
-  G4Box* annular_clamp2 = new G4Box("annular_clamp2", clamp_half_length, clamp_half_width, clamp_half_thickness);
-  G4ThreeVector trans(0, 2*beam_clamp_distance, 0);
-  G4UnionSolid* double_clamps2 = new G4UnionSolid("double_clamps2", annular_clamp2, annular_clamp2, 0, trans);
-  
-  G4ThreeVector trans2(beam_clamp_distance, -beam_clamp_distance, 0);
-  G4UnionSolid* four_clamps = new G4UnionSolid("four_clamps", double_clamps, double_clamps2, 0, trans2);
-  
-  // ** Logical
-  G4Material* AnnularClampMaterial = G4Material::GetMaterial(this->fAnnularClampMaterial);
-  fAnnularClampLog = new G4LogicalVolume(four_clamps, AnnularClampMaterial, "fAnnularClampLog", 0, 0, 0);
-  fAnnularClampLog->SetVisAttributes(vis_att);
-  
+	// ** Visualisation
+	G4VisAttributes* vis_att = new G4VisAttributes(G4Colour(PEEK_COL));
+	vis_att->SetVisibility(true);
+
+	// ** Dimensions
+	G4double clamp_half_length = fAnnularClampLength/2.;
+	G4double clamp_half_width = fAnnularClampWidth/2.;
+	G4double clamp_half_thickness = fAnnularClampThickness/2.;
+	// Distance
+	G4double beam_clamp_distance = fAnnularClampPlaneOffset + clamp_half_length;
+
+	// ** Shapes
+	G4Box* annular_clamp = new G4Box("annular_clamp", clamp_half_width, clamp_half_length, clamp_half_thickness);
+
+	G4ThreeVector move(2*beam_clamp_distance, 0, 0);
+	G4UnionSolid* double_clamps = new G4UnionSolid("double_clamps", annular_clamp, annular_clamp, 0, move);
+
+	G4Box* annular_clamp2 = new G4Box("annular_clamp2", clamp_half_length, clamp_half_width, clamp_half_thickness);
+	G4ThreeVector trans(0, 2*beam_clamp_distance, 0);
+	G4UnionSolid* double_clamps2 = new G4UnionSolid("double_clamps2", annular_clamp2, annular_clamp2, 0, trans);
+
+	G4ThreeVector trans2(beam_clamp_distance, -beam_clamp_distance, 0);
+	G4UnionSolid* four_clamps = new G4UnionSolid("four_clamps", double_clamps, double_clamps2, 0, trans2);
+
+	// ** Logical
+	G4Material* AnnularClampMaterial = G4Material::GetMaterial(fAnnularClampMaterial);
+	fAnnularClampLog = new G4LogicalVolume(four_clamps, AnnularClampMaterial, "fAnnularClampLog", 0, 0, 0);
+	fAnnularClampLog->SetVisAttributes(vis_att);
+
 } // end::BuildAnnularClamps()  
 

--- a/src/DetectionSystemTestcan.cc
+++ b/src/DetectionSystemTestcan.cc
@@ -27,139 +27,139 @@
 #include <string>
 
 DetectionSystemTestcan::DetectionSystemTestcan(G4double length, G4double radius) :
-    // LogicalVolumes
-    fTestcanAlumCasingLog(0),
-    fTestcanScintillatorLog(0),
-    fTestcanQuartzWindowLog(0)
+	// LogicalVolumes
+	fTestcanAlumCasingLog(0),
+	fTestcanScintillatorLog(0),
+	fTestcanQuartzWindowLog(0)
 {
-    // can properties
-    fScintillatorLength        = length;
-    fAlumCanThickness          = 1.0*mm;
-    fScintillatorInnerRadius   = 0.0*mm;
-    fScintillatorOuterRadius   = radius;
-    fQuartzThickness           = 6.35*mm;
-    fQuartzRadius              = radius + fAlumCanThickness;
-    fCanMaterial               = "G4_Al";
-    fLiquidMaterial            = "Deuterated Scintillator";
-    fQuartzMaterial            = "G4_SILICON_DIOXIDE";
+	// can properties
+	fScintillatorLength        = length;
+	fAlumCanThickness          = 1.0*mm;
+	fScintillatorInnerRadius   = 0.0*mm;
+	fScintillatorOuterRadius   = radius;
+	fQuartzThickness           = 6.35*mm;
+	fQuartzRadius              = radius + fAlumCanThickness;
+	fCanMaterial               = "G4_Al";
+	fLiquidMaterial            = "Deuterated Scintillator";
+	fQuartzMaterial            = "G4_SILICON_DIOXIDE";
 
-    fStartPhi               = 0.0*deg;
-    fEndPhi                 = 360.0*deg;
-   
-    fLiquidColour           = G4Colour(0.0/255.0,255.0/255.0,225.0/255.0);
-    fGreyColour             = G4Colour(0.5, 0.5, 0.5); 
-    fQuartzColour           = G4Colour(1.0, 0.0, 1.0);    
+	fStartPhi               = 0.0*deg;
+	fEndPhi                 = 360.0*deg;
+
+	fLiquidColour           = G4Colour(0.0/255.0,255.0/255.0,225.0/255.0);
+	fGreyColour             = G4Colour(0.5, 0.5, 0.5); 
+	fQuartzColour           = G4Colour(1.0, 0.0, 1.0);    
 
 }
 
 
 DetectionSystemTestcan::~DetectionSystemTestcan() {
-    // LogicalVolumes
-    delete fTestcanAlumCasingLog;
-    delete fTestcanScintillatorLog;
-    delete fTestcanQuartzWindowLog;
+	// LogicalVolumes
+	delete fTestcanAlumCasingLog;
+	delete fTestcanScintillatorLog;
+	delete fTestcanQuartzWindowLog;
 }
 
 
 G4int DetectionSystemTestcan::Build() {
-    fAssemblyTestcan = new G4AssemblyVolume(); 
+	fAssemblyTestcan = new G4AssemblyVolume(); 
 
-    BuildTestcan();
+	BuildTestcan();
 
-    return 1;
+	return 1;
 }
 
 G4int DetectionSystemTestcan::PlaceDetector(G4LogicalVolume* expHallLog) {
-    G4RotationMatrix * rotate = new G4RotationMatrix;
-    G4ThreeVector move = G4ThreeVector(0., 0., 0.);
+	G4RotationMatrix * rotate = new G4RotationMatrix;
+	G4ThreeVector move = G4ThreeVector(0., 0., 0.);
 
-    fAssemblyTestcan->MakeImprint(expHallLog, move, rotate);
+	fAssemblyTestcan->MakeImprint(expHallLog, move, rotate);
 
-    return 1;
+	return 1;
 }
 
 G4int DetectionSystemTestcan::BuildTestcan() {
-    G4ThreeVector move, direction;
-    G4RotationMatrix* rotate;
+	G4ThreeVector move, direction;
+	G4RotationMatrix* rotate;
 
-    G4Material* canG4material = G4Material::GetMaterial(fCanMaterial);
-    if( !canG4material ) {
-        G4cout << " ----> Material " << fCanMaterial << " not found, cannot build! " << G4endl;
-        return 0;
-    }
+	G4Material* canG4material = G4Material::GetMaterial(fCanMaterial);
+	if(!canG4material) {
+		G4cout<<" ----> Material "<<fCanMaterial<<" not found, cannot build! "<<G4endl;
+		return 0;
+	}
 
-    G4Material* liquidG4material = G4Material::GetMaterial(fLiquidMaterial);
-    if( !liquidG4material ) {
-        G4cout << " ----> Material " << fLiquidMaterial << " not found, cannot build! " << G4endl;
-        return 0;
-    }
+	G4Material* liquidG4material = G4Material::GetMaterial(fLiquidMaterial);
+	if(!liquidG4material) {
+		G4cout<<" ----> Material "<<fLiquidMaterial<<" not found, cannot build! "<<G4endl;
+		return 0;
+	}
 
-    G4Material* quartzG4material = G4Material::GetMaterial(fQuartzMaterial);
-    if(!quartzG4material ) {
-        G4cout << " ----> Material " << fQuartzMaterial << " not found, cannot build! " << G4endl;
-        return 0;
-    }
+	G4Material* quartzG4material = G4Material::GetMaterial(fQuartzMaterial);
+	if(!quartzG4material) {
+		G4cout<<" ----> Material "<<fQuartzMaterial<<" not found, cannot build! "<<G4endl;
+		return 0;
+	}
 
-    // building the aluminum can
-    G4double cutExtra = 10.0*cm;
-    G4Tubs* cut = new G4Tubs("cutting volume", fScintillatorInnerRadius, fScintillatorOuterRadius, fScintillatorLength/2.0 + cutExtra, fStartPhi, fEndPhi);
-    G4Tubs* can = new G4Tubs("can volume before cut", fScintillatorInnerRadius, fScintillatorOuterRadius + fAlumCanThickness, fScintillatorLength/2.0 + fAlumCanThickness/2.0, fStartPhi, fEndPhi);
-    
-    move = G4ThreeVector(0., 0., -0.5*fAlumCanThickness - cutExtra);
-    rotate = new G4RotationMatrix;
-    G4SubtractionSolid* testcanAlumCasing = new G4SubtractionSolid("testcanAlumCan", can, cut, rotate, move);
+	// building the aluminum can
+	G4double cutExtra = 10.0*cm;
+	G4Tubs* cut = new G4Tubs("cutting volume", fScintillatorInnerRadius, fScintillatorOuterRadius, fScintillatorLength/2.0 + cutExtra, fStartPhi, fEndPhi);
+	G4Tubs* can = new G4Tubs("can volume before cut", fScintillatorInnerRadius, fScintillatorOuterRadius + fAlumCanThickness, fScintillatorLength/2.0 + fAlumCanThickness/2.0, fStartPhi, fEndPhi);
 
-    // building the scintillator
-    G4Tubs* testcanScintillator = new G4Tubs("testcanScintillator", fScintillatorInnerRadius, fScintillatorOuterRadius, fScintillatorLength/2.0, fStartPhi, fEndPhi);
+	move = G4ThreeVector(0., 0., -0.5*fAlumCanThickness - cutExtra);
+	rotate = new G4RotationMatrix;
+	G4SubtractionSolid* testcanAlumCasing = new G4SubtractionSolid("testcanAlumCan", can, cut, rotate, move);
 
-    // building the quartz window
-    G4Tubs* testcanQuartzWindow = new G4Tubs("testcanQuartzWindow", fScintillatorInnerRadius, fQuartzRadius, fQuartzThickness/2.0, fStartPhi, fEndPhi);
+	// building the scintillator
+	G4Tubs* testcanScintillator = new G4Tubs("testcanScintillator", fScintillatorInnerRadius, fScintillatorOuterRadius, fScintillatorLength/2.0, fStartPhi, fEndPhi);
 
-    // Set visualization attributes
-    G4VisAttributes* canVisAtt = new G4VisAttributes(fGreyColour);
-    canVisAtt->SetVisibility(true);
-    G4VisAttributes* liquidVisAtt = new G4VisAttributes(fLiquidColour);
-    liquidVisAtt->SetVisibility(true);
-    G4VisAttributes* quartzVisAtt = new G4VisAttributes(fQuartzColour);
-    quartzVisAtt->SetVisibility(true);
-    //quartzVisAtt->SetForceWireframe(true);
-    
-    // Define rotation and movement objects for aluminum can
-    direction 	  = G4ThreeVector(0., 0., 1.);
-    move          = G4ThreeVector(0., 0., -1.0*fScintillatorLength/2.0 + fAlumCanThickness/2.0 );
-    rotate = new G4RotationMatrix;
-    
-    //logical volume for aluminum can
-    if(fTestcanAlumCasingLog == NULL ) {
-        fTestcanAlumCasingLog = new G4LogicalVolume(testcanAlumCasing, canG4material, "testcanAlumCasingLog", 0, 0, 0);
-        fTestcanAlumCasingLog->SetVisAttributes(canVisAtt);
-    }
-    fAssemblyTestcan->AddPlacedVolume(fTestcanAlumCasingLog, move, rotate);
-    
-    // Define rotation and movement objects for scintillator
-    direction 	  = G4ThreeVector(0., 0., 1.);
-    move          = G4ThreeVector(0., 0., -1.0*fScintillatorLength/2.0);
-    rotate = new G4RotationMatrix;
-    
-    // logical volume for scintillator
-    if(fTestcanScintillatorLog == NULL) {
-        fTestcanScintillatorLog = new G4LogicalVolume(testcanScintillator, liquidG4material, "testcanScintillatorLog", 0, 0, 0);
-        fTestcanScintillatorLog->SetVisAttributes(liquidVisAtt);
-    }
-    fAssemblyTestcan->AddPlacedVolume(fTestcanScintillatorLog, move, rotate);
+	// building the quartz window
+	G4Tubs* testcanQuartzWindow = new G4Tubs("testcanQuartzWindow", fScintillatorInnerRadius, fQuartzRadius, fQuartzThickness/2.0, fStartPhi, fEndPhi);
 
-    // Define rotation and movement objects for quartzWindow
-    direction 	  = G4ThreeVector(0., 0., 1.);
-    move         = G4ThreeVector(0., 0., -1.0*fQuartzThickness/2.0 - 1.0*fScintillatorLength);
-    rotate = new G4RotationMatrix;
-    
-    // logical volume for quartz window
-    if(fTestcanQuartzWindowLog == NULL) {
-        fTestcanQuartzWindowLog = new G4LogicalVolume(testcanQuartzWindow, quartzG4material, "testcanQuartzWindowLog", 0, 0, 0);
-        fTestcanQuartzWindowLog->SetVisAttributes(quartzVisAtt);
-    }
-    fAssemblyTestcan->AddPlacedVolume(fTestcanQuartzWindowLog, move, rotate);
-    
-    return 1;
+	// Set visualization attributes
+	G4VisAttributes* canVisAtt = new G4VisAttributes(fGreyColour);
+	canVisAtt->SetVisibility(true);
+	G4VisAttributes* liquidVisAtt = new G4VisAttributes(fLiquidColour);
+	liquidVisAtt->SetVisibility(true);
+	G4VisAttributes* quartzVisAtt = new G4VisAttributes(fQuartzColour);
+	quartzVisAtt->SetVisibility(true);
+	//quartzVisAtt->SetForceWireframe(true);
+
+	// Define rotation and movement objects for aluminum can
+	direction 	  = G4ThreeVector(0., 0., 1.);
+	move          = G4ThreeVector(0., 0., -1.0*fScintillatorLength/2.0 + fAlumCanThickness/2.0);
+	rotate = new G4RotationMatrix;
+
+	//logical volume for aluminum can
+	if(fTestcanAlumCasingLog == nullptr) {
+		fTestcanAlumCasingLog = new G4LogicalVolume(testcanAlumCasing, canG4material, "testcanAlumCasingLog", 0, 0, 0);
+		fTestcanAlumCasingLog->SetVisAttributes(canVisAtt);
+	}
+	fAssemblyTestcan->AddPlacedVolume(fTestcanAlumCasingLog, move, rotate);
+
+	// Define rotation and movement objects for scintillator
+	direction 	  = G4ThreeVector(0., 0., 1.);
+	move          = G4ThreeVector(0., 0., -1.0*fScintillatorLength/2.0);
+	rotate = new G4RotationMatrix;
+
+	// logical volume for scintillator
+	if(fTestcanScintillatorLog == nullptr) {
+		fTestcanScintillatorLog = new G4LogicalVolume(testcanScintillator, liquidG4material, "testcanScintillatorLog", 0, 0, 0);
+		fTestcanScintillatorLog->SetVisAttributes(liquidVisAtt);
+	}
+	fAssemblyTestcan->AddPlacedVolume(fTestcanScintillatorLog, move, rotate);
+
+	// Define rotation and movement objects for quartzWindow
+	direction 	  = G4ThreeVector(0., 0., 1.);
+	move         = G4ThreeVector(0., 0., -1.0*fQuartzThickness/2.0 - 1.0*fScintillatorLength);
+	rotate = new G4RotationMatrix;
+
+	// logical volume for quartz window
+	if(fTestcanQuartzWindowLog == nullptr) {
+		fTestcanQuartzWindowLog = new G4LogicalVolume(testcanQuartzWindow, quartzG4material, "testcanQuartzWindowLog", 0, 0, 0);
+		fTestcanQuartzWindowLog->SetVisAttributes(quartzVisAtt);
+	}
+	fAssemblyTestcan->AddPlacedVolume(fTestcanQuartzWindowLog, move, rotate);
+
+	return 1;
 }
 

--- a/src/DetectionSystemTrific.cc
+++ b/src/DetectionSystemTrific.cc
@@ -260,7 +260,7 @@ void DetectionSystemTrific::PlacePCBs(G4LogicalVolume*  TrificGasVol){
 	for(int i=0;i<24;i++){
 		G4ThreeVector move(0,0,Zpos);
 		std::stringstream temp;
-		temp << "TrificGasCell" <<i;
+		temp << "TrificGasCell_" <<i;
 		new G4PVPlacement(0, move, fGasCell, temp.str(), TrificGasVol, false, 0);
 // 		fGridPCB->MakeImprint(TrificGasVol, move, rotate, i);
 		Zpos+=fGridSpacing;

--- a/src/DetectionSystemTrific.cc
+++ b/src/DetectionSystemTrific.cc
@@ -19,7 +19,7 @@
 #include "G4PVReplica.hh"
 #include "G4PVDivision.hh"
 
-
+#include "G4SystemOfUnits.hh"
 
 #include "G4VisAttributes.hh"
 #include "G4Colour.hh"
@@ -27,75 +27,71 @@
 #include "DetectionSystemTrific.hh"
 #include "HistoManager.hh" // for Trific histogram array when placing detector
 
-using namespace CLHEP;
-
 DetectionSystemTrific::DetectionSystemTrific(G4double setpressure) 
 {
-
-	
 	//-----------------------------//
 	// Materials     			   //
 	//-----------------------------//
-	this->fWireMaterial    = "Tungsten";
-	this->fPCBMaterial     = "Acrylic";//Need to define G10
-	this->fChamberMaterial = "G4_STAINLESS-STEEL"; 
-	this->fWindowFrameMaterial = "G4_Al"; 
-	this->fWindowMaterial = "Mylar";
-	this->fWindowSurfaceMaterial = "G4_Al";
-	this->fGasMaterial = "TrificCF4";
+	fWireMaterial    = "Tungsten";
+	fPCBMaterial     = "Acrylic";//Need to define G10
+	fChamberMaterial = "G4_STAINLESS-STEEL"; 
+	fWindowFrameMaterial = "G4_Al"; 
+	fWindowMaterial = "Mylar";
+	fWindowSurfaceMaterial = "G4_Al";
+	fGasMaterial = "TrificCF4";
 
-	
+
 	G4double a, z, density, temperature, pressure;
 	G4String name, symbol;
 	G4int    ncomponents, natoms;
-// 	G4double fractionmass;
-    
+	// 	G4double fractionmass;
+
 	G4Element* ElC = new G4Element(name="C", symbol="C", z=6., a = 12.01*g/mole);
 	G4Element* ElF  = new G4Element(name="F" , symbol="F" , z=9. , a= 18.9984 *g/mole);
-	
-	temperature = STP_Temperature;
-	pressure = (setpressure/760.)*STP_Pressure;
+
+	temperature = CLHEP::STP_Temperature;
+	pressure = (setpressure/760.)*CLHEP::STP_Pressure;
 	density = (setpressure/760.)*3.72*mg/cm3;
-	
+
 	G4Material* TrificCF4 = new G4Material(name="TrificCF4",  density,ncomponents=2,kStateGas,temperature,pressure);
-// 	G4Material* TrificCF4= new G4Material(name="TrificCF4",density, ncomponents=2);
+	// 	G4Material* TrificCF4= new G4Material(name="TrificCF4",density, ncomponents=2);
 	TrificCF4->AddElement(ElC,natoms=1);
 	TrificCF4->AddElement(ElF,natoms=4);
-	
+
 	G4cout<<G4endl<<"Created CF4 gas for pressure "<<setpressure<< " Torr ("<<1000.*pressure/bar<<" mbar)";
 	G4cout<<G4endl<<"Density "<<density/(mg/cm3)<< " mg/cm3";
 
 	// ----------------------------
 	// Dimensions 
 	// ----------------------------
-	this->fPCBThickness = 2.3*mm;
-	this->fGridAngle = 30*deg;
-	this->fSpacerZThickness = 1.8*cm;
-	this->fGridSpacing = fPCBThickness/cos(fGridAngle)+fSpacerZThickness;
-	this->fWireD = 20*um;
-// 	this->fWireD = 4*mm;//easier to see for development
-	this->fWirePitch = 2*mm;
-// 	this->fWirePitch = 10*mm;//simpler for development
-	this->fChamberLength = 60*cm;
-	this->fChamberInnerD = 12*cm;
-	this->fChamberOuterD = 12.8*cm;
-	this->fPCBInnerD = 6*cm;
-	this->fPCBOuterD = 11.5*cm;
-	this->fPCBCutDepth = 2*cm;
-	this->fPCBCutHalfHeight = 2*cm;
-	this->fRodD = 0.5*cm;
-	this->fRodPlaceD = 9*cm;
-	
-	
-	this->fTargetChamberZOffset = 0*cm;
-	this->fChamberWindowZ = 4*cm;
-	this->fWindowGridZ = 1.5*cm;
-	this->fWindowWasherZ = 1*cm;
-	this->fWindowTickness = 5*um;
-	this->fWindowCoatingThickness = 0.9*um;
-	this->fWindowInnerD = 4*cm;
-	this->fWindowOuterD = 8*cm;
-	this->fWindowChamberLength = 2*cm;
+	fPCBThickness = 2.3*mm;
+	fGridAngle = 30*deg;
+	fSpacerZThickness = 1.8*cm;
+	fGridSpacing = fPCBThickness/cos(fGridAngle)+fSpacerZThickness;
+	fWireD = 20*um;
+	// 	fWireD = 4*mm;//easier to see for development
+	fWirePitch = 2*mm;
+	// 	fWirePitch = 10*mm;//simpler for development
+	fChamberLength = 60*cm;
+	fChamberInnerD = 12*cm;
+	fChamberOuterD = 12.8*cm;
+	fPCBInnerD = 6*cm;
+	fPCBOuterD = 11.5*cm;
+	fPCBCutDepth = 2*cm;
+	fPCBCutHalfHeight = 2*cm;
+	fRodD = 0.5*cm;
+	fRodPlaceD = 9*cm;
+
+
+	fTargetChamberZOffset = 0*cm;
+	fChamberWindowZ = 4*cm;
+	fWindowGridZ = 1.5*cm;
+	fWindowWasherZ = 1*cm;
+	fWindowTickness = 5*um;
+	fWindowCoatingThickness = 0.9*um;
+	fWindowInnerD = 4*cm;
+	fWindowOuterD = 8*cm;
+	fWindowChamberLength = 2*cm;
 
 }
 
@@ -120,41 +116,41 @@ G4int DetectionSystemTrific::BuildPlace(G4LogicalVolume* ExpHallLog)
 
 void DetectionSystemTrific::BuildPCB(){
 	fGridPCB = new G4AssemblyVolume();
-	
+
 	///
 	/// First we defined the volume of gas that is one "cell" i.e. one grid + spacer
 	///
-	
+
 	// Define the material, return error if not found
-	G4Material* material = G4Material::GetMaterial(this->fGasMaterial);
-		if( !material ) {
-		G4cout << " ----> Material " << this->fGasMaterial<< " not found, cannot build the Trific detector! " << G4endl;
+	G4Material* material = G4Material::GetMaterial(fGasMaterial);
+	if(!material) {
+		G4cout<<" ----> Material "<<fGasMaterial<< " not found, cannot build the Trific detector! "<<G4endl;
 		return;
 	}
-	
+
 	G4double cell_rad =(fChamberInnerD/2)-0.1*mm;
 	G4double tubelength =cell_rad*tan(fGridAngle)+fGridSpacing;
 
 	G4double cutlength =tubelength/cos(fGridAngle);
 	G4double cutwidth =0.1*mm+cell_rad;
 	G4double cutheight =0.1*mm+cell_rad/cos(fGridAngle)+cutlength*tan(fGridAngle);
-	
+
 	G4double cutfrontZ =cutlength/cos(fGridAngle)+fGridSpacing;
 	G4double cutbackZ =-cutlength/cos(fGridAngle);
 
 	G4RotationMatrix* rotate = new G4RotationMatrix;
 	rotate->rotateX(fGridAngle);
-	
+
 	G4Tubs* CellTube = new G4Tubs("CellTube",0,cell_rad, tubelength, 0, 360.*deg);
 	G4Box* CutBox = new G4Box("CutBox", cutwidth, cutheight, cutlength);
 
 	G4VSolid* Cell = new G4SubtractionSolid("Cell", CellTube, CutBox,rotate, G4ThreeVector(0,0,cutfrontZ));
 	G4VSolid* CellB = new G4SubtractionSolid("CellB", Cell, CutBox,rotate, G4ThreeVector(0,0,cutbackZ));
-	
+
 	fGasCell = new G4LogicalVolume(CellB, material, "TrificGasCell", 0, 0, 0);
 	fGasCell->SetVisAttributes (G4VisAttributes::Invisible); 
-	
-	
+
+
 	//Original version was box with tube cut (so defined verticle and rotated later)
 	//but for some reason that didnt work here, though that method is used for the PCB next
 
@@ -164,9 +160,9 @@ void DetectionSystemTrific::BuildPCB(){
 	///
 
 	// Define the material, return error if not found
-	material = G4Material::GetMaterial(this->fPCBMaterial);
-		if( !material ) {
-		G4cout << " ----> Material " << this->fPCBMaterial<< " not found, cannot build the Trific detector! " << G4endl;
+	material = G4Material::GetMaterial(fPCBMaterial);
+	if(!material) {
+		G4cout<<" ----> Material "<<fPCBMaterial<< " not found, cannot build the Trific detector! "<<G4endl;
 		return;
 	}
 
@@ -211,17 +207,17 @@ void DetectionSystemTrific::BuildPCB(){
 	G4double pcbplacedistance = (box_half_thickness+fWireD)/cos(fGridAngle);
 	G4ThreeVector moveP(0,0,pcbplacedistance);
 	new G4PVPlacement(rotate, moveP, fFullPCB, "TrificPCB", fGasCell,false, 0);
-	
-// 	fGridPCB->AddPlacedVolume(fFullPCB, moveP, rotate); //G4AssemblyVolume version
+
+	// 	fGridPCB->AddPlacedVolume(fFullPCB, moveP, rotate); //G4AssemblyVolume version
 
 	///
 	/// Next we add the wires next to/on the PCB in the cell
 	///
-	
+
 	//Add wires
-	material = G4Material::GetMaterial(this->fWireMaterial);
-	if( !material ) {
-		G4cout << " ----> Material " << this->fPCBMaterial<< " not found, cannot build the Trific detector! " << G4endl;
+	material = G4Material::GetMaterial(fWireMaterial);
+	if(!material) {
+		G4cout<<" ----> Material "<<fPCBMaterial<< " not found, cannot build the Trific detector! "<<G4endl;
 		return;
 	}
 
@@ -254,65 +250,65 @@ void DetectionSystemTrific::BuildPCB(){
 
 
 void DetectionSystemTrific::PlacePCBs(G4LogicalVolume*  TrificGasVol){
-	
+
 
 	G4double Zpos=-fChamberLength/2+fChamberWindowZ+fWindowGridZ;
 	for(int i=0;i<24;i++){
 		G4ThreeVector move(0,0,Zpos);
 		std::stringstream temp;
-		temp << "TrificGasCell_" <<i;
+		temp<<"TrificGasCell_" <<i;
 		new G4PVPlacement(0, move, fGasCell, temp.str(), TrificGasVol, false, 0);
-// 		fGridPCB->MakeImprint(TrificGasVol, move, rotate, i);
+		// 		fGridPCB->MakeImprint(TrificGasVol, move, rotate, i);
 		Zpos+=fGridSpacing;
 	}
 
-	
+
 }
 
 
 void DetectionSystemTrific::BuildPlacePipe(G4LogicalVolume*  ExpHallLog){
 	// Define the material, return error if not found
-	G4Material* material = G4Material::GetMaterial(this->fChamberMaterial);
-		if( !material ) {
-		G4cout << " ----> Material " << this->fPCBMaterial<< " not found, cannot build the Trific detector! " << G4endl;
+	G4Material* material = G4Material::GetMaterial(fChamberMaterial);
+	if(!material) {
+		G4cout<<" ----> Material "<<fPCBMaterial<< " not found, cannot build the Trific detector! "<<G4endl;
 		return;
 	}
-	
+
 	G4Tubs* Pipe = new G4Tubs("Pipe",fChamberInnerD/2, fChamberOuterD/2, fChamberLength/2, 0, 360.*CLHEP::deg);
-	
+
 	G4LogicalVolume* TrificPipe = new G4LogicalVolume(Pipe, material, "TrificPipe", 0, 0, 0);
 	G4VisAttributes* vis_att = new G4VisAttributes(G4Colour(0.0,1,1));
 	vis_att->SetVisibility(true);  
 	TrificPipe->SetVisAttributes(vis_att);
-	
+
 	G4double sPosZ = fTargetChamberZOffset+fChamberLength/2; 
 	G4ThreeVector sTranslate(0, 0, sPosZ);
 	new G4PVPlacement(0, sTranslate, TrificPipe, "fTrificPipePhysical", ExpHallLog, false, 0);
-	
 
-	material = G4Material::GetMaterial(this->fWindowFrameMaterial);
-		if( !material ) {
-		G4cout << " ----> Material " << this->fWindowFrameMaterial<< " not found, cannot build the Trific detector! " << G4endl;
+
+	material = G4Material::GetMaterial(fWindowFrameMaterial);
+	if(!material) {
+		G4cout<<" ----> Material "<<fWindowFrameMaterial<< " not found, cannot build the Trific detector! "<<G4endl;
 		return;
 	}
-	
-	
+
+
 	G4Tubs* Windowipe = new G4Tubs("Pipe",fWindowInnerD/2, fChamberOuterD/2, fWindowChamberLength/2, 0, 360.*CLHEP::deg);
-	
+
 	G4LogicalVolume* WindowPipe = new G4LogicalVolume(Windowipe, material, "WindowPipe", 0, 0, 0);
-	
+
 	sPosZ = fTargetChamberZOffset-fWindowChamberLength/2; 
 	G4ThreeVector WPPosZ(0, 0, sPosZ);
 	new G4PVPlacement(0, WPPosZ, WindowPipe, "fTrificWindowPipe", ExpHallLog, false, 0);	
-	
+
 }
 
 void DetectionSystemTrific::BuildGasVolume(G4LogicalVolume* ExpHallLog){
-	
+
 	// Define the material, return error if not found
-	G4Material* material = G4Material::GetMaterial(this->fGasMaterial);
-		if( !material ) {
-		G4cout << " ----> Material " << this->fGasMaterial<< " not found, cannot build the Trific detector! " << G4endl;
+	G4Material* material = G4Material::GetMaterial(fGasMaterial);
+	if(!material) {
+		G4cout<<" ----> Material "<<fGasMaterial<< " not found, cannot build the Trific detector! "<<G4endl;
 		return;
 	}
 
@@ -324,7 +320,7 @@ void DetectionSystemTrific::BuildGasVolume(G4LogicalVolume* ExpHallLog){
 	PlacePCBs(TrificGasVol);	
 	BuildPlaceWindow(TrificGasVol);
 
-	
+
 	G4double sPosZ = fTargetChamberZOffset+fChamberLength/2; 
 	G4ThreeVector sTranslate(0, 0, sPosZ);	
 	new G4PVPlacement(0, sTranslate, TrificGasVol, "fTrificGasVol", ExpHallLog, false, 0);
@@ -333,22 +329,22 @@ void DetectionSystemTrific::BuildGasVolume(G4LogicalVolume* ExpHallLog){
 
 
 void DetectionSystemTrific::BuildPlaceWindow(G4LogicalVolume* TrificGasVol){
-	
+
 	//
 	// First we make the part of the window frame that is inside the gas volume
 	//
-	
+
 	// Define the material, return error if not found
-	G4Material* material = G4Material::GetMaterial(this->fWindowFrameMaterial);
-		if( !material ) {
-		G4cout << " ----> Material " << this->fWindowFrameMaterial<< " not found, cannot build the Trific detector! " << G4endl;
+	G4Material* material = G4Material::GetMaterial(fWindowFrameMaterial);
+	if(!material) {
+		G4cout<<" ----> Material "<<fWindowFrameMaterial<< " not found, cannot build the Trific detector! "<<G4endl;
 		return;
 	}	
-	
+
 	G4double winframhalfrise =(fWindowOuterD*tan(fGridAngle))/2;
 	G4double winframhalflength =(winframhalfrise+fChamberWindowZ)/2;
 	G4double cutheight =(fWindowOuterD/2)/cos(fGridAngle)+winframhalfrise*tan(fGridAngle);
-	
+
 	G4Tubs* CellTube = new G4Tubs("CellTube",fWindowInnerD/2,fWindowOuterD/2, winframhalflength, 0, 360.*deg);
 	G4Box* CutBox = new G4Box("CutBox", 0.1*mm+fWindowOuterD/2, cutheight, winframhalfrise);
 
@@ -358,36 +354,36 @@ void DetectionSystemTrific::BuildPlaceWindow(G4LogicalVolume* TrificGasVol){
 	rotate->rotateX(fGridAngle);
 
 	G4VSolid* WindowFrame = new G4SubtractionSolid("WindowFrame", CellTube, CutBox,rotate, G4ThreeVector(0,0,cutZ));
-	
+
 	G4LogicalVolume* fWindowFrame = new G4LogicalVolume(WindowFrame, material, "fWindowFrame", 0, 0, 0);
 
 	G4double sPosZ = winframhalflength-fChamberLength/2; 
 	G4ThreeVector sTranslate(0, 0, sPosZ);	
 	new G4PVPlacement(0, sTranslate, fWindowFrame, "fTrificGasVol", TrificGasVol, false, 0);
-	
+
 	//
 	// Next we add vacuum to the small bit of pipe to displace the gas in that region of the mother volume TrificGasVol
 	//	
-	
+
 	material = G4Material::GetMaterial("Vacuum");
-	if( !material ) {
-		G4cout << " ----> Material Vacuum not found, cannot build the Trific detector! " << G4endl;
+	if(!material) {
+		G4cout<<" ----> Material Vacuum not found, cannot build the Trific detector! "<<G4endl;
 		return;
 	}	
-	
+
 	G4Tubs* VacTube = new G4Tubs("VacTube",0,(fWindowInnerD/2)-0.1*mm, winframhalflength, 0, 360.*deg);
 	G4VSolid* VacSolid = new G4SubtractionSolid("VacSolid", VacTube, CutBox,rotate, G4ThreeVector(0,0,cutZ));
 	G4LogicalVolume* VacLog = new G4LogicalVolume(VacSolid, material, "VacLog", 0, 0, 0);
 	VacLog->SetVisAttributes(G4VisAttributes::Invisible); 
 	new G4PVPlacement(0, sTranslate, VacLog, "fVacLog", TrificGasVol, false, 0);
-	
+
 	//
 	// Next we add the window itself
 	//	
-	
-	material = G4Material::GetMaterial(this->fWindowMaterial);
-		if( !material ) {
-		G4cout << " ----> Material " << this->fWindowMaterial<< " not found, cannot build the Trific detector! " << G4endl;
+
+	material = G4Material::GetMaterial(fWindowMaterial);
+	if(!material) {
+		G4cout<<" ----> Material "<<fWindowMaterial<< " not found, cannot build the Trific detector! "<<G4endl;
 		return;
 	}	
 
@@ -403,14 +399,14 @@ void DetectionSystemTrific::BuildPlaceWindow(G4LogicalVolume* TrificGasVol){
 	sPosZ = fChamberWindowZ+fWindowTickness/2-fChamberLength/2; 
 	G4ThreeVector sWindTrans(0, 0, sPosZ);	
 	new G4PVPlacement(0, sWindTrans, Window, "fWindow", TrificGasVol, false, 0);
-	
+
 	//
 	// Next we add the window aluminised layer
 	//	
-	
-	material = G4Material::GetMaterial(this->fWindowSurfaceMaterial);
-		if( !material ) {
-		G4cout << " ----> Material " << this->fWindowMaterial<< " not found, cannot build the Trific detector! " << G4endl;
+
+	material = G4Material::GetMaterial(fWindowSurfaceMaterial);
+	if(!material) {
+		G4cout<<" ----> Material "<<fWindowMaterial<< " not found, cannot build the Trific detector! "<<G4endl;
 		return;
 	}	
 
@@ -421,26 +417,26 @@ void DetectionSystemTrific::BuildPlaceWindow(G4LogicalVolume* TrificGasVol){
 	vis_att = new G4VisAttributes(G4Colour(1.0,0.5,1.0));
 	vis_att->SetVisibility(true);  
 	WindowCo->SetVisAttributes(vis_att);
-	
+
 	sPosZ = fChamberWindowZ+fWindowTickness+fWindowCoatingThickness/2-fChamberLength/2; 
 	G4ThreeVector sWindCoTrans(0, 0, sPosZ);	
 	new G4PVPlacement(0, sWindCoTrans, WindowCo, "fWindowcov", TrificGasVol, false, 0);
-	
-	
+
+
 	//
 	// Finally we add the window washer
 	//	
-	
-	material = G4Material::GetMaterial(this->fWindowFrameMaterial);
+
+	material = G4Material::GetMaterial(fWindowFrameMaterial);
 
 	cutZ =winframhalfrise/cos(fGridAngle)+fWindowWasherZ/2;
 	G4VSolid* WindowWasherA = new G4SubtractionSolid("WindowWasherA", CellTube, CutBox,rotate, G4ThreeVector(0,0,cutZ));
 	G4VSolid* WindowWasherB = new G4SubtractionSolid("WindowWasherB", WindowWasherA, CutBox,rotate, G4ThreeVector(0,0,-cutZ));
 	G4LogicalVolume* WindowWasher = new G4LogicalVolume(WindowWasherB, material, "WindowWasher", 0, 0, 0);
-	
+
 	sPosZ = fChamberWindowZ+fWindowTickness+fWindowCoatingThickness+fWindowWasherZ/2-fChamberLength/2; 
 	G4ThreeVector sWindWashTrans(0, 0, sPosZ);	
 	new G4PVPlacement(0, sWindWashTrans, WindowWasher, "fWindowwash", TrificGasVol, false, 0);		
-	
+
 
 }

--- a/src/DetectorConstruction.cc
+++ b/src/DetectorConstruction.cc
@@ -159,7 +159,7 @@ DetectorConstruction::DetectorConstruction() :
   fGriffinDetectorsMapIndex = 0;
   for(G4int i = 0; i < 16; ++i) {
 	  fGriffinDetectorsMap[i] = 0;
-	  for(G4int j = 0; j < 3; ++j) {
+	  for(G4int j = 0; j < 4; ++j) {
 		  fGriffinDeadLayer[i][j] = -1;
 	  }
   }
@@ -944,7 +944,6 @@ DetectorProperties DetectorConstruction::ParseVolumeName(G4String volumeName) {
 		std::string tmpString = volumeName.substr(volumeName.find("germaniumBlock1")+16);
 		// replace all '_' with spaces so we can just use istringstream::operator>>
 		std::replace(tmpString.begin(), tmpString.end(), '_', ' ');
-		std::cout<<volumeName<<" => "<<tmpString<<std::endl;
 		// create istringstream from the stripped and converted stream, and read detector and crystal number
 		std::istringstream is(tmpString);
 		is>>result.detectorNumber>>result.crystalNumber;
@@ -968,7 +967,6 @@ DetectorProperties DetectorConstruction::ParseVolumeName(G4String volumeName) {
 		std::string tmpString = volumeName.substr(volumeName.find("germaniumDlsBlock1")+19);
 		// replace all '_' with spaces so we can just use istringstream::operator>>
 		std::replace(tmpString.begin(), tmpString.end(), '_', ' ');
-		std::cout<<volumeName<<" => "<<tmpString<<std::endl;
 		// create istringstream from the stripped and converted stream, and read detector and crystal number
 		std::istringstream is(tmpString);
 		is>>result.detectorNumber>>result.crystalNumber;
@@ -993,7 +991,6 @@ DetectorProperties DetectorConstruction::ParseVolumeName(G4String volumeName) {
 		std::string tmpString = volumeName.substr(volumeName.find("SiSegmentPhys")+13);
 		// replace all '_' with spaces so we can just use istringstream::operator>>
 		std::replace(tmpString.begin(), tmpString.end(), '_', ' ');
-		std::cout<<volumeName<<" => "<<tmpString<<std::endl;
 		// create istringstream from the stripped and converted stream, and read detector and crystal number
 		std::istringstream is(tmpString);
 		is>>result.detectorNumber>>result.crystalNumber;
@@ -1014,7 +1011,6 @@ DetectorProperties DetectorConstruction::ParseVolumeName(G4String volumeName) {
 		std::string tmpString = volumeName.substr(volumeName.find("TrificGasCell")+13);
 		// replace all '_' with spaces so we can just use istringstream::operator>>
 		std::replace(tmpString.begin(), tmpString.end(), '_', ' ');
-		std::cout<<volumeName<<" => "<<tmpString<<std::endl;
 		// create istringstream from the stripped and converted stream, and read detector and crystal number
 		std::istringstream is(tmpString);
 		is>>result.detectorNumber;
@@ -1038,14 +1034,12 @@ DetectorProperties DetectorConstruction::ParseVolumeName(G4String volumeName) {
 	std::string tmpString = volumeName.substr(3);
 	// replace all '_' with spaces so we can just use istringstream::operator>>
 	std::replace(tmpString.begin(), tmpString.end(), '_', ' ');
-	std::cout<<volumeName<<" => "<<tmpString<<std::endl;
 	std::istringstream is(tmpString);
 	G4int assemblyNumber;
 	is>>assemblyNumber;
 
 	// create new string that starts with the imprint number ('_' have been replace by ' ') and use stringstream to read it
 	tmpString = tmpString.substr(tmpString.find(" impr ")+6);
-	std::cout<<volumeName<<" => "<<tmpString<<std::endl;
 	is.str(tmpString);
 	G4int imprintNumber;
 	is>>imprintNumber;
@@ -1054,7 +1048,6 @@ DetectorProperties DetectorConstruction::ParseVolumeName(G4String volumeName) {
 	// and the crystal number is the imprint number (fNumberOfAssemblyVols was hard-coded to be 13 in the constructor)
 	result.detectorNumber = static_cast<G4int>(ceil((assemblyNumber-5.)/13.));
 	result.crystalNumber = imprintNumber;
-	std::cout<<"assembly "<<assemblyNumber<<", imprint "<<imprintNumber<<" => detector "<<result.detectorNumber<<", crystal "<<result.crystalNumber<<std::endl;
 	if(volumeName.find("backQuarterSuppressor") != G4String::npos) {
 		// build mnemonic
 		mnemonic.replace(0,3,"GRS");
@@ -1124,7 +1117,6 @@ DetectorProperties DetectorConstruction::ParseVolumeName(G4String volumeName) {
 	// and the crystal number is the imprint number minus 3 times the detector number minus one
 	result.detectorNumber = static_cast<G4int>(ceil(imprintNumber/3.0));
 	result.crystalNumber = imprintNumber - (result.detectorNumber-1)*3;
-	std::cout<<"assembly "<<assemblyNumber<<", imprint "<<imprintNumber<<" => detector "<<result.detectorNumber<<", crystal "<<result.crystalNumber<<std::endl;
 	if(volumeName.find("ancillaryBgoBlock") != G4String::npos) {
 		// build mnemonic
 		mnemonic.replace(0,3,"ABG");
@@ -1140,7 +1132,6 @@ DetectorProperties DetectorConstruction::ParseVolumeName(G4String volumeName) {
 	// for "generic" detectors the detector number is the imprint number
 	result.detectorNumber = imprintNumber;
 	result.crystalNumber = 0;
-	std::cout<<"assembly "<<assemblyNumber<<", imprint "<<imprintNumber<<" => detector "<<result.detectorNumber<<", crystal "<<result.crystalNumber<<std::endl;
 	if(volumeName.find("lanthanumBromideCrystalBlock") != G4String::npos) {
 		// build mnemonic
 		mnemonic.replace(0,3,"LAB");

--- a/src/DetectorConstruction.cc
+++ b/src/DetectorConstruction.cc
@@ -59,6 +59,7 @@
 #include "G4RunManager.hh"
 #include "G4UserLimits.hh"
 
+#include "G4Threading.hh"
 
 //#include "DetectionSystemGammaTracking.hh"
 #include "DetectionSystem8pi.hh"
@@ -882,7 +883,11 @@ void DetectorConstruction::SetProperties() {
 	// loop over all existing daughters of the world volume
 	// check if their properties are set and if not, set them
 	if(fLogicWorld == nullptr) return;
-	G4cout<<fLogicWorld->GetNoDaughters()<<" daughter volumes"<<std::endl;
+	// thread id is -1 for master, -2 in sequential mode
+	// so this only outputs the number of volumes once
+	if(G4Threading::G4GetThreadId() < 0) {
+		G4cout<<fLogicWorld->GetNoDaughters()<<" daughter volumes"<<std::endl;
+	}
 	for(int i = 0; i < fLogicWorld->GetNoDaughters(); ++i) {
 		if(!HasProperties(fLogicWorld->GetDaughter(i)) && CheckVolumeName(fLogicWorld->GetDaughter(i)->GetName())) {
 			fPropertiesMap[fLogicWorld->GetDaughter(i)] = ParseVolumeName(fLogicWorld->GetDaughter(i)->GetName());

--- a/src/DetectorConstruction.cc
+++ b/src/DetectorConstruction.cc
@@ -206,7 +206,7 @@ G4VPhysicalVolume* DetectorConstruction::Construct() {
 
 	G4Material* matWorld = G4Material::GetMaterial(fMatWorldName);
 
-	if( !matWorld ) {
+	if(!matWorld) {
 		G4cout<<" ----> Material "<<fMatWorldName<<" not found, cannot build world! "<<G4endl;
 		return 0;
 	}
@@ -217,7 +217,7 @@ G4VPhysicalVolume* DetectorConstruction::Construct() {
 			matWorld,	//its material
 			"World");		//its name
 
-	fPhysiWorld = new G4PVPlacement(   0,                  //no rotation
+	fPhysiWorld = new G4PVPlacement(  0,                  //no rotation
 			G4ThreeVector(),	//at (0,0,0)
 			fLogicWorld,         //its logical volume
 			"World",            //its name
@@ -238,31 +238,31 @@ G4VPhysicalVolume* DetectorConstruction::Construct() {
 	return fPhysiWorld;
 }
 
-void DetectorConstruction::SetWorldMaterial( G4String name ) {
+void DetectorConstruction::SetWorldMaterial(G4String name) {
 	fMatWorldName = name;
 	UpdateGeometry(); // auto update
 }
 
-void DetectorConstruction::SetWorldDimensions( G4ThreeVector vec ) {
+void DetectorConstruction::SetWorldDimensions(G4ThreeVector vec) {
 	fWorldSizeX = vec.x() ;
 	fWorldSizeY = vec.y() ;
 	fWorldSizeZ = vec.z() ;
 	UpdateGeometry(); // auto update
 }
 
-void DetectorConstruction::SetWorldVis( G4bool vis ) {
+void DetectorConstruction::SetWorldVis(G4bool vis) {
 	fWorldVis = vis;
 	UpdateGeometry(); // auto update
 }
 
-void DetectorConstruction::SetWorldStepLimit( G4double step ) {
+void DetectorConstruction::SetWorldStepLimit(G4double step) {
 	if(fLogicWorld == NULL) {
 			Construct();
 	}
 	fLogicWorld->SetUserLimits(new G4UserLimits(step));
 }
 
-//void DetectorConstruction::SetWorldMagneticField( G4ThreeVector vec )
+//void DetectorConstruction::SetWorldMagneticField(G4ThreeVector vec)
 //{
 //    //expHallMagField->SetFieldValue(G4ThreeVector(vec.x(),vec.y(),vec.z()));
 //}
@@ -288,21 +288,21 @@ void DetectorConstruction::UpdateGeometry() {
 	G4RunManager::GetRunManager()->DefineWorldVolume(Construct());
 }
 
-void DetectorConstruction::SetGenericTargetMaterial( G4String name )
+void DetectorConstruction::SetGenericTargetMaterial(G4String name)
 {
 	DetectorConstruction::fSetGenericTargetMaterial = true;
 	DetectorConstruction::fGenericTargetMaterial = name;
 	DetectorConstruction::SetGenericTarget();
 }
 
-void DetectorConstruction::SetGenericTargetDimensions( G4ThreeVector vec )
+void DetectorConstruction::SetGenericTargetDimensions(G4ThreeVector vec)
 {
 	DetectorConstruction::fSetGenericTargetDimensions = true;
 	DetectorConstruction::fGenericTargetDimensions = vec;
 	DetectorConstruction::SetGenericTarget();
 }
 
-void DetectorConstruction::SetGenericTargetPosition( G4ThreeVector vec )
+void DetectorConstruction::SetGenericTargetPosition(G4ThreeVector vec)
 {
 	DetectorConstruction::fSetGenericTargetPosition = true;
 	DetectorConstruction::fGenericTargetPosition = vec;
@@ -311,9 +311,9 @@ void DetectorConstruction::SetGenericTargetPosition( G4ThreeVector vec )
 
 void DetectorConstruction::SetGenericTarget()
 {
-	if( fSetGenericTargetMaterial ) {
-		if( fSetGenericTargetDimensions ) {
-			if( fSetGenericTargetPosition ) {
+	if(fSetGenericTargetMaterial) {
+		if(fSetGenericTargetDimensions) {
+			if(fSetGenericTargetPosition) {
 				G4String name = fGenericTargetMaterial;
 				G4double vecX = fGenericTargetDimensions.x()/mm;
 				G4double vecY = fGenericTargetDimensions.y()/mm;
@@ -352,7 +352,7 @@ void DetectorConstruction::AddGrid() {
 				fGridColour,
 				fGridOffset) ;
 		pGrid->Build();
-		pGrid->PlaceDetector( fLogicWorld );
+		pGrid->PlaceDetector(fLogicWorld);
 	}
 }
 
@@ -360,7 +360,7 @@ void DetectorConstruction::AddApparatusSpiceTargetChamber(G4String Options)//par
 {
 	//Create Target Chamber
 	ApparatusSpiceTargetChamber* fApparatusSpiceTargetChamber = new ApparatusSpiceTargetChamber(Options);
-	fApparatusSpiceTargetChamber->Build( fLogicWorld );
+	fApparatusSpiceTargetChamber->Build(fLogicWorld);
 }
 
 void DetectorConstruction::AddApparatus8piVacuumChamber() {
@@ -370,7 +370,7 @@ void DetectorConstruction::AddApparatus8piVacuumChamber() {
 	}
 
 	Apparatus8piVacuumChamber* pApparatus8piVacuumChamber = new Apparatus8piVacuumChamber();
-	pApparatus8piVacuumChamber->Build( fLogicWorld );
+	pApparatus8piVacuumChamber->Build(fLogicWorld);
 }
 
 void DetectorConstruction::AddApparatus8piVacuumChamberAuxMatShell(G4double thickness) {
@@ -380,7 +380,7 @@ void DetectorConstruction::AddApparatus8piVacuumChamberAuxMatShell(G4double thic
 	}
 
 	Apparatus8piVacuumChamberAuxMatShell* pApparatus8piVacuumChamberAuxMatShell = new Apparatus8piVacuumChamberAuxMatShell();
-	pApparatus8piVacuumChamberAuxMatShell->Build( fLogicWorld, thickness );
+	pApparatus8piVacuumChamberAuxMatShell->Build(fLogicWorld, thickness);
 }
 
 void DetectorConstruction::AddApparatusGriffinStructure(G4int selector) {
@@ -440,7 +440,7 @@ void DetectorConstruction::AddDetectionSystemSodiumIodide(G4int ndet) {
 		rotate->rotateY(0);
 		rotate->rotateZ(phi+0.5*M_PI);
 
-		pSodiumIodide->PlaceDetector( fLogicWorld, move, rotate, detectorNumber ) ;
+		pSodiumIodide->PlaceDetector(fLogicWorld, move, rotate, detectorNumber) ;
 	}
 	fNaI = true;
 }
@@ -552,7 +552,7 @@ void DetectorConstruction::AddDetectionSystemGriffinCustomDetector(G4int) {
 	DetectionSystemGriffin* pGriffinCustom = new DetectionSystemGriffin(fExtensionSuppressorLocation, fDetectorShieldSelect, fDetectorRadialDistance, fHevimetSelector); // Select Forward (0) or Back (1)
 
 	// check for each crystal if a custom dead layer has been specified
-	for(G4int crystal = 0; crystal < 3; ++crystal) {
+	for(G4int crystal = 0; crystal < 4; ++crystal) {
 		if(fGriffinDeadLayer[fCustomDetectorNumber-1][crystal] >= 0.) {
 			pGriffinCustom->SetDeadLayer(fCustomDetectorNumber-1, crystal, fGriffinDeadLayer[fCustomDetectorNumber-1][crystal]);
 		}
@@ -577,33 +577,33 @@ void DetectorConstruction::AddDetectionSystemGriffinCustom(G4int ndet) {
 	G4int detNum;
 	G4int posNum;
 
-	for( detNum = 1; detNum <= ndet; detNum++ ) {
+	for(detNum = 1; detNum <= ndet; detNum++) {
 		posNum = detNum;
 
 		fGriffinDetectorsMap[fGriffinDetectorsMapIndex] = detNum;
 		fGriffinDetectorsMapIndex++;
 
-		DetectionSystemGriffin* pGriffinCustom = new DetectionSystemGriffin( fExtensionSuppressorLocation,  fDetectorShieldSelect ,  fDetectorRadialDistance, fHevimetSelector ) ; // Select Forward (0) or Back (1)
+		DetectionSystemGriffin* pGriffinCustom = new DetectionSystemGriffin(fExtensionSuppressorLocation, fDetectorShieldSelect, fDetectorRadialDistance, fHevimetSelector) ; // Select Forward (0) or Back (1)
 
 		pGriffinCustom->BuildDeadLayerSpecificCrystal(detNum-1);
-		pGriffinCustom->PlaceDeadLayerSpecificCrystal( fLogicWorld, detNum-1, posNum-1, fUseTigressPositions ) ;
+		pGriffinCustom->PlaceDeadLayerSpecificCrystal(fLogicWorld, detNum-1, posNum-1, fUseTigressPositions) ;
 		pGriffinCustom->BuildEverythingButCrystals();
-		pGriffinCustom->PlaceEverythingButCrystals( fLogicWorld, detNum-1, posNum-1, fUseTigressPositions ) ;
+		pGriffinCustom->PlaceEverythingButCrystals(fLogicWorld, detNum-1, posNum-1, fUseTigressPositions) ;
 
 	}
 
 	fGriffin = true;
 }
 
-void DetectorConstruction::AddDetectionSystemGriffinShieldSelect( G4int ShieldSelect ){
+void DetectorConstruction::AddDetectionSystemGriffinShieldSelect(G4int ShieldSelect){
 	fDetectorShieldSelect = ShieldSelect ;
 }
 
-void DetectorConstruction::AddDetectionSystemGriffinSetRadialDistance( G4double detectorDist ){
+void DetectorConstruction::AddDetectionSystemGriffinSetRadialDistance(G4double detectorDist){
 	fDetectorRadialDistance = detectorDist ;
 }
 
-void DetectorConstruction::AddDetectionSystemGriffinSetExtensionSuppLocation( G4int detectorPos ){
+void DetectorConstruction::AddDetectionSystemGriffinSetExtensionSuppLocation(G4int detectorPos){
 	fExtensionSuppressorLocation = detectorPos ;
 }
 
@@ -637,7 +637,7 @@ void DetectorConstruction::AddDetectionSystemGriffinForward(G4int ndet) {
 	G4int detNum;
 	G4int posNum;
 	G4int config  = 0;
-	for( detNum = 1; detNum <= ndet; detNum++ ) {
+	for(detNum = 1; detNum <= ndet; detNum++) {
 		posNum = detNum;
 
 		fGriffinDetectorsMap[fGriffinDetectorsMapIndex] = detNum;
@@ -646,9 +646,9 @@ void DetectorConstruction::AddDetectionSystemGriffinForward(G4int ndet) {
 		DetectionSystemGriffin* pGriffinDLS = new DetectionSystemGriffin(config, 1, fGriffinFwdBackPosition, fHevimetSelector); // Select Forward (0) or Back (1)
 
 		pGriffinDLS->BuildDeadLayerSpecificCrystal(detNum-1);
-		pGriffinDLS->PlaceDeadLayerSpecificCrystal( fLogicWorld, detNum-1, posNum-1, fUseTigressPositions ) ;
+		pGriffinDLS->PlaceDeadLayerSpecificCrystal(fLogicWorld, detNum-1, posNum-1, fUseTigressPositions) ;
 		pGriffinDLS->BuildEverythingButCrystals();
-		pGriffinDLS->PlaceEverythingButCrystals( fLogicWorld, detNum-1, posNum-1, fUseTigressPositions ) ;
+		pGriffinDLS->PlaceEverythingButCrystals(fLogicWorld, detNum-1, posNum-1, fUseTigressPositions) ;
 	}
 
 	fGriffin = true;
@@ -665,15 +665,15 @@ void DetectorConstruction::AddDetectionSystemGriffinForwardDetector(G4int ndet) 
 	fGriffinDetectorsMap[fGriffinDetectorsMapIndex] = detNum;
 	fGriffinDetectorsMapIndex++;
 
-	DetectionSystemGriffin* pGriffinDLS = new DetectionSystemGriffin(config, 1, fGriffinFwdBackPosition, fHevimetSelector ); // Select Forward (0) or Back (1)
+	DetectionSystemGriffin* pGriffinDLS = new DetectionSystemGriffin(config, 1, fGriffinFwdBackPosition, fHevimetSelector); // Select Forward (0) or Back (1)
 
 	pGriffinDLS->BuildDeadLayerSpecificCrystal(detNum-1);
 
-	pGriffinDLS->PlaceDeadLayerSpecificCrystal( fLogicWorld, detNum-1, posNum-1, fUseTigressPositions ) ;
+	pGriffinDLS->PlaceDeadLayerSpecificCrystal(fLogicWorld, detNum-1, posNum-1, fUseTigressPositions) ;
 
 	pGriffinDLS->BuildEverythingButCrystals();
 
-	pGriffinDLS->PlaceEverythingButCrystals( fLogicWorld, detNum-1, posNum-1, fUseTigressPositions ) ;
+	pGriffinDLS->PlaceEverythingButCrystals(fLogicWorld, detNum-1, posNum-1, fUseTigressPositions) ;
 
 	fGriffin = true;
 }
@@ -687,18 +687,18 @@ void DetectorConstruction::AddDetectionSystemGriffinBack(G4int ndet) {
 	G4int posNum;
 	G4int config  = 1;
 
-	for( detNum = 1; detNum <= ndet; detNum++ ) {
+	for(detNum = 1; detNum <= ndet; detNum++) {
 		posNum = detNum;
 
 		fGriffinDetectorsMap[fGriffinDetectorsMapIndex] = detNum;
 		fGriffinDetectorsMapIndex++;
 
-		DetectionSystemGriffin* pGriffinDLS = new DetectionSystemGriffin(config, 1, fGriffinFwdBackPosition, fHevimetSelector ); // Select Forward (0) or Back (1)
+		DetectionSystemGriffin* pGriffinDLS = new DetectionSystemGriffin(config, 1, fGriffinFwdBackPosition, fHevimetSelector); // Select Forward (0) or Back (1)
 
 		pGriffinDLS->BuildDeadLayerSpecificCrystal(detNum-1);
-		pGriffinDLS->PlaceDeadLayerSpecificCrystal( fLogicWorld, detNum-1, posNum-1, fUseTigressPositions ) ;
+		pGriffinDLS->PlaceDeadLayerSpecificCrystal(fLogicWorld, detNum-1, posNum-1, fUseTigressPositions) ;
 		pGriffinDLS->BuildEverythingButCrystals();
-		pGriffinDLS->PlaceEverythingButCrystals( fLogicWorld, detNum-1, posNum-1, fUseTigressPositions ) ;
+		pGriffinDLS->PlaceEverythingButCrystals(fLogicWorld, detNum-1, posNum-1, fUseTigressPositions) ;
 	}
 
 	fGriffin = true;
@@ -719,9 +719,9 @@ void DetectorConstruction::AddDetectionSystemGriffinBackDetector(G4int ndet) {
 	DetectionSystemGriffin* pGriffinDLS = new DetectionSystemGriffin(config, 1, fGriffinFwdBackPosition, fHevimetSelector); // Select Forward (0) or Back (1)
 
 	pGriffinDLS->BuildDeadLayerSpecificCrystal(detNum-1);
-	pGriffinDLS->PlaceDeadLayerSpecificCrystal( fLogicWorld, detNum-1, posNum-1, fUseTigressPositions ) ;
+	pGriffinDLS->PlaceDeadLayerSpecificCrystal(fLogicWorld, detNum-1, posNum-1, fUseTigressPositions) ;
 	pGriffinDLS->BuildEverythingButCrystals();
-	pGriffinDLS->PlaceEverythingButCrystals( fLogicWorld, detNum-1, posNum-1, fUseTigressPositions ) ;
+	pGriffinDLS->PlaceEverythingButCrystals(fLogicWorld, detNum-1, posNum-1, fUseTigressPositions) ;
 
 	fGriffin = true;
 }
@@ -739,7 +739,7 @@ void DetectorConstruction::AddDetectionSystemSceptar(G4int ndet) {
 
 	DetectionSystemSceptar* pSceptar = new DetectionSystemSceptar() ;
 	pSceptar->Build() ;
-	pSceptar->PlaceDetector( fLogicWorld, ndet ) ;
+	pSceptar->PlaceDetector(fLogicWorld, ndet) ;
 
 	fSceptar = true;
 }
@@ -752,7 +752,7 @@ void DetectorConstruction::AddDetectionSystemDescant(G4int ndet) {
 
 	DetectionSystemDescant* pDetectionSystemDescant = new DetectionSystemDescant(true) ;
 	pDetectionSystemDescant->Build() ;
-	pDetectionSystemDescant->PlaceDetector( fLogicWorld, ndet ) ;
+	pDetectionSystemDescant->PlaceDetector(fLogicWorld, ndet) ;
 
 	fDescant = true;
 }
@@ -799,7 +799,7 @@ void DetectorConstruction::AddDetectionSystemDescantCart(G4ThreeVector input) {
 
 	DetectionSystemDescant* pDetectionSystemDescant = new DetectionSystemDescant(true) ;
 	pDetectionSystemDescant->Build() ;
-	pDetectionSystemDescant->PlaceDetector( fLogicWorld, fDescantColor, input, fDescantRotation ) ;
+	pDetectionSystemDescant->PlaceDetector(fLogicWorld, fDescantColor, input, fDescantRotation) ;
 
 	fDescant = true;
 }
@@ -820,9 +820,9 @@ void DetectorConstruction::AddApparatusDescantStructure() {
 
 	ApparatusDescantStructure* pApparatusDescantStructure = new ApparatusDescantStructure() ;
 	pApparatusDescantStructure->Build() ;
-	pApparatusDescantStructure->PlaceDescantStructure( fLogicWorld );
+	pApparatusDescantStructure->PlaceDescantStructure(fLogicWorld);
 
-	//pApparatusDescantStructure->PlaceDetector( fLogicWorld, ndet ) ;
+	//pApparatusDescantStructure->PlaceDetector(fLogicWorld, ndet) ;
 }
 
 void DetectorConstruction::AddDetectionSystemTestcan(G4ThreeVector input) {

--- a/src/DetectorConstruction.cc
+++ b/src/DetectorConstruction.cc
@@ -102,91 +102,91 @@ bool operator==(const DetectorProperties& lhs, const DetectorProperties& rhs)
 }
 
 DetectorConstruction::DetectorConstruction() :
-  fSolidWorld(NULL),
-  fLogicWorld(NULL),
-  fPhysiWorld(NULL)
+	fSolidWorld(nullptr),
+	fLogicWorld(nullptr),
+	fPhysiWorld(nullptr)
 {
-  fWorldSizeX  = fWorldSizeY = fWorldSizeZ = 10.0*m;
+	fWorldSizeX  = fWorldSizeY = fWorldSizeZ = 10.0*m;
 
-  fBoxMat = "G4_WATER";
-  fBoxThickness = 0.0*mm;
-  fBoxInnerDimensions = G4ThreeVector(0.0*mm,0.0*mm,0.0*mm);
-  fBoxColour = G4ThreeVector(0.0,0.0,1.0);
+	fBoxMat = "G4_WATER";
+	fBoxThickness = 0.0*mm;
+	fBoxInnerDimensions = G4ThreeVector(0.0*mm,0.0*mm,0.0*mm);
+	fBoxColour = G4ThreeVector(0.0,0.0,1.0);
 
-  fGridMat = "G4_WATER";
-  fGridSize = 0.0*mm;
-  fGridDimensions = G4ThreeVector(0.0*mm,0.0*mm,0.0*mm);
-  fGridColour = G4ThreeVector(1.0,0.0,0.0);
+	fGridMat = "G4_WATER";
+	fGridSize = 0.0*mm;
+	fGridDimensions = G4ThreeVector(0.0*mm,0.0*mm,0.0*mm);
+	fGridColour = G4ThreeVector(1.0,0.0,0.0);
 
-  // materials
-  DefineMaterials();
+	// materials
+	DefineMaterials();
 
-  //  builtDetectors = false;
+	//  builtDetectors = false;
 
 
-  fMatWorldName = "G4_AIR";
+	fMatWorldName = "G4_AIR";
 
-  // Generic Target Apparatus
-  fSetGenericTargetMaterial   = false;
-  fSetGenericTargetDimensions = false;
-  fSetGenericTargetPosition   = false;
+	// Generic Target Apparatus
+	fSetGenericTargetMaterial   = false;
+	fSetGenericTargetDimensions = false;
+	fSetGenericTargetPosition   = false;
 
-  // Field Box
-  fSetFieldBoxMaterial= false;//think this has been removed 17/8
-  fSetFieldBoxDimensions= false;
-  fSetFieldBoxPosition= false;
-  fSetFieldBoxMagneticField= false;
+	// Field Box
+	fSetFieldBoxMaterial= false;//think this has been removed 17/8
+	fSetFieldBoxDimensions= false;
+	fSetFieldBoxPosition= false;
+	fSetFieldBoxMagneticField= false;
 
-  // parameters to suppress:
+	// parameters to suppress:
 
-  DefineSuppressedParameters();
+	DefineSuppressedParameters();
 
-  // Shield Selection Default
+	// Shield Selection Default
 
-  fUseTigressPositions = false;
+	fUseTigressPositions = false;
 
-  fDetectorShieldSelect = 1 ; // Include suppressors by default.
-  fExtensionSuppressorLocation = 0 ; // Back by default (Detector Forward)
-  fHevimetSelector = 0 ; // Chooses whether or not to include a hevimet
+	fDetectorShieldSelect = 1 ; // Include suppressors by default.
+	fExtensionSuppressorLocation = 0 ; // Back by default (Detector Forward)
+	fHevimetSelector = 0 ; // Chooses whether or not to include a hevimet
 
-  fCustomDetectorNumber 		= 1 ; // detNum
-  fCustomDetectorPosition  = 1 ; // posNum
+	fCustomDetectorNumber 		= 1 ; // detNum
+	fCustomDetectorPosition  = 1 ; // posNum
 
-  // create commands for interactive definition
+	// create commands for interactive definition
 
-  fDetectorMessenger = new DetectorMessenger(this);
- 
-  // ensure the global field is initialized
-  //(void)GlobalField::getObject();
+	fDetectorMessenger = new DetectorMessenger(this);
 
-  //expHallMagField = new MagneticField(); // Global field is set to zero
+	// ensure the global field is initialized
+	//(void)GlobalField::getObject();
 
-  fGriffinDetectorsMapIndex = 0;
-  for(G4int i = 0; i < 16; ++i) {
-	  fGriffinDetectorsMap[i] = 0;
-	  for(G4int j = 0; j < 4; ++j) {
-		  fGriffinDeadLayer[i][j] = -1;
-	  }
-  }
+	//expHallMagField = new MagneticField(); // Global field is set to zero
 
-  fDescantColor = "white";
-  fDescantRotation.setX(M_PI);
-  fDescantRotation.setY(0.);
-  fDescantRotation.setZ(0.);
-  
-  fApparatusLayeredTarget=0;
+	fGriffinDetectorsMapIndex = 0;
+	for(G4int i = 0; i < 16; ++i) {
+		fGriffinDetectorsMap[i] = 0;
+		for(G4int j = 0; j < 4; ++j) {
+			fGriffinDeadLayer[i][j] = -1;
+		}
+	}
 
-  fGridCell = false;
-  fGriffin  = false;
-  fLaBr     = false;
-  fAncBgo   = false;
-  fNaI      = false;
-  fSceptar  = false;
-  fEightPi  = false;
-  fSpice    = false;
-  fPaces    = false;
-  fDescant  = false;
-  fTestcan  = false;
+	fDescantColor = "white";
+	fDescantRotation.setX(M_PI);
+	fDescantRotation.setY(0.);
+	fDescantRotation.setZ(0.);
+
+	fApparatusLayeredTarget=0;
+
+	fGridCell = false;
+	fGriffin  = false;
+	fLaBr     = false;
+	fAncBgo   = false;
+	fNaI      = false;
+	fSceptar  = false;
+	fEightPi  = false;
+	fSpice    = false;
+	fPaces    = false;
+	fDescant  = false;
+	fTestcan  = false;
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
@@ -222,7 +222,7 @@ G4VPhysicalVolume* DetectorConstruction::Construct() {
 			matWorld,	//its material
 			"World");		//its name
 
-	fPhysiWorld = new G4PVPlacement(  0,                  //no rotation
+	fPhysiWorld = new G4PVPlacement(0,                  //no rotation
 			G4ThreeVector(),	//at (0,0,0)
 			fLogicWorld,         //its logical volume
 			"World",            //its name
@@ -261,8 +261,8 @@ void DetectorConstruction::SetWorldVis(G4bool vis) {
 }
 
 void DetectorConstruction::SetWorldStepLimit(G4double step) {
-	if(fLogicWorld == NULL) {
-			Construct();
+	if(fLogicWorld == nullptr) {
+		Construct();
 	}
 	fLogicWorld->SetUserLimits(new G4UserLimits(step));
 }
@@ -275,7 +275,7 @@ void DetectorConstruction::LayeredTargetAdd(G4String Material, G4double Areal)
 {
 	if(!fApparatusLayeredTarget)fApparatusLayeredTarget=new ApparatusLayeredTarget(fDetEffPosition.z());
 	if(fApparatusLayeredTarget->BuildTargetLayer(Material,Areal)){
-		if(fLogicWorld == NULL) {
+		if(fLogicWorld == nullptr) {
 			Construct();
 		}  
 		fApparatusLayeredTarget->PlaceTarget(fLogicWorld);
@@ -343,7 +343,7 @@ G4double DetectorConstruction::LayeredTargetLayerStart(int layer){
 
 
 void DetectorConstruction::AddGrid() {
-	if(fLogicWorld == NULL) {
+	if(fLogicWorld == nullptr) {
 		Construct();
 	}
 
@@ -370,7 +370,7 @@ void DetectorConstruction::AddApparatusSpiceTargetChamber(G4String Options)//par
 
 void DetectorConstruction::AddApparatus8piVacuumChamber() {
 	//Create Vacuum Chamber
-	if(fLogicWorld == NULL) {
+	if(fLogicWorld == nullptr) {
 		Construct();
 	}
 
@@ -380,7 +380,7 @@ void DetectorConstruction::AddApparatus8piVacuumChamber() {
 
 void DetectorConstruction::AddApparatus8piVacuumChamberAuxMatShell(G4double thickness) {
 	//Create Shell Around Vacuum Chamber
-	if(fLogicWorld == NULL) {
+	if(fLogicWorld == nullptr) {
 		Construct();
 	}
 
@@ -390,7 +390,7 @@ void DetectorConstruction::AddApparatus8piVacuumChamberAuxMatShell(G4double thic
 
 void DetectorConstruction::AddApparatusGriffinStructure(G4int selector) {
 	//Create Shell Around Vacuum Chamber
-	if(fLogicWorld == NULL) {
+	if(fLogicWorld == nullptr) {
 		Construct();
 	}
 
@@ -402,7 +402,7 @@ void DetectorConstruction::AddApparatusGriffinStructure(G4int selector) {
 
 
 void DetectorConstruction::AddDetectionSystemSodiumIodide(G4int ndet) {
-	if(fLogicWorld == NULL) {
+	if(fLogicWorld == nullptr) {
 		Construct();
 	}
 
@@ -451,7 +451,7 @@ void DetectorConstruction::AddDetectionSystemSodiumIodide(G4int ndet) {
 }
 
 void DetectorConstruction::AddDetectionSystemLanthanumBromide(G4ThreeVector input) {
-	if(fLogicWorld == NULL) {
+	if(fLogicWorld == nullptr) {
 		Construct();
 	}
 
@@ -469,7 +469,7 @@ void DetectorConstruction::AddDetectionSystemLanthanumBromide(G4ThreeVector inpu
 }
 
 void DetectorConstruction::AddDetectionSystemAncillaryBGO(G4ThreeVector input) {
-	if(fLogicWorld == NULL) {
+	if(fLogicWorld == nullptr) {
 		Construct();
 	}
 
@@ -544,7 +544,7 @@ G4double DetectorConstruction::GetLanthanumBromideCrystalRadialPosition() {
 
 // Temporary Function for testing purposes
 void DetectorConstruction::AddDetectionSystemGriffinCustomDetector(G4int) {
-	if(fLogicWorld == NULL) {
+	if(fLogicWorld == nullptr) {
 		Construct();
 	}
 
@@ -575,7 +575,7 @@ void DetectorConstruction::AddDetectionSystemGriffinCustomDetector(G4int) {
 }
 
 void DetectorConstruction::AddDetectionSystemGriffinCustom(G4int ndet) {
-	if(fLogicWorld == NULL) {
+	if(fLogicWorld == nullptr) {
 		Construct();
 	}
 
@@ -635,7 +635,7 @@ void DetectorConstruction::AddDetectionSystemGriffinSetDeadLayer(G4ThreeVector p
 }
 
 void DetectorConstruction::AddDetectionSystemGriffinForward(G4int ndet) {
-	if(fLogicWorld == NULL) {
+	if(fLogicWorld == nullptr) {
 		Construct();
 	}
 
@@ -660,7 +660,7 @@ void DetectorConstruction::AddDetectionSystemGriffinForward(G4int ndet) {
 }
 
 void DetectorConstruction::AddDetectionSystemGriffinForwardDetector(G4int ndet) {
-	if(fLogicWorld == NULL) {
+	if(fLogicWorld == nullptr) {
 		Construct();
 	}
 
@@ -684,7 +684,7 @@ void DetectorConstruction::AddDetectionSystemGriffinForwardDetector(G4int ndet) 
 }
 
 void DetectorConstruction::AddDetectionSystemGriffinBack(G4int ndet) {
-	if(fLogicWorld == NULL) {
+	if(fLogicWorld == nullptr) {
 		Construct();
 	}
 
@@ -710,7 +710,7 @@ void DetectorConstruction::AddDetectionSystemGriffinBack(G4int ndet) {
 }
 
 void DetectorConstruction::AddDetectionSystemGriffinBackDetector(G4int ndet) {
-	if(fLogicWorld == NULL) {
+	if(fLogicWorld == nullptr) {
 		Construct();
 	}
 
@@ -738,7 +738,7 @@ void DetectorConstruction::AddDetectionSystemGriffinHevimet(G4int input) {
 }
 
 void DetectorConstruction::AddDetectionSystemSceptar(G4int ndet) {
-	if(fLogicWorld == NULL) {
+	if(fLogicWorld == nullptr) {
 		Construct();
 	}
 
@@ -751,7 +751,7 @@ void DetectorConstruction::AddDetectionSystemSceptar(G4int ndet) {
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 void DetectorConstruction::AddDetectionSystemDescant(G4int ndet) {
-	if(fLogicWorld == NULL) {
+	if(fLogicWorld == nullptr) {
 		Construct();
 	}
 
@@ -764,7 +764,7 @@ void DetectorConstruction::AddDetectionSystemDescant(G4int ndet) {
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 void DetectorConstruction::AddDetectionSystemDescantAuxPorts(G4ThreeVector input) {
-	if(fLogicWorld == NULL) {
+	if(fLogicWorld == nullptr) {
 		Construct();
 	}
 
@@ -798,7 +798,7 @@ void DetectorConstruction::SetDetectionSystemDescantColor(G4String input) {
 }
 
 void DetectorConstruction::AddDetectionSystemDescantCart(G4ThreeVector input) {
-	if(fLogicWorld == NULL) {
+	if(fLogicWorld == nullptr) {
 		Construct();
 	}
 
@@ -819,7 +819,7 @@ void DetectorConstruction::AddDetectionSystemDescantSpher(G4ThreeVector input, G
 }
 
 void DetectorConstruction::AddApparatusDescantStructure() {
-	if(fLogicWorld == NULL) {
+	if(fLogicWorld == nullptr) {
 		Construct();
 	}
 
@@ -831,7 +831,7 @@ void DetectorConstruction::AddApparatusDescantStructure() {
 }
 
 void DetectorConstruction::AddDetectionSystemTestcan(G4ThreeVector input) {
-	if(fLogicWorld == NULL) {
+	if(fLogicWorld == nullptr) {
 		Construct();
 	}
 
@@ -846,27 +846,27 @@ void DetectorConstruction::AddDetectionSystemTestcan(G4ThreeVector input) {
 }
 
 void DetectorConstruction::AddDetectionSystemSpice() {
-  if(fLogicWorld == NULL) {
-	Construct();
-  }
-  DetectionSystemSpice* pSpice = new DetectionSystemSpice() ;
-  pSpice->BuildPlace(fLogicWorld); 
-  
-  fSpice = true;
-  //HistoManager::Instance().Spice(true);//boolean needed to make SPICE histograms
+	if(fLogicWorld == nullptr) {
+		Construct();
+	}
+	DetectionSystemSpice* pSpice = new DetectionSystemSpice() ;
+	pSpice->BuildPlace(fLogicWorld); 
+
+	fSpice = true;
+	//HistoManager::Instance().Spice(true);//boolean needed to make SPICE histograms
 }
 
 void DetectorConstruction::AddDetectionSystemTrific(G4double Torr) {
-  if(fLogicWorld == NULL) {
-	Construct();
-  }
-  DetectionSystemTrific* pTrific = new DetectionSystemTrific(Torr) ;
-  pTrific->BuildPlace(fLogicWorld); 
-  
+	if(fLogicWorld == nullptr) {
+		Construct();
+	}
+	DetectionSystemTrific* pTrific = new DetectionSystemTrific(Torr) ;
+	pTrific->BuildPlace(fLogicWorld); 
+
 }
 
 void DetectorConstruction::AddDetectionSystemPaces(G4int ndet) {
-	if(fLogicWorld == NULL) {
+	if(fLogicWorld == nullptr) {
 		Construct();
 	}
 
@@ -881,7 +881,7 @@ void DetectorConstruction::AddDetectionSystemPaces(G4int ndet) {
 void DetectorConstruction::SetProperties() {
 	// loop over all existing daughters of the world volume
 	// check if their properties are set and if not, set them
-	if(fLogicWorld == NULL) return;
+	if(fLogicWorld == nullptr) return;
 	G4cout<<fLogicWorld->GetNoDaughters()<<" daughter volumes"<<std::endl;
 	for(int i = 0; i < fLogicWorld->GetNoDaughters(); ++i) {
 		if(!HasProperties(fLogicWorld->GetDaughter(i)) && CheckVolumeName(fLogicWorld->GetDaughter(i)->GetName())) {
@@ -891,7 +891,7 @@ void DetectorConstruction::SetProperties() {
 }
 
 void DetectorConstruction::Print() {
-	if(fLogicWorld == NULL) {
+	if(fLogicWorld == nullptr) {
 		std::cout<<"World volume does not exist yet!"<<std::endl;
 		return;
 	}

--- a/src/DetectorMessenger.cc
+++ b/src/DetectorMessenger.cc
@@ -485,16 +485,14 @@ void DetectorMessenger::SetNewValue(G4UIcommand* command,G4String newValue)
 	if(command == fLayeredTargetAddCmd) {
 		G4String Material;
 		G4double areal;
-		const char* s = newValue;///string
-		std::istringstream is ((char*)s);///string
+		std::istringstream is(newValue);///string
 		is>>Material>>areal;
 		fDetector->LayeredTargetAdd(Material, areal);
 	}
 	if(command == fTabMagneticFieldCmd) {
 		G4String PathAndTableName;
 		G4double z_offset, z_rotation;
-		const char* s = newValue;///string
-		std::istringstream is ((char*)s);///string
+		std::istringstream is(newValue);///string
 		is>>PathAndTableName>>z_offset>>z_rotation;
 		fDetector->SetTabMagneticField(PathAndTableName, z_offset, z_rotation); // z in mm, angle in degree  
 	}
@@ -622,8 +620,7 @@ void DetectorMessenger::SetNewValue(G4UIcommand* command,G4String newValue)
 	if(command == fAddDetectionSystemTrificCmd) {
 		//Done as a string because Torr isnt a default unit 
 		G4double torr;
-		const char* s = newValue;///string
-		std::istringstream is ((char*)s);///string
+		std::istringstream is(newValue);///string
 		is>>torr;
 		if(torr>1)fDetector->AddDetectionSystemTrific(torr);
 		else fDetector->AddDetectionSystemTrific(760.0);

--- a/src/DetectorMessenger.cc
+++ b/src/DetectorMessenger.cc
@@ -51,7 +51,7 @@
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
 DetectorMessenger::DetectorMessenger(DetectorConstruction* Det)
-    :fDetector(Det)
+:fDetector(Det)
 {
 	fDetSysDir = new G4UIdirectory("/DetSys/");
 	fDetSysDir->SetGuidance("UI commands of this example");
@@ -83,7 +83,7 @@ DetectorMessenger::DetectorMessenger(DetectorConstruction* Det)
 	fWorldMagneticFieldCmd->SetGuidance("Set world magnetic field - x y z unit.");
 	fWorldMagneticFieldCmd->SetUnitCategory("Magnetic flux density");
 	fWorldMagneticFieldCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
-	
+
 	fWorldStepLimit = new G4UIcmdWithADoubleAndUnit("/DetSys/world/StepLimit",this);
 	fWorldStepLimit->SetGuidance("Set user step limit for the world volume.");
 	fWorldStepLimit->SetUnitCategory("Length");
@@ -283,39 +283,39 @@ DetectorMessenger::DetectorMessenger(DetectorConstruction* Det)
 	fAddDetectionSystemGriffinBackDetectorCmd->SetGuidance("Add GriffinBack Detector");
 	fAddDetectionSystemGriffinBackDetectorCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
 
-	fAddDetectionSystemGriffinCustomDetectorCmd = new G4UIcmdWithAnInteger( "/DetSys/det/addGriffinCustomDetector", this);
-	fAddDetectionSystemGriffinCustomDetectorCmd->SetGuidance( "Adds a detector using the paramaters specified");
-	fAddDetectionSystemGriffinCustomDetectorCmd->AvailableForStates( G4State_PreInit, G4State_Idle);
+	fAddDetectionSystemGriffinCustomDetectorCmd = new G4UIcmdWithAnInteger("/DetSys/det/addGriffinCustomDetector", this);
+	fAddDetectionSystemGriffinCustomDetectorCmd->SetGuidance("Adds a detector using the paramaters specified");
+	fAddDetectionSystemGriffinCustomDetectorCmd->AvailableForStates(G4State_PreInit, G4State_Idle);
 
-	fAddDetectionSystemGriffinCustomCmd = new G4UIcmdWithAnInteger( "/DetSys/det/addGriffinCustom", this);
-	fAddDetectionSystemGriffinCustomCmd->SetGuidance( "Adds a detection system using the paramaters specified");
-	fAddDetectionSystemGriffinCustomCmd->AvailableForStates( G4State_PreInit, G4State_Idle);
+	fAddDetectionSystemGriffinCustomCmd = new G4UIcmdWithAnInteger("/DetSys/det/addGriffinCustom", this);
+	fAddDetectionSystemGriffinCustomCmd->SetGuidance("Adds a detection system using the paramaters specified");
+	fAddDetectionSystemGriffinCustomCmd->AvailableForStates(G4State_PreInit, G4State_Idle);
 
 	//////// Commands that are required for addGriffinCustom
-	fAddDetectionSystemGriffinShieldSelectCmd = new G4UIcmdWithAnInteger( "/DetSys/det/SetCustomShieldsPresent", this);
-	fAddDetectionSystemGriffinShieldSelectCmd->SetGuidance( "Selects whether or not the detector suppressors are included");
-	fAddDetectionSystemGriffinShieldSelectCmd->AvailableForStates( G4State_PreInit, G4State_Idle);
+	fAddDetectionSystemGriffinShieldSelectCmd = new G4UIcmdWithAnInteger("/DetSys/det/SetCustomShieldsPresent", this);
+	fAddDetectionSystemGriffinShieldSelectCmd->SetGuidance("Selects whether or not the detector suppressors are included");
+	fAddDetectionSystemGriffinShieldSelectCmd->AvailableForStates(G4State_PreInit, G4State_Idle);
 
-	fAddDetectionSystemGriffinSetRadialDistanceCmd = new G4UIcmdWithADoubleAndUnit( "/DetSys/det/SetCustomRadialDistance", this);
-	fAddDetectionSystemGriffinSetRadialDistanceCmd->SetGuidance( "Selects the radial distance for the detector from the origin");
-	fAddDetectionSystemGriffinSetRadialDistanceCmd->AvailableForStates( G4State_PreInit, G4State_Idle);
+	fAddDetectionSystemGriffinSetRadialDistanceCmd = new G4UIcmdWithADoubleAndUnit("/DetSys/det/SetCustomRadialDistance", this);
+	fAddDetectionSystemGriffinSetRadialDistanceCmd->SetGuidance("Selects the radial distance for the detector from the origin");
+	fAddDetectionSystemGriffinSetRadialDistanceCmd->AvailableForStates(G4State_PreInit, G4State_Idle);
 
-	fAddDetectionSystemGriffinSetExtensionSuppLocationCmd = new G4UIcmdWithAnInteger( "/DetSys/det/SetCustomExtensionSuppressorLocation", this);
-	fAddDetectionSystemGriffinSetExtensionSuppLocationCmd->SetGuidance( "Selects a position for the extension suppressors. Either forward (0) or back (1).");
-	fAddDetectionSystemGriffinSetExtensionSuppLocationCmd->AvailableForStates( G4State_PreInit, G4State_Idle);
+	fAddDetectionSystemGriffinSetExtensionSuppLocationCmd = new G4UIcmdWithAnInteger("/DetSys/det/SetCustomExtensionSuppressorLocation", this);
+	fAddDetectionSystemGriffinSetExtensionSuppLocationCmd->SetGuidance("Selects a position for the extension suppressors. Either forward (0) or back (1).");
+	fAddDetectionSystemGriffinSetExtensionSuppLocationCmd->AvailableForStates(G4State_PreInit, G4State_Idle);
 
-	fAddDetectionSystemGriffinSetPositionCmd = new G4UIcmdWith3Vector( "/DetSys/det/SetCustomPosition", this);
-	fAddDetectionSystemGriffinSetPositionCmd->SetGuidance( "Sets the position and number for the detector placed in the next call to addGriffinCustom.");
-	fAddDetectionSystemGriffinSetPositionCmd->AvailableForStates( G4State_PreInit, G4State_Idle);
+	fAddDetectionSystemGriffinSetPositionCmd = new G4UIcmdWith3Vector("/DetSys/det/SetCustomPosition", this);
+	fAddDetectionSystemGriffinSetPositionCmd->SetGuidance("Sets the position and number for the detector placed in the next call to addGriffinCustom.");
+	fAddDetectionSystemGriffinSetPositionCmd->AvailableForStates(G4State_PreInit, G4State_Idle);
 
-	fAddDetectionSystemGriffinSetDeadLayerCmd = new G4UIcmdWith3Vector( "/DetSys/det/SetCustomDeadLayer", this);
-	fAddDetectionSystemGriffinSetDeadLayerCmd->SetGuidance( "Sets the dead layer for the specified crystal.");
-	fAddDetectionSystemGriffinSetDeadLayerCmd->AvailableForStates( G4State_PreInit, G4State_Idle);
+	fAddDetectionSystemGriffinSetDeadLayerCmd = new G4UIcmdWith3Vector("/DetSys/det/SetCustomDeadLayer", this);
+	fAddDetectionSystemGriffinSetDeadLayerCmd->SetGuidance("Sets the dead layer for the specified crystal.");
+	fAddDetectionSystemGriffinSetDeadLayerCmd->AvailableForStates(G4State_PreInit, G4State_Idle);
 	////////
 
-	fAddDetectionSystemGriffinHevimetCmd = new G4UIcmdWithAnInteger( "/DetSys/det/includeGriffinHevimet", this);
-	fAddDetectionSystemGriffinHevimetCmd->SetGuidance( "Includes the Hevimet for a Griffin detector.");
-	fAddDetectionSystemGriffinHevimetCmd->AvailableForStates( G4State_PreInit, G4State_Idle);
+	fAddDetectionSystemGriffinHevimetCmd = new G4UIcmdWithAnInteger("/DetSys/det/includeGriffinHevimet", this);
+	fAddDetectionSystemGriffinHevimetCmd->SetGuidance("Includes the Hevimet for a Griffin detector.");
+	fAddDetectionSystemGriffinHevimetCmd->AvailableForStates(G4State_PreInit, G4State_Idle);
 
 	fAddDetectionSystemSceptarCmd = new G4UIcmdWithAnInteger("/DetSys/det/addSceptar",this);
 	fAddDetectionSystemSceptarCmd->SetGuidance("Add Detection System Sceptar");
@@ -328,7 +328,7 @@ DetectorMessenger::DetectorMessenger(DetectorConstruction* Det)
 	fAddDetectionSystemTrificCmd = new G4UIcmdWithAString("/DetSys/det/addTrificDetector",this);
 	fAddDetectionSystemTrificCmd->SetGuidance("Add Detection System Trific");
 	fAddDetectionSystemTrificCmd->AvailableForStates(G4State_PreInit,G4State_Idle);	
-	
+
 	fUseSpiceResolutionCmd = new G4UIcmdWithABool("/DetSys/det/UseSpiceResolution",this);
 	fUseSpiceResolutionCmd->SetGuidance("Apply a resolution to energy depositions");
 	fUseSpiceResolutionCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
@@ -443,7 +443,7 @@ void DetectorMessenger::SetNewValue(G4UIcommand* command,G4String newValue)
 	if(command == fUpdateCmd) {
 		fDetector->UpdateGeometry();
 	}
-	if(command == fWorldStepLimit ) {
+	if(command == fWorldStepLimit) {
 		fDetector->SetWorldStepLimit(fWorldStepLimit->GetNewDoubleValue(newValue));
 	}
 	if(command == fGenericTargetCmd) {
@@ -490,7 +490,7 @@ void DetectorMessenger::SetNewValue(G4UIcommand* command,G4String newValue)
 		is>>Material>>areal;
 		fDetector->LayeredTargetAdd(Material, areal);
 	}
-	if( command == fTabMagneticFieldCmd) {
+	if(command == fTabMagneticFieldCmd) {
 		G4String PathAndTableName;
 		G4double z_offset, z_rotation;
 		const char* s = newValue;///string
@@ -616,10 +616,10 @@ void DetectorMessenger::SetNewValue(G4UIcommand* command,G4String newValue)
 	if(command == fAddDetectionSystemGriffinSetDeadLayerCmd) {
 		fDetector->AddDetectionSystemGriffinSetDeadLayer(fAddDetectionSystemGriffinSetDeadLayerCmd->GetNew3VectorValue(newValue));
 	}
-	if(command == fAddDetectionSystemSpiceCmd ) {
+	if(command == fAddDetectionSystemSpiceCmd) {
 		fDetector->AddDetectionSystemSpice(); 
 	}
-	if(command == fAddDetectionSystemTrificCmd ) {
+	if(command == fAddDetectionSystemTrificCmd) {
 		//Done as a string because Torr isnt a default unit 
 		G4double torr;
 		const char* s = newValue;///string
@@ -628,7 +628,7 @@ void DetectorMessenger::SetNewValue(G4UIcommand* command,G4String newValue)
 		if(torr>1)fDetector->AddDetectionSystemTrific(torr);
 		else fDetector->AddDetectionSystemTrific(760.0);
 	}
-	if(command == fUseSpiceResolutionCmd ) {
+	if(command == fUseSpiceResolutionCmd) {
 		fDetector->SpiceRes(fUseSpiceResolutionCmd->GetNewBoolValue(newValue));
 	}
 	if(command == fAddDetectionSystemPacesCmd) {

--- a/src/EventAction.cc
+++ b/src/EventAction.cc
@@ -46,17 +46,17 @@
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
 EventAction::EventAction(RunAction* run, HistoManager* hist)
-    :G4UserEventAction(),
-      fRunAction(run),
-		fHistoManager(hist),
-      fPrintModulo(1000)
+:G4UserEventAction(),
+	fRunAction(run),
+	fHistoManager(hist),
+	fPrintModulo(1000)
 {
-    fNumberOfHits = 0;
-    fNumberOfSteps = 0;
+	fNumberOfHits = 0;
+	fNumberOfSteps = 0;
 
-	 if(fHistoManager->GetDetectorConstruction()->Spice()) {
-		 SetupSpiceErfc();
-	 }
+	if(fHistoManager->GetDetectorConstruction()->Spice()) {
+		SetupSpiceErfc();
+	}
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......

--- a/src/EventAction.cc
+++ b/src/EventAction.cc
@@ -96,76 +96,68 @@ void EventAction::EndOfEventAction(const G4Event*) {
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
-void EventAction::AddHitTracker(G4String mnemonic, G4int eventNumber, G4int trackID, G4int parentID, G4int stepNumber, G4int particleType, G4int processType, G4int systemID, G4int cryNumber, G4int detNumber, G4double depEnergy, G4double posx, G4double posy, G4double posz, G4double time, G4int targetZ) {
-	G4bool newhit = true;
+void EventAction::AddHitTracker(const DetectorProperties& properties, const G4int& eventNumber, const G4int& trackID, const G4int& parentID, const G4int& stepNumber, const G4int& particleType, const G4int& processType, const G4double& depEnergy, const G4ThreeVector& pos, const G4double& time, const G4int& targetZ) {
 	for(G4int i = 0; i < fNumberOfHits; i++) {
-		if(fPHitMnemonic[i] == mnemonic) {
+		if(fProperties[i] == properties) {
 			// sum the new enery
 			fHitTrackerD[0][i] = fHitTrackerD[0][i] + depEnergy;
-			newhit = false;
-			break;
+			return;
 		}
 	}
-	if(newhit) { // new hit
-		fPHitMnemonic[fHitIndex] = mnemonic;
-		fPTrackID = trackID;
-		fPParentID = parentID;
-		fHitTrackerI[0][fHitIndex] = eventNumber;
-		fHitTrackerI[1][fHitIndex] = trackID;
-		fHitTrackerI[2][fHitIndex] = parentID;
-		fHitTrackerI[3][fHitIndex] = stepNumber;
-		fHitTrackerI[4][fHitIndex] = particleType;
-		fHitTrackerI[5][fHitIndex] = processType;
-		fHitTrackerI[6][fHitIndex] = systemID;
-		fHitTrackerI[7][fHitIndex] = cryNumber;
-		fHitTrackerI[8][fHitIndex] = detNumber;
-		fHitTrackerI[9][fHitIndex] = targetZ;
-		fHitTrackerD[0][fHitIndex] = depEnergy;
-		fHitTrackerD[1][fHitIndex] = posx;
-		fHitTrackerD[2][fHitIndex] = posy;
-		fHitTrackerD[3][fHitIndex] = posz;
-		fHitTrackerD[4][fHitIndex] = time;
+	// new hit
+	fProperties[fNumberOfHits] = properties;
+	fHitTrackerI[0][fNumberOfHits] = eventNumber;
+	fHitTrackerI[1][fNumberOfHits] = trackID;
+	fHitTrackerI[2][fNumberOfHits] = parentID;
+	fHitTrackerI[3][fNumberOfHits] = stepNumber;
+	fHitTrackerI[4][fNumberOfHits] = particleType;
+	fHitTrackerI[5][fNumberOfHits] = processType;
+	fHitTrackerI[6][fNumberOfHits] = properties.systemID;
+	fHitTrackerI[7][fNumberOfHits] = properties.crystalNumber;
+	fHitTrackerI[8][fNumberOfHits] = properties.detectorNumber;
+	fHitTrackerI[9][fNumberOfHits] = targetZ;
+	fHitTrackerD[0][fNumberOfHits] = depEnergy;
+	fHitTrackerD[1][fNumberOfHits] = pos.x();
+	fHitTrackerD[2][fNumberOfHits] = pos.y();
+	fHitTrackerD[3][fNumberOfHits] = pos.z();
+	fHitTrackerD[4][fNumberOfHits] = time;
 
-		fHitIndex++;
-		fNumberOfHits = fHitIndex;
+	++fNumberOfHits;
 
-		if(fNumberOfHits >= MAXHITS) {
-			G4cout << "ERROR! Too many hits!" << G4endl;
-		}
+	if(fNumberOfHits >= MAXHITS) {
+		G4cout<<"ERROR! Too many hits!"<<G4endl;
+		throw;
 	}
 }
 
-void EventAction::AddStepTracker(G4int eventNumber, G4int trackID, G4int parentID, G4int stepNumber, G4int particleType, G4int processType, G4int systemID, G4int cryNumber, G4int detNumber, G4double depEnergy, G4double posx, G4double posy, G4double posz, G4double time, G4int targetZ) {
-	G4bool newstep = true;
-	if(newstep) { // new step
-		fStepTrackerI[0][fStepIndex] = eventNumber;
-		fStepTrackerI[1][fStepIndex] = trackID;
-		fStepTrackerI[2][fStepIndex] = parentID;
-		fStepTrackerI[3][fStepIndex] = stepNumber;
-		fStepTrackerI[4][fStepIndex] = particleType;
-		fStepTrackerI[5][fStepIndex] = processType;
-		fStepTrackerI[6][fStepIndex] = systemID;
-		fStepTrackerI[7][fStepIndex] = cryNumber;
-		fStepTrackerI[8][fStepIndex] = detNumber;
-		fStepTrackerI[9][fStepIndex] = targetZ;
-		fStepTrackerD[0][fStepIndex] = depEnergy;
-		fStepTrackerD[1][fStepIndex] = posx;
-		fStepTrackerD[2][fStepIndex] = posy;
-		fStepTrackerD[3][fStepIndex] = posz;
-		fStepTrackerD[4][fStepIndex] = time;
+void EventAction::AddStepTracker(const DetectorProperties& properties, const G4int& eventNumber, const G4int& trackID, const G4int& parentID, const G4int& stepNumber, const G4int& particleType, const G4int& processType, const G4double& depEnergy, const G4ThreeVector& pos, const G4double& time, const G4int& targetZ) {
+	// new step
+	fStepTrackerI[0][fNumberOfSteps] = eventNumber;
+	fStepTrackerI[1][fNumberOfSteps] = trackID;
+	fStepTrackerI[2][fNumberOfSteps] = parentID;
+	fStepTrackerI[3][fNumberOfSteps] = stepNumber;
+	fStepTrackerI[4][fNumberOfSteps] = particleType;
+	fStepTrackerI[5][fNumberOfSteps] = processType;
+	fStepTrackerI[6][fNumberOfSteps] = properties.systemID;
+	fStepTrackerI[7][fNumberOfSteps] = properties.crystalNumber;
+	fStepTrackerI[8][fNumberOfSteps] = properties.detectorNumber;
+	fStepTrackerI[9][fNumberOfSteps] = targetZ;
+	fStepTrackerD[0][fNumberOfSteps] = depEnergy;
+	fStepTrackerD[1][fNumberOfSteps] = pos.x();
+	fStepTrackerD[2][fNumberOfSteps] = pos.y();
+	fStepTrackerD[3][fNumberOfSteps] = pos.z();
+	fStepTrackerD[4][fNumberOfSteps] = time;
 
-		fStepIndex++;
+	++fNumberOfSteps;
 
-		fNumberOfSteps = fStepIndex;
-		if(fNumberOfSteps >= MAXSTEPS) {
-			G4cout << "ERROR! Too many steps!" << G4endl;
-		}
+	if(fNumberOfSteps >= MAXSTEPS) {
+		G4cout<<"ERROR! Too many steps!"<<G4endl;
+		throw;
 	}
 }
 
 void EventAction::ClearVariables() {
 	if(fHistoManager->GetStepTrackerBool()) {
-		fStepIndex = 0;
 		fNumberOfSteps = 0;
 		for(G4int i = 0; i < MAXSTEPS; i++) {
 			for(G4int j = 0; j < NUMSTEPVARS; j++) {
@@ -176,13 +168,10 @@ void EventAction::ClearVariables() {
 	}
 
 	if(fHistoManager->GetHitTrackerBool()) {
-		fHitIndex = 0;
 		fNumberOfHits = 0;
-		fPTrackID = -1;
-		fPParentID = -1;
 
 		for(G4int i = 0; i < MAXHITS; i++) {
-			fPHitMnemonic[i] = "XXX00XX00X";
+			fProperties[i].Clear();
 			for(G4int j = 0; j < NUMSTEPVARS; j++) {
 				fHitTrackerI[j][i] = 0;
 				fHitTrackerD[j][i] = 0.0;

--- a/src/NonUniformMagneticField.cc
+++ b/src/NonUniformMagneticField.cc
@@ -21,7 +21,7 @@
 #include "G4RKG3_Stepper.hh"
 
 NonUniformMagneticField::NonUniformMagneticField(const char* fieldName="./", G4double zOffset=0., G4double zRotation=0.) //hard code here? as no changes made??
-	: fChordFinder(0), fStepper(0)
+: fChordFinder(0), fStepper(0)
 {
 	fMagneticField = new TabulatedMagneticField(fieldName, zOffset, zRotation);//sets field to that read in from the table
 	GetGlobalFieldManager()->CreateChordFinder(fMagneticField);
@@ -49,7 +49,7 @@ void NonUniformMagneticField::UpdateField()
 	SetStepper();
 	G4cout<<"The minimal step is equal to "<<fMinStep/CLHEP::mm<<" mm"<<G4endl;
 
-	fFieldManager->SetDetectorField(fMagneticField );
+	fFieldManager->SetDetectorField(fMagneticField);
 
 	delete fChordFinder; //why delete here and remake below? - allows for new steppers/minimum steps/or field, but this is never invoked may allow for greater optimisation
 
@@ -74,43 +74,43 @@ void NonUniformMagneticField::SetStepper()
 			G4cout<<"G4ExplicitEuler is called"<<G4endl;     
 			break;
 		case 1:  
-			fStepper = new G4ImplicitEuler( fEquation );      
+			fStepper = new G4ImplicitEuler(fEquation);      
 			G4cout<<"G4ImplicitEuler is called"<<G4endl;     
 			break;
 		case 2:  
-			fStepper = new G4SimpleRunge( fEquation );        
+			fStepper = new G4SimpleRunge(fEquation);        
 			G4cout<<"G4SimpleRunge is called"<<G4endl;     
 			break;
 		case 3:  
-			fStepper = new G4SimpleHeum( fEquation );         
+			fStepper = new G4SimpleHeum(fEquation);         
 			G4cout<<"G4SimpleHeum is called"<<G4endl;     
 			break;
 		case 4:  
-			fStepper = new G4ClassicalRK4( fEquation );       
+			fStepper = new G4ClassicalRK4(fEquation);       
 			G4cout<<"G4ClassicalRK4 (default) is called"<<G4endl;     
 			break;
 		case 5:  
-			fStepper = new G4HelixExplicitEuler( fEquation ); 
+			fStepper = new G4HelixExplicitEuler(fEquation); 
 			G4cout<<"G4HelixExplicitEuler is called"<<G4endl;     
 			break;
 		case 6:  
-			fStepper = new G4HelixImplicitEuler( fEquation ); 
+			fStepper = new G4HelixImplicitEuler(fEquation); 
 			G4cout<<"G4HelixImplicitEuler is called"<<G4endl;     
 			break;
 		case 7:  
-			fStepper = new G4HelixSimpleRunge( fEquation );   
+			fStepper = new G4HelixSimpleRunge(fEquation);   
 			G4cout<<"G4HelixSimpleRunge is called"<<G4endl;     
 			break;
 		case 8:  
-			fStepper = new G4CashKarpRKF45( fEquation );      
+			fStepper = new G4CashKarpRKF45(fEquation);      
 			G4cout<<"G4CashKarpRKF45 is called"<<G4endl;     
 			break;
 		case 9:  
-			fStepper = new G4RKG3_Stepper( fEquation );       
+			fStepper = new G4RKG3_Stepper(fEquation);       
 			G4cout<<"G4RKG3_Stepper is called"<<G4endl;     
 			break;
 		default: 
-			fStepper = NULL;
+			fStepper = nullptr;
 	}
 }
 

--- a/src/PhysListHadron.cc
+++ b/src/PhysListHadron.cc
@@ -83,11 +83,11 @@
 
 
 PhysListHadron::PhysListHadron(const G4String& name)
-    : G4VPhysicsConstructor(name),
-      fTheNeutronElasticProcess(0), fTheFissionProcess(0),
-      fTheCaptureProcess(0),fTheDeuteronInelasticProcess(0),
-      fTheTritonInelasticProcess(0), fTheAlphaInelasticProcess(0),
-      fTheIonInelasticProcess(0)
+: G4VPhysicsConstructor(name),
+	fTheNeutronElasticProcess(0), fTheFissionProcess(0),
+	fTheCaptureProcess(0),fTheDeuteronInelasticProcess(0),
+	fTheTritonInelasticProcess(0), fTheAlphaInelasticProcess(0),
+	fTheIonInelasticProcess(0)
 {}
 
 PhysListHadron::~PhysListHadron()
@@ -96,191 +96,191 @@ PhysListHadron::~PhysListHadron()
 
 void PhysListHadron::ConstructProcess()
 {
-    G4ProcessManager* pManager = 0;
+	G4ProcessManager* pManager = 0;
 
-    G4TheoFSGenerator* theTheoModel = new G4TheoFSGenerator;
-    // all models for treatment of thermal nucleus
-    G4Evaporation* theEvaporation = new G4Evaporation;
-    //G4FermiBreakUp* theFermiBreakUp = new G4FermiBreakUp;
-    G4StatMF* theMF = new G4StatMF;
-    // Evaporation logic
-    G4ExcitationHandler* theHandler = new G4ExcitationHandler;
-    theHandler->SetEvaporation(theEvaporation);
-    //theHandler->SetFermiModel(theFermiBreakUp);
-    theHandler->SetMultiFragmentation(theMF);
-    theHandler->SetMaxAandZForFermiBreakUp(12, 6);
-    theHandler->SetMinEForMultiFrag(5*MeV);
-    // Pre equilibrium stage
-    G4PreCompoundModel* thePreEquilib = new G4PreCompoundModel(theHandler);
+	G4TheoFSGenerator* theTheoModel = new G4TheoFSGenerator;
+	// all models for treatment of thermal nucleus
+	G4Evaporation* theEvaporation = new G4Evaporation;
+	//G4FermiBreakUp* theFermiBreakUp = new G4FermiBreakUp;
+	G4StatMF* theMF = new G4StatMF;
+	// Evaporation logic
+	G4ExcitationHandler* theHandler = new G4ExcitationHandler;
+	theHandler->SetEvaporation(theEvaporation);
+	//theHandler->SetFermiModel(theFermiBreakUp);
+	theHandler->SetMultiFragmentation(theMF);
+	theHandler->SetMaxAandZForFermiBreakUp(12, 6);
+	theHandler->SetMinEForMultiFrag(5*MeV);
+	// Pre equilibrium stage
+	G4PreCompoundModel* thePreEquilib = new G4PreCompoundModel(theHandler);
 
-    // a no-cascade generator-precompound interaface
-    G4GeneratorPrecompoundInterface* theCascade =
-            new G4GeneratorPrecompoundInterface;
-    theCascade->SetDeExcitation(thePreEquilib);
+	// a no-cascade generator-precompound interaface
+	G4GeneratorPrecompoundInterface* theCascade =
+		new G4GeneratorPrecompoundInterface;
+	theCascade->SetDeExcitation(thePreEquilib);
 
-    // High energy parts
-    // String model; still not quite according to design
-    // Explicit use of the forseen interfaces
-    G4VPartonStringModel* theStringModel;
-    theStringModel = new G4QGSModel<G4QGSParticipants>;
-    theTheoModel->SetTransport(theCascade);
-    theTheoModel->SetHighEnergyGenerator(theStringModel);
-    theTheoModel->SetMinEnergy(10*GeV);  // 15 GeV may be the right limit
-    theTheoModel->SetMaxEnergy(100*TeV);
+	// High energy parts
+	// String model; still not quite according to design
+	// Explicit use of the forseen interfaces
+	G4VPartonStringModel* theStringModel;
+	theStringModel = new G4QGSModel<G4QGSParticipants>;
+	theTheoModel->SetTransport(theCascade);
+	theTheoModel->SetHighEnergyGenerator(theStringModel);
+	theTheoModel->SetMinEnergy(10*GeV);  // 15 GeV may be the right limit
+	theTheoModel->SetMaxEnergy(100*TeV);
 
-    G4VLongitudinalStringDecay * theFragmentation = new G4QGSMFragmentation;
-    G4ExcitedStringDecay * theStringDecay =
-            new G4ExcitedStringDecay(theFragmentation);
-    theStringModel->SetFragmentationModel(theStringDecay);
+	G4VLongitudinalStringDecay * theFragmentation = new G4QGSMFragmentation;
+	G4ExcitedStringDecay * theStringDecay =
+		new G4ExcitedStringDecay(theFragmentation);
+	theStringModel->SetFragmentationModel(theStringDecay);
 
-    // Elastic Process
+	// Elastic Process
 
-    fTheElasticProcess.RegisterMe(new G4HadronElastic());
+	fTheElasticProcess.RegisterMe(new G4HadronElastic());
 
-    // Hadron elastic process for all particles except neutrons and generic ions
-	 auto aParticleIterator = GetParticleIterator();
-    aParticleIterator->reset();
-    while ((*aParticleIterator)() ) {
-        G4ParticleDefinition* particle = aParticleIterator->value();
-        G4String particleName = particle->GetParticleName();
-        if (particleName != "neutron" && particleName != "GenericIon" &&
-                particleName != "He3") {
-            pManager = particle->GetProcessManager();
-            if (particle->GetPDGMass() > 110.*MeV &&
-                    fTheElasticProcess.IsApplicable(*particle) &&
-                    !particle->IsShortLived()) {
-                pManager->AddDiscreteProcess(&fTheElasticProcess);
-                //        G4cout << "### Elastic model are registered for "
-                //       << particle->GetParticleName()
-                //       << G4endl;
-            }
-        }
-    }
+	// Hadron elastic process for all particles except neutrons and generic ions
+	auto aParticleIterator = GetParticleIterator();
+	aParticleIterator->reset();
+	while ((*aParticleIterator)()) {
+		G4ParticleDefinition* particle = aParticleIterator->value();
+		G4String particleName = particle->GetParticleName();
+		if(particleName != "neutron" && particleName != "GenericIon" &&
+				particleName != "He3") {
+			pManager = particle->GetProcessManager();
+			if(particle->GetPDGMass() > 110.*MeV &&
+					fTheElasticProcess.IsApplicable(*particle) &&
+					!particle->IsShortLived()) {
+				pManager->AddDiscreteProcess(&fTheElasticProcess);
+				//        G4cout<<"### Elastic model are registered for "
+				//      <<particle->GetParticleName()
+				//      <<G4endl;
+			}
+		}
+	}
 
-    // Proton
-    pManager = G4Proton::Proton()->GetProcessManager();
-    // add inelastic process
-    // Binary Cascade
-    G4BinaryCascade * theBC = new G4BinaryCascade;
-    theBC->SetMaxEnergy(10.5*GeV);
-    fTheProtonInelastic.RegisterMe(theBC);
-    // Higher energy
-    fTheProtonInelastic.RegisterMe(theTheoModel);
-    // now the cross-sections.
-    G4ProtonInelasticCrossSection* theProtonData =
-            new G4ProtonInelasticCrossSection;
-    fTheProtonInelastic.AddDataSet(theProtonData);
-    pManager->AddDiscreteProcess(&fTheProtonInelastic);
+	// Proton
+	pManager = G4Proton::Proton()->GetProcessManager();
+	// add inelastic process
+	// Binary Cascade
+	G4BinaryCascade * theBC = new G4BinaryCascade;
+	theBC->SetMaxEnergy(10.5*GeV);
+	fTheProtonInelastic.RegisterMe(theBC);
+	// Higher energy
+	fTheProtonInelastic.RegisterMe(theTheoModel);
+	// now the cross-sections.
+	G4ProtonInelasticCrossSection* theProtonData =
+		new G4ProtonInelasticCrossSection;
+	fTheProtonInelastic.AddDataSet(theProtonData);
+	pManager->AddDiscreteProcess(&fTheProtonInelastic);
 
-    // Neutron
-    pManager = G4Neutron::Neutron()->GetProcessManager();
-    // add process
-    // elastic scattering
-    fTheNeutronElasticProcess = new G4HadronElasticProcess();
-    G4HadronElastic* theElasticModel1 = new G4HadronElastic;
-    G4NeutronHPElastic * theElasticNeutron = new G4NeutronHPElastic;
-    fTheNeutronElasticProcess->RegisterMe(theElasticModel1);
-    theElasticModel1->SetMinEnergy(19.*MeV);
-    fTheNeutronElasticProcess->RegisterMe(theElasticNeutron);
-    theElasticNeutron->SetMaxEnergy(20.*MeV);
+	// Neutron
+	pManager = G4Neutron::Neutron()->GetProcessManager();
+	// add process
+	// elastic scattering
+	fTheNeutronElasticProcess = new G4HadronElasticProcess();
+	G4HadronElastic* theElasticModel1 = new G4HadronElastic;
+	G4NeutronHPElastic * theElasticNeutron = new G4NeutronHPElastic;
+	fTheNeutronElasticProcess->RegisterMe(theElasticModel1);
+	theElasticModel1->SetMinEnergy(19.*MeV);
+	fTheNeutronElasticProcess->RegisterMe(theElasticNeutron);
+	theElasticNeutron->SetMaxEnergy(20.*MeV);
 
-    G4NeutronHPElasticData * theNeutronData = new G4NeutronHPElasticData;
-    fTheNeutronElasticProcess->AddDataSet(theNeutronData);
-    pManager->AddDiscreteProcess(fTheNeutronElasticProcess);
+	G4NeutronHPElasticData * theNeutronData = new G4NeutronHPElasticData;
+	fTheNeutronElasticProcess->AddDataSet(theNeutronData);
+	pManager->AddDiscreteProcess(fTheNeutronElasticProcess);
 
-    // inelastic
-    G4NeutronHPInelastic * theHPNeutronInelasticModel =
-            new G4NeutronHPInelastic;
-    theHPNeutronInelasticModel->SetMaxEnergy(20.*MeV);
-    fTheNeutronInelastic.RegisterMe(theHPNeutronInelasticModel);
-    G4NeutronHPInelasticData * theNeutronData1 = new G4NeutronHPInelasticData;
-    fTheNeutronInelastic.AddDataSet(theNeutronData1);
-    // binary
-    G4BinaryCascade * neutronBC = new G4BinaryCascade;
-    neutronBC->SetMinEnergy(19.*MeV);
-    neutronBC->SetMaxEnergy(10.5*GeV);
-    fTheNeutronInelastic.RegisterMe(neutronBC);
-    // higher energy
-    fTheNeutronInelastic.RegisterMe(theTheoModel);
-    // now the cross-sections.
-    G4NeutronInelasticCrossSection * theNeutronData2 =
-            new G4NeutronInelasticCrossSection;
-    fTheNeutronInelastic.AddDataSet(theNeutronData2);
-    pManager->AddDiscreteProcess(&fTheNeutronInelastic);
+	// inelastic
+	G4NeutronHPInelastic * theHPNeutronInelasticModel =
+		new G4NeutronHPInelastic;
+	theHPNeutronInelasticModel->SetMaxEnergy(20.*MeV);
+	fTheNeutronInelastic.RegisterMe(theHPNeutronInelasticModel);
+	G4NeutronHPInelasticData * theNeutronData1 = new G4NeutronHPInelasticData;
+	fTheNeutronInelastic.AddDataSet(theNeutronData1);
+	// binary
+	G4BinaryCascade * neutronBC = new G4BinaryCascade;
+	neutronBC->SetMinEnergy(19.*MeV);
+	neutronBC->SetMaxEnergy(10.5*GeV);
+	fTheNeutronInelastic.RegisterMe(neutronBC);
+	// higher energy
+	fTheNeutronInelastic.RegisterMe(theTheoModel);
+	// now the cross-sections.
+	G4NeutronInelasticCrossSection * theNeutronData2 =
+		new G4NeutronInelasticCrossSection;
+	fTheNeutronInelastic.AddDataSet(theNeutronData2);
+	pManager->AddDiscreteProcess(&fTheNeutronInelastic);
 
-    // fission
-    fTheFissionProcess = new G4HadronFissionProcess;
-    G4LFission* theFissionModel = new G4LFission;
-    fTheFissionProcess->RegisterMe(theFissionModel);
-    pManager->AddDiscreteProcess(fTheFissionProcess);
+	// fission
+	fTheFissionProcess = new G4HadronFissionProcess;
+	G4LFission* theFissionModel = new G4LFission;
+	fTheFissionProcess->RegisterMe(theFissionModel);
+	pManager->AddDiscreteProcess(fTheFissionProcess);
 
-    //capture
-    fTheCaptureProcess = new G4HadronCaptureProcess;
-    G4NeutronRadCapture* theCaptureModel = new G4NeutronRadCapture;
-    theCaptureModel->SetMinEnergy(19.*MeV);
-    fTheCaptureProcess->RegisterMe(theCaptureModel);
-    fTheCaptureProcess->AddDataSet(new G4NeutronCaptureXS);
+	//capture
+	fTheCaptureProcess = new G4HadronCaptureProcess;
+	G4NeutronRadCapture* theCaptureModel = new G4NeutronRadCapture;
+	theCaptureModel->SetMinEnergy(19.*MeV);
+	fTheCaptureProcess->RegisterMe(theCaptureModel);
+	fTheCaptureProcess->AddDataSet(new G4NeutronCaptureXS);
 
-    G4NeutronHPCapture * theHPNeutronCaptureModel = new G4NeutronHPCapture;
-    fTheCaptureProcess->RegisterMe(theHPNeutronCaptureModel);
-    G4NeutronHPCaptureData * theNeutronData3 = new G4NeutronHPCaptureData;
-    fTheCaptureProcess->AddDataSet(theNeutronData3);
-    pManager->AddDiscreteProcess(fTheCaptureProcess);
+	G4NeutronHPCapture * theHPNeutronCaptureModel = new G4NeutronHPCapture;
+	fTheCaptureProcess->RegisterMe(theHPNeutronCaptureModel);
+	G4NeutronHPCaptureData * theNeutronData3 = new G4NeutronHPCaptureData;
+	fTheCaptureProcess->AddDataSet(theNeutronData3);
+	pManager->AddDiscreteProcess(fTheCaptureProcess);
 
-    // now light ions
-    // light Ion BC
-    G4BinaryLightIonReaction* theIonBC= new G4BinaryLightIonReaction;
-    theIonBC->SetMinEnergy(1*MeV);
-    theIonBC->SetMaxEnergy(20*GeV);
-    G4TripathiCrossSection * TripathiCrossSection= new G4TripathiCrossSection;
-    G4IonsShenCrossSection * aShen = new G4IonsShenCrossSection;
+	// now light ions
+	// light Ion BC
+	G4BinaryLightIonReaction* theIonBC= new G4BinaryLightIonReaction;
+	theIonBC->SetMinEnergy(1*MeV);
+	theIonBC->SetMaxEnergy(20*GeV);
+	G4TripathiCrossSection * TripathiCrossSection= new G4TripathiCrossSection;
+	G4IonsShenCrossSection * aShen = new G4IonsShenCrossSection;
 
-    // deuteron
-    pManager = G4Deuteron::Deuteron()->GetProcessManager();
-    fTheDeuteronInelasticProcess = new G4DeuteronInelasticProcess("inelastic");
-    fTheDeuteronInelasticProcess->AddDataSet(TripathiCrossSection);
-    fTheDeuteronInelasticProcess->AddDataSet(aShen);
-    fTheDeuteronInelasticProcess->RegisterMe(theIonBC);
-    fTheDeuteronInelasticProcess->RegisterMe(theTheoModel);
-    pManager->AddDiscreteProcess(fTheDeuteronInelasticProcess);
+	// deuteron
+	pManager = G4Deuteron::Deuteron()->GetProcessManager();
+	fTheDeuteronInelasticProcess = new G4DeuteronInelasticProcess("inelastic");
+	fTheDeuteronInelasticProcess->AddDataSet(TripathiCrossSection);
+	fTheDeuteronInelasticProcess->AddDataSet(aShen);
+	fTheDeuteronInelasticProcess->RegisterMe(theIonBC);
+	fTheDeuteronInelasticProcess->RegisterMe(theTheoModel);
+	pManager->AddDiscreteProcess(fTheDeuteronInelasticProcess);
 
-    // triton
-    pManager = G4Triton::Triton()->GetProcessManager();
-    fTheTritonInelasticProcess = new G4TritonInelasticProcess("inelastic");
-    fTheTritonInelasticProcess->AddDataSet(TripathiCrossSection);
-    fTheTritonInelasticProcess->AddDataSet(aShen);
-    fTheTritonInelasticProcess->RegisterMe(theIonBC);
-    fTheTritonInelasticProcess->RegisterMe(theTheoModel);
-    pManager->AddDiscreteProcess(fTheTritonInelasticProcess);
+	// triton
+	pManager = G4Triton::Triton()->GetProcessManager();
+	fTheTritonInelasticProcess = new G4TritonInelasticProcess("inelastic");
+	fTheTritonInelasticProcess->AddDataSet(TripathiCrossSection);
+	fTheTritonInelasticProcess->AddDataSet(aShen);
+	fTheTritonInelasticProcess->RegisterMe(theIonBC);
+	fTheTritonInelasticProcess->RegisterMe(theTheoModel);
+	pManager->AddDiscreteProcess(fTheTritonInelasticProcess);
 
-    // alpha
-    pManager = G4Alpha::Alpha()->GetProcessManager();
-    fTheAlphaInelasticProcess = new G4AlphaInelasticProcess("inelastic");
-    fTheAlphaInelasticProcess->AddDataSet(TripathiCrossSection);
-    fTheAlphaInelasticProcess->AddDataSet(aShen);
-    fTheAlphaInelasticProcess->RegisterMe(theIonBC);
-    fTheAlphaInelasticProcess->RegisterMe(theTheoModel);
-    pManager->AddDiscreteProcess(fTheAlphaInelasticProcess);
+	// alpha
+	pManager = G4Alpha::Alpha()->GetProcessManager();
+	fTheAlphaInelasticProcess = new G4AlphaInelasticProcess("inelastic");
+	fTheAlphaInelasticProcess->AddDataSet(TripathiCrossSection);
+	fTheAlphaInelasticProcess->AddDataSet(aShen);
+	fTheAlphaInelasticProcess->RegisterMe(theIonBC);
+	fTheAlphaInelasticProcess->RegisterMe(theTheoModel);
+	pManager->AddDiscreteProcess(fTheAlphaInelasticProcess);
 
-    // Generic ion elastic
-    G4NuclNuclDiffuseElastic* ionElasticModel = new G4NuclNuclDiffuseElastic;
-    
-    // ----------------------
-    //G4ComponentGGNuclNuclXsc * ionElasticXS = new G4ComponentGGNuclNuclXsc;
-    G4VCrossSectionDataSet* ionElasticXS = new G4VCrossSectionDataSet;
-    //G4GGNuclNuclCrossSection* ionElasticXS = new G4GGNuclNuclCrossSection;
-    //--------------------------
+	// Generic ion elastic
+	G4NuclNuclDiffuseElastic* ionElasticModel = new G4NuclNuclDiffuseElastic;
 
-    fIonElasticProcess.RegisterMe(ionElasticModel);
-    fIonElasticProcess.AddDataSet(ionElasticXS);
-    pManager = G4GenericIon::GenericIon()->GetProcessManager();
-    pManager->AddDiscreteProcess(&fIonElasticProcess);
+	// ----------------------
+	//G4ComponentGGNuclNuclXsc * ionElasticXS = new G4ComponentGGNuclNuclXsc;
+	G4VCrossSectionDataSet* ionElasticXS = new G4VCrossSectionDataSet;
+	//G4GGNuclNuclCrossSection* ionElasticXS = new G4GGNuclNuclCrossSection;
+	//--------------------------
 
-    // Generic ion inelastic
-    fTheIonInelasticProcess = new G4IonInelasticProcess();
-    fTheIonInelasticProcess->AddDataSet(TripathiCrossSection);
-    fTheIonInelasticProcess->AddDataSet(aShen);
-    fTheIonInelasticProcess->RegisterMe(theIonBC);
-    fTheIonInelasticProcess->RegisterMe(theTheoModel);
-    pManager->AddDiscreteProcess(fTheIonInelasticProcess);
+	fIonElasticProcess.RegisterMe(ionElasticModel);
+	fIonElasticProcess.AddDataSet(ionElasticXS);
+	pManager = G4GenericIon::GenericIon()->GetProcessManager();
+	pManager->AddDiscreteProcess(&fIonElasticProcess);
+
+	// Generic ion inelastic
+	fTheIonInelasticProcess = new G4IonInelasticProcess();
+	fTheIonInelasticProcess->AddDataSet(TripathiCrossSection);
+	fTheIonInelasticProcess->AddDataSet(aShen);
+	fTheIonInelasticProcess->RegisterMe(theIonBC);
+	fTheIonInelasticProcess->RegisterMe(theTheoModel);
+	pManager->AddDiscreteProcess(fTheIonInelasticProcess);
 }

--- a/src/PhysListParticles.cc
+++ b/src/PhysListParticles.cc
@@ -61,7 +61,7 @@
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
 PhysListParticles::PhysListParticles(const G4String& name)
-    :  G4VPhysicsConstructor(name)
+:  G4VPhysicsConstructor(name)
 {}
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
@@ -74,42 +74,42 @@ PhysListParticles::~PhysListParticles()
 void PhysListParticles::ConstructParticle()
 {
 
-    // pseudo-particles
-    G4Geantino::GeantinoDefinition();
-    G4ChargedGeantino::ChargedGeantinoDefinition();
+	// pseudo-particles
+	G4Geantino::GeantinoDefinition();
+	G4ChargedGeantino::ChargedGeantinoDefinition();
 
-    // gamma
-    G4Gamma::GammaDefinition();
+	// gamma
+	G4Gamma::GammaDefinition();
 
-    // optical photon
-    G4OpticalPhoton::OpticalPhotonDefinition();
+	// optical photon
+	G4OpticalPhoton::OpticalPhotonDefinition();
 
-    // leptons
-    G4Electron::ElectronDefinition();
-    G4Positron::PositronDefinition();
-    G4MuonPlus::MuonPlusDefinition();
-    G4MuonMinus::MuonMinusDefinition();
+	// leptons
+	G4Electron::ElectronDefinition();
+	G4Positron::PositronDefinition();
+	G4MuonPlus::MuonPlusDefinition();
+	G4MuonMinus::MuonMinusDefinition();
 
-    G4NeutrinoE::NeutrinoEDefinition();
-    G4AntiNeutrinoE::AntiNeutrinoEDefinition();
-    G4NeutrinoMu::NeutrinoMuDefinition();
-    G4AntiNeutrinoMu::AntiNeutrinoMuDefinition();
+	G4NeutrinoE::NeutrinoEDefinition();
+	G4AntiNeutrinoE::AntiNeutrinoEDefinition();
+	G4NeutrinoMu::NeutrinoMuDefinition();
+	G4AntiNeutrinoMu::AntiNeutrinoMuDefinition();
 
-    // mesons
-    G4MesonConstructor mConstructor;
-    mConstructor.ConstructParticle();
+	// mesons
+	G4MesonConstructor mConstructor;
+	mConstructor.ConstructParticle();
 
-    // barions
-    G4BaryonConstructor bConstructor;
-    bConstructor.ConstructParticle();
+	// barions
+	G4BaryonConstructor bConstructor;
+	bConstructor.ConstructParticle();
 
-    // ions
-    G4IonConstructor iConstructor;
-    iConstructor.ConstructParticle();
+	// ions
+	G4IonConstructor iConstructor;
+	iConstructor.ConstructParticle();
 
-    //  Construct  resonaces and quarks
-    G4ShortLivedConstructor pShortLivedConstructor;
-    pShortLivedConstructor.ConstructParticle();
+	//  Construct  resonaces and quarks
+	G4ShortLivedConstructor pShortLivedConstructor;
+	pShortLivedConstructor.ConstructParticle();
 
 }
 

--- a/src/PhysicsList.cc
+++ b/src/PhysicsList.cc
@@ -79,37 +79,37 @@
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
 PhysicsList::PhysicsList() :
-    G4VModularPhysicsList(),
-    fCutForGamma(1.*mm), fCutForElectron(0.01*mm),//e- cut to follow old code
-    fCutForPositron(1.*mm),//just sets defaults, can be altered through commands in a macro
-    fEmPhysicsList(0),
-    fRaddecayList(0),
-    fParticleList(0),
-    fHadPhysicsList(0),
-    fNhadcomp(0),
-    fPMessenger(0),fDetectorCuts(0), fTargetCuts(0),
-    fScintProcess(0)
+	G4VModularPhysicsList(),
+	fCutForGamma(1.*mm), fCutForElectron(0.01*mm),//e- cut to follow old code
+	fCutForPositron(1.*mm),//just sets defaults, can be altered through commands in a macro
+	fEmPhysicsList(0),
+	fRaddecayList(0),
+	fParticleList(0),
+	fHadPhysicsList(0),
+	fNhadcomp(0),
+	fPMessenger(0),fDetectorCuts(0), fTargetCuts(0),
+	fScintProcess(0)
 {
-    G4LossTableManager::Instance();
-    defaultCutValue =0.1*mm;
+	G4LossTableManager::Instance();
+	defaultCutValue =0.1*mm;
 
-    fPMessenger = new PhysicsListMessenger(this);
+	fPMessenger = new PhysicsListMessenger(this);
 
-    SetVerboseLevel(1);
+	SetVerboseLevel(1);
 
-    //default physics
-    fParticleList = new G4DecayPhysics();
+	//default physics
+	fParticleList = new G4DecayPhysics();
 
-    //default radioactive physics
-    fRaddecayList = new G4RadioactiveDecayPhysics();
+	//default radioactive physics
+	fRaddecayList = new G4RadioactiveDecayPhysics();
 
-    // EM physics
-    fEmPhysicsList = new G4EmStandardPhysics();
+	// EM physics
+	fEmPhysicsList = new G4EmStandardPhysics();
 
-    // Scintillation phyics
-    fScintProcess = new G4Scintillation();
-    fScintProcess->SetScintillationYieldFactor(1.);
-    fScintProcess->SetTrackSecondariesFirst(true);
+	// Scintillation phyics
+	fScintProcess = new G4Scintillation();
+	fScintProcess->SetScintillationYieldFactor(1.);
+	fScintProcess->SetTrackSecondariesFirst(true);
 
 }
 
@@ -117,42 +117,42 @@ PhysicsList::PhysicsList() :
 
 PhysicsList::~PhysicsList()
 {
-    delete fPMessenger;
-    delete fRaddecayList;
-    delete fEmPhysicsList;
-    if (fHadPhysicsList) delete fHadPhysicsList;
-    if (fNhadcomp > 0) {
-        for(G4int i=0; i<fNhadcomp; i++) {
-            delete fHadronPhys[i];
-        }
-    }
+	delete fPMessenger;
+	delete fRaddecayList;
+	delete fEmPhysicsList;
+	if(fHadPhysicsList) delete fHadPhysicsList;
+	if(fNhadcomp > 0) {
+		for(G4int i=0; i<fNhadcomp; i++) {
+			delete fHadronPhys[i];
+		}
+	}
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
 void PhysicsList::ConstructParticle()
 {
-    fParticleList->ConstructParticle();
+	fParticleList->ConstructParticle();
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
 void PhysicsList::ConstructProcess()
 {
-    AddTransportation();
-    // em
-    fEmPhysicsList->ConstructProcess();
-    // decays
-    fParticleList->ConstructProcess();
-    fRaddecayList->ConstructProcess();
-    // had
-    if (fNhadcomp > 0) {
-        for(G4int i=0; i<fNhadcomp; i++) {
-            (fHadronPhys[i])->ConstructProcess();
-        }
-    }
-    if (fHadPhysicsList) fHadPhysicsList->ConstructProcess();
-    G4cout << "### PhysicsList::ConstructProcess is done" << G4endl;
+	AddTransportation();
+	// em
+	fEmPhysicsList->ConstructProcess();
+	// decays
+	fParticleList->ConstructProcess();
+	fRaddecayList->ConstructProcess();
+	// had
+	if(fNhadcomp > 0) {
+		for(G4int i=0; i<fNhadcomp; i++) {
+			(fHadronPhys[i])->ConstructProcess();
+		}
+	}
+	if(fHadPhysicsList) fHadPhysicsList->ConstructProcess();
+	G4cout<<"### PhysicsList::ConstructProcess is done"<<G4endl;
 
 }
 
@@ -160,43 +160,43 @@ void PhysicsList::ConstructProcess()
 
 void PhysicsList::SelectPhysicsList(const G4String& name)
 {
-    if (verboseLevel>1) {
-        G4cout << "PhysicsList::SelectPhysicsList: <" << name << ">" << G4endl;
-    }
-    // default  Had physics
-    if (name == "Hadron" && !fHadPhysicsList) {
-        fHadPhysicsList = new PhysListHadron("hadron");
-    } else if (name == "QGSP_BERT") {
-        AddExtraBuilders(false);
-        fHadPhysicsList = new G4HadronPhysicsQGSP_BERT(verboseLevel);
-    } else if (name == "QGSP_BIC" && !fHadPhysicsList) {
-        AddExtraBuilders(false);
-        fHadPhysicsList = new G4HadronPhysicsQGSP_BIC(verboseLevel);
-    } else if (name == "QGSP_BERT_HP"  && !fHadPhysicsList) {
-        AddExtraBuilders(true);
-        fHadPhysicsList = new G4HadronPhysicsQGSP_BERT_HP(verboseLevel);
-    } else if (name == "QGSP_BIC_HP"  && !fHadPhysicsList) {
-        AddExtraBuilders(true);
-        fHadPhysicsList = new G4HadronPhysicsQGSP_BIC_HP(verboseLevel);
-    } else if (name == "emlivermore") {
-        delete fEmPhysicsList;
-        fEmPhysicsList = new G4EmLivermorePhysics(verboseLevel);
-    } else if (name == "emlivermorepolarized") {
-        delete fEmPhysicsList;
-        fEmPhysicsList = new G4EmLivermorePolarizedPhysics(verboseLevel);
-    } else if (name == "empenelope") {
-        delete fEmPhysicsList;
-        fEmPhysicsList = new G4EmPenelopePhysics(verboseLevel);
-    } else if (name == "emstandard") {
-        delete fEmPhysicsList;
-        fEmPhysicsList = new G4EmStandardPhysics(verboseLevel);
-    } else if (name == "emstandard_opt4") {
-        delete fEmPhysicsList;
-        fEmPhysicsList = new G4EmStandardPhysics_option4(verboseLevel);
-    } else {
-        G4cout << "PhysicsList WARNING wrong or unknown <"
-               << name << "> Physics " << G4endl;
-    }
+	if(verboseLevel>1) {
+		G4cout<<"PhysicsList::SelectPhysicsList: <"<<name<<">"<<G4endl;
+	}
+	// default  Had physics
+	if(name == "Hadron" && !fHadPhysicsList) {
+		fHadPhysicsList = new PhysListHadron("hadron");
+	} else if(name == "QGSP_BERT") {
+		AddExtraBuilders(false);
+		fHadPhysicsList = new G4HadronPhysicsQGSP_BERT(verboseLevel);
+	} else if(name == "QGSP_BIC" && !fHadPhysicsList) {
+		AddExtraBuilders(false);
+		fHadPhysicsList = new G4HadronPhysicsQGSP_BIC(verboseLevel);
+	} else if(name == "QGSP_BERT_HP"  && !fHadPhysicsList) {
+		AddExtraBuilders(true);
+		fHadPhysicsList = new G4HadronPhysicsQGSP_BERT_HP(verboseLevel);
+	} else if(name == "QGSP_BIC_HP"  && !fHadPhysicsList) {
+		AddExtraBuilders(true);
+		fHadPhysicsList = new G4HadronPhysicsQGSP_BIC_HP(verboseLevel);
+	} else if(name == "emlivermore") {
+		delete fEmPhysicsList;
+		fEmPhysicsList = new G4EmLivermorePhysics(verboseLevel);
+	} else if(name == "emlivermorepolarized") {
+		delete fEmPhysicsList;
+		fEmPhysicsList = new G4EmLivermorePolarizedPhysics(verboseLevel);
+	} else if(name == "empenelope") {
+		delete fEmPhysicsList;
+		fEmPhysicsList = new G4EmPenelopePhysics(verboseLevel);
+	} else if(name == "emstandard") {
+		delete fEmPhysicsList;
+		fEmPhysicsList = new G4EmStandardPhysics(verboseLevel);
+	} else if(name == "emstandard_opt4") {
+		delete fEmPhysicsList;
+		fEmPhysicsList = new G4EmStandardPhysics_option4(verboseLevel);
+	} else {
+		G4cout<<"PhysicsList WARNING wrong or unknown <"
+			<< name<<"> Physics "<<G4endl;
+	}
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
@@ -204,139 +204,139 @@ void PhysicsList::SelectPhysicsList(const G4String& name)
 
 void PhysicsList::ConstructOp(G4bool constructOp)
 {
-  if( constructOp == false ) { G4cout << "NOT Building Optical Phyiscs" << G4endl; return; }
-  else if( constructOp == true ) 
-    {
-        G4cout << "Building Optical Phyiscs... " << G4endl;
-        // G4Cerenkov* cerenkovProcess = new G4Cerenkov("Cerenkov");
+	if(constructOp == false) { G4cout<<"NOT Building Optical Phyiscs"<<G4endl; return; }
+	else if(constructOp == true) 
+	{
+		G4cout<<"Building Optical Phyiscs... "<<G4endl;
+		// G4Cerenkov* cerenkovProcess = new G4Cerenkov("Cerenkov");
 
-        //   turning on particle-specific scintillation process
-        G4Scintillation* scintillationProcess = new G4Scintillation("Scintillation");
-        scintillationProcess->SetScintillationByParticleType(true);
+		//   turning on particle-specific scintillation process
+		G4Scintillation* scintillationProcess = new G4Scintillation("Scintillation");
+		scintillationProcess->SetScintillationByParticleType(true);
 
-        G4OpAbsorption* absorptionProcess = new G4OpAbsorption();
-        G4OpRayleigh* rayleighScatteringProcess = new G4OpRayleigh();
-        //G4OpMieHG* mieHGScatteringProcess = new G4OpMieHG();
-        //G4OpBoundaryProcess* boundaryProcess = new G4OpBoundaryProcess();
+		G4OpAbsorption* absorptionProcess = new G4OpAbsorption();
+		G4OpRayleigh* rayleighScatteringProcess = new G4OpRayleigh();
+		//G4OpMieHG* mieHGScatteringProcess = new G4OpMieHG();
+		//G4OpBoundaryProcess* boundaryProcess = new G4OpBoundaryProcess();
 
-        // Use Birks Correction in the Scintillation process
-        if(!G4Threading::IsWorkerThread())
-        {
-            G4EmSaturation* emSaturation =
-            G4LossTableManager::Instance()->EmSaturation();
-            fScintProcess->AddSaturation(emSaturation);
-        }
+		// Use Birks Correction in the Scintillation process
+		if(!G4Threading::IsWorkerThread())
+		{
+			G4EmSaturation* emSaturation =
+				G4LossTableManager::Instance()->EmSaturation();
+			fScintProcess->AddSaturation(emSaturation);
+		}
 
-		  auto aParticleIterator = GetParticleIterator();
-        aParticleIterator->reset();
-        while( (*aParticleIterator)() )
-        {
-            G4ParticleDefinition* particle = aParticleIterator->value();
-            G4ProcessManager* pmanager = particle->GetProcessManager();
-            G4String particleName = particle->GetParticleName();
+		auto aParticleIterator = GetParticleIterator();
+		aParticleIterator->reset();
+		while((*aParticleIterator)())
+		{
+			G4ParticleDefinition* particle = aParticleIterator->value();
+			G4ProcessManager* pmanager = particle->GetProcessManager();
+			G4String particleName = particle->GetParticleName();
 
-            if (scintillationProcess->IsApplicable(*particle)) {
-                pmanager->AddProcess(scintillationProcess);
-                pmanager->SetProcessOrderingToLast(scintillationProcess, idxAtRest);
-                pmanager->SetProcessOrderingToLast(scintillationProcess, idxPostStep);
-            }
-    
-            if (particleName == "opticalphoton") {
-            G4cout << "AddDiscreteProcess to OpticalPhoton " << G4endl;
-            pmanager->AddDiscreteProcess(absorptionProcess);
-            pmanager->AddDiscreteProcess(rayleighScatteringProcess);
-            // pmanager->AddDiscreteProcess(mieHGScatteringProcess);
-            //  pmanager->AddDiscreteProcess(boundaryProcess);
-            }
-        }
-        G4cout << "Done Building Optical Physics" << G4endl;
-     }
+			if(scintillationProcess->IsApplicable(*particle)) {
+				pmanager->AddProcess(scintillationProcess);
+				pmanager->SetProcessOrderingToLast(scintillationProcess, idxAtRest);
+				pmanager->SetProcessOrderingToLast(scintillationProcess, idxPostStep);
+			}
+
+			if(particleName == "opticalphoton") {
+				G4cout<<"AddDiscreteProcess to OpticalPhoton "<<G4endl;
+				pmanager->AddDiscreteProcess(absorptionProcess);
+				pmanager->AddDiscreteProcess(rayleighScatteringProcess);
+				// pmanager->AddDiscreteProcess(mieHGScatteringProcess);
+				//  pmanager->AddDiscreteProcess(boundaryProcess);
+			}
+		}
+		G4cout<<"Done Building Optical Physics"<<G4endl;
+	}
 }
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
 void PhysicsList::SpiceStepper(G4bool step)
 {
-  if( step == false ) { G4cout << "No SPICE step" << G4endl; return; }
-  else if( step == true ) 
-    {
-        G4ProcessManager* pmanager = G4Electron::Electron()->GetProcessManager();
-	pmanager->AddDiscreteProcess(new G4StepLimiter);
-	//Electrons will now use user defined maxstep set by LogicVolume->SetUserLimits(new G4UserLimits(1.*mm));
+	if(step == false) { G4cout<<"No SPICE step"<<G4endl; return; }
+	else if(step == true) 
+	{
+		G4ProcessManager* pmanager = G4Electron::Electron()->GetProcessManager();
+		pmanager->AddDiscreteProcess(new G4StepLimiter);
+		//Electrons will now use user defined maxstep set by LogicVolume->SetUserLimits(new G4UserLimits(1.*mm));
 
-        G4cout << "SPICE stepper" << G4endl;
-     }
+		G4cout<<"SPICE stepper"<<G4endl;
+	}
 }
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
 void PhysicsList::AddExtraBuilders(G4bool flagHP)
 {
-    fNhadcomp = 5;
-    fHadronPhys.push_back( new G4EmExtraPhysics(verboseLevel));
-    if(flagHP) {
-        fHadronPhys.push_back( new G4HadronElasticPhysicsHP(verboseLevel));
-    } else {
-        fHadronPhys.push_back( new G4HadronElasticPhysics(verboseLevel));
-    }
-    fHadronPhys.push_back( new G4StoppingPhysics(verboseLevel));
-    fHadronPhys.push_back( new G4IonBinaryCascadePhysics(verboseLevel));
-    fHadronPhys.push_back( new G4NeutronTrackingCut(verboseLevel));
+	fNhadcomp = 5;
+	fHadronPhys.push_back(new G4EmExtraPhysics(verboseLevel));
+	if(flagHP) {
+		fHadronPhys.push_back(new G4HadronElasticPhysicsHP(verboseLevel));
+	} else {
+		fHadronPhys.push_back(new G4HadronElasticPhysics(verboseLevel));
+	}
+	fHadronPhys.push_back(new G4StoppingPhysics(verboseLevel));
+	fHadronPhys.push_back(new G4IonBinaryCascadePhysics(verboseLevel));
+	fHadronPhys.push_back(new G4NeutronTrackingCut(verboseLevel));
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
 void PhysicsList::SetCuts()
 {
-    SetCutValue(fCutForGamma, "gamma");
-    SetCutValue(fCutForElectron, "e-");
-    SetCutValue(fCutForPositron, "e+");
-    G4cout << "world cuts are set" << G4endl;
+	SetCutValue(fCutForGamma, "gamma");
+	SetCutValue(fCutForElectron, "e-");
+	SetCutValue(fCutForPositron, "e+");
+	G4cout<<"world cuts are set"<<G4endl;
 
-    //  if( !fTargetCuts ) SetTargetCut(fCutForElectron);
-    //  G4Region* region = (G4RegionStore::GetInstance())->GetRegion("Target");
-    //  region->SetProductionCuts(fTargetCuts);
-    //  G4cout << "Target cuts are set" << G4endl;
+	//  if(!fTargetCuts) SetTargetCut(fCutForElectron);
+	//  G4Region* region = (G4RegionStore::GetInstance())->GetRegion("Target");
+	//  region->SetProductionCuts(fTargetCuts);
+	//  G4cout<<"Target cuts are set"<<G4endl;
 
-    //  if( !fDetectorCuts ) SetDetectorCut(fCutForElectron);
-    //  region = (G4RegionStore::GetInstance())->GetRegion("Detector");
-    //  region->SetProductionCuts(fDetectorCuts);
-    //  G4cout << "Detector cuts are set" << G4endl;
+	//  if(!fDetectorCuts) SetDetectorCut(fCutForElectron);
+	//  region = (G4RegionStore::GetInstance())->GetRegion("Detector");
+	//  region->SetProductionCuts(fDetectorCuts);
+	//  G4cout<<"Detector cuts are set"<<G4endl;
 
-    if (verboseLevel>0) DumpCutValuesTable();
+	if(verboseLevel>0) DumpCutValuesTable();
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
 void PhysicsList::SetCutForGamma(G4double cut)
 {
-    fCutForGamma = cut;
-    SetParticleCuts(fCutForGamma, G4Gamma::Gamma());
+	fCutForGamma = cut;
+	SetParticleCuts(fCutForGamma, G4Gamma::Gamma());
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
 void PhysicsList::SetCutForElectron(G4double cut)
 {
-    fCutForElectron = cut;
-    SetParticleCuts(fCutForElectron, G4Electron::Electron());
+	fCutForElectron = cut;
+	SetParticleCuts(fCutForElectron, G4Electron::Electron());
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
 void PhysicsList::SetCutForPositron(G4double cut)
 {
-    fCutForPositron = cut;
-    SetParticleCuts(fCutForPositron, G4Positron::Positron());
+	fCutForPositron = cut;
+	SetParticleCuts(fCutForPositron, G4Positron::Positron());
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
 void PhysicsList::SetTargetCut(G4double cut)
 {
-    if( !fTargetCuts ) fTargetCuts = new G4ProductionCuts();
+	if(!fTargetCuts) fTargetCuts = new G4ProductionCuts();
 
-    fTargetCuts->SetProductionCut(cut, idxG4GammaCut);
-    fTargetCuts->SetProductionCut(cut, idxG4ElectronCut);
-    fTargetCuts->SetProductionCut(cut, idxG4PositronCut);
+	fTargetCuts->SetProductionCut(cut, idxG4GammaCut);
+	fTargetCuts->SetProductionCut(cut, idxG4ElectronCut);
+	fTargetCuts->SetProductionCut(cut, idxG4PositronCut);
 
 }
 
@@ -344,11 +344,11 @@ void PhysicsList::SetTargetCut(G4double cut)
 
 void PhysicsList::SetDetectorCut(G4double cut)
 {
-    if( !fDetectorCuts ) fDetectorCuts = new G4ProductionCuts();
+	if(!fDetectorCuts) fDetectorCuts = new G4ProductionCuts();
 
-    fDetectorCuts->SetProductionCut(cut, idxG4GammaCut);
-    fDetectorCuts->SetProductionCut(cut, idxG4ElectronCut);
-    fDetectorCuts->SetProductionCut(cut, idxG4PositronCut);
+	fDetectorCuts->SetProductionCut(cut, idxG4GammaCut);
+	fDetectorCuts->SetProductionCut(cut, idxG4ElectronCut);
+	fDetectorCuts->SetProductionCut(cut, idxG4PositronCut);
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......

--- a/src/PhysicsListMessenger.cc
+++ b/src/PhysicsListMessenger.cc
@@ -42,132 +42,148 @@
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
 PhysicsListMessenger::PhysicsListMessenger(PhysicsList* pPhys)
-    :G4UImessenger(),
-      fPPhysicsList(pPhys),
-      fPhysDir(0),
-      fGammaCutCmd(0),
-      fElectCutCmd(0),
-      fProtoCutCmd(0),
-      fAllCutCmd(0),
-      fMCutCmd(0),
-      fECutCmd(0),
-      fPListCmd(0),
-      fConstructOpCmd(0),
-      fSpiceStepperCmd(0)
+:G4UImessenger(),
+	fPPhysicsList(pPhys),
+	fPhysDir(0),
+	fGammaCutCmd(0),
+	fElectCutCmd(0),
+	fProtoCutCmd(0),
+	fAllCutCmd(0),
+	fMCutCmd(0),
+	fECutCmd(0),
+	fPListCmd(0),
+	fConstructOpCmd(0),
+	fSpiceStepperCmd(0)
 {
-    fPhysDir = new G4UIdirectory("/DetSys/phys/");
-    fPhysDir->SetGuidance("physics control.");
+	fPhysDir = new G4UIdirectory("/DetSys/phys/");
+	fPhysDir->SetGuidance("physics control.");
 
-    fGammaCutCmd = new G4UIcmdWithADoubleAndUnit("/DetSys/phys/setGCut",this);
-    fGammaCutCmd->SetGuidance("Set gamma cut.");
-    fGammaCutCmd->SetParameterName("Gcut",false);
-    fGammaCutCmd->SetUnitCategory("Length");
-    fGammaCutCmd->SetRange("Gcut>0.0");
-    fGammaCutCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
+	fGammaCutCmd = new G4UIcmdWithADoubleAndUnit("/DetSys/phys/setGCut",this);
+	fGammaCutCmd->SetGuidance("Set gamma cut.");
+	fGammaCutCmd->SetParameterName("Gcut",false);
+	fGammaCutCmd->SetUnitCategory("Length");
+	fGammaCutCmd->SetRange("Gcut>0.0");
+	fGammaCutCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
 
-    fElectCutCmd = new G4UIcmdWithADoubleAndUnit("/DetSys/phys/setECut",this);
-    fElectCutCmd->SetGuidance("Set electron cut.");
-    fElectCutCmd->SetParameterName("Ecut",false);
-    fElectCutCmd->SetUnitCategory("Length");
-    fElectCutCmd->SetRange("Ecut>0.0");
-    fElectCutCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
+	fElectCutCmd = new G4UIcmdWithADoubleAndUnit("/DetSys/phys/setECut",this);
+	fElectCutCmd->SetGuidance("Set electron cut.");
+	fElectCutCmd->SetParameterName("Ecut",false);
+	fElectCutCmd->SetUnitCategory("Length");
+	fElectCutCmd->SetRange("Ecut>0.0");
+	fElectCutCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
 
-    fProtoCutCmd = new G4UIcmdWithADoubleAndUnit("/DetSys/phys/setPCut",this);
-    fProtoCutCmd->SetGuidance("Set positron cut.");
-    fProtoCutCmd->SetParameterName("Pcut",false);
-    fProtoCutCmd->SetUnitCategory("Length");
-    fProtoCutCmd->SetRange("Pcut>0.0");
-    fProtoCutCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
+	fProtoCutCmd = new G4UIcmdWithADoubleAndUnit("/DetSys/phys/setPCut",this);
+	fProtoCutCmd->SetGuidance("Set positron cut.");
+	fProtoCutCmd->SetParameterName("Pcut",false);
+	fProtoCutCmd->SetUnitCategory("Length");
+	fProtoCutCmd->SetRange("Pcut>0.0");
+	fProtoCutCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
 
-    fAllCutCmd = new G4UIcmdWithADoubleAndUnit("/DetSys/phys/setCuts",this);
-    fAllCutCmd->SetGuidance("Set cut for all.");
-    fAllCutCmd->SetParameterName("cut",false);
-    fAllCutCmd->SetUnitCategory("Length");
-    fAllCutCmd->SetRange("cut>0.0");
-    fAllCutCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
+	fAllCutCmd = new G4UIcmdWithADoubleAndUnit("/DetSys/phys/setCuts",this);
+	fAllCutCmd->SetGuidance("Set cut for all.");
+	fAllCutCmd->SetParameterName("cut",false);
+	fAllCutCmd->SetUnitCategory("Length");
+	fAllCutCmd->SetRange("cut>0.0");
+	fAllCutCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
 
-    fECutCmd = new G4UIcmdWithADoubleAndUnit("/DetSys/phys/TargetCuts",this);
-    fECutCmd->SetGuidance("Set cuts for the target");
-    fECutCmd->SetParameterName("Ecut",false);
-    fECutCmd->SetUnitCategory("Length");
-    fECutCmd->SetRange("Ecut>0.0");
-    fECutCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
+	fECutCmd = new G4UIcmdWithADoubleAndUnit("/DetSys/phys/TargetCuts",this);
+	fECutCmd->SetGuidance("Set cuts for the target");
+	fECutCmd->SetParameterName("Ecut",false);
+	fECutCmd->SetUnitCategory("Length");
+	fECutCmd->SetRange("Ecut>0.0");
+	fECutCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
 
-    fMCutCmd = new G4UIcmdWithADoubleAndUnit("/DetSys/phys/DetectorCuts",this);
-    fMCutCmd->SetGuidance("Set cuts for the Detector");
-    fMCutCmd->SetParameterName("Ecut",false);
-    fMCutCmd->SetUnitCategory("Length");
-    fMCutCmd->SetRange("Ecut>0.0");
-    fMCutCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
+	fMCutCmd = new G4UIcmdWithADoubleAndUnit("/DetSys/phys/DetectorCuts",this);
+	fMCutCmd->SetGuidance("Set cuts for the Detector");
+	fMCutCmd->SetParameterName("Ecut",false);
+	fMCutCmd->SetUnitCategory("Length");
+	fMCutCmd->SetRange("Ecut>0.0");
+	fMCutCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
 
-    fPListCmd = new G4UIcmdWithAString("/DetSys/phys/SelectPhysics",this);
-    fPListCmd->SetGuidance("Select modula physics list.");
-    fPListCmd->SetParameterName("PList",false);
-    fPListCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
+	fPListCmd = new G4UIcmdWithAString("/DetSys/phys/SelectPhysics",this);
+	fPListCmd->SetGuidance("Select modula physics list.");
+	fPListCmd->SetParameterName("PList",false);
+	fPListCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
 
-    fConstructOpCmd = new G4UIcmdWithABool("/DetSys/phys/ConstructOpticalPhysics",this);
-    fConstructOpCmd->SetGuidance("Choose to build optical physics models");
-    fConstructOpCmd->SetDefaultValue(false);
-    fConstructOpCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
-    
-    fSpiceStepperCmd = new G4UIcmdWithABool("/DetSys/phys/SpiceStepper",this);
-    fSpiceStepperCmd->SetGuidance("Choose to invoke SPICE stepper");
-    fSpiceStepperCmd->SetDefaultValue(false);
-    fSpiceStepperCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
+	fConstructOpCmd = new G4UIcmdWithABool("/DetSys/phys/ConstructOpticalPhysics",this);
+	fConstructOpCmd->SetGuidance("Choose to build optical physics models");
+	fConstructOpCmd->SetDefaultValue(false);
+	fConstructOpCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
+
+	fSpiceStepperCmd = new G4UIcmdWithABool("/DetSys/phys/SpiceStepper",this);
+	fSpiceStepperCmd->SetGuidance("Choose to invoke SPICE stepper");
+	fSpiceStepperCmd->SetDefaultValue(false);
+	fSpiceStepperCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
 PhysicsListMessenger::~PhysicsListMessenger()
 {
-    delete fPhysDir;
-    delete fGammaCutCmd;
-    delete fElectCutCmd;
-    delete fProtoCutCmd;
-    delete fAllCutCmd;
-    delete fPListCmd;
-    delete fECutCmd;
-    delete fMCutCmd;
-    delete fConstructOpCmd;
-    delete fSpiceStepperCmd;
+	delete fPhysDir;
+	delete fGammaCutCmd;
+	delete fElectCutCmd;
+	delete fProtoCutCmd;
+	delete fAllCutCmd;
+	delete fPListCmd;
+	delete fECutCmd;
+	delete fMCutCmd;
+	delete fConstructOpCmd;
+	delete fSpiceStepperCmd;
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
 void PhysicsListMessenger::SetNewValue(G4UIcommand* command,
-                                       G4String newValue)
+		G4String newValue)
 {
-    if( command == fGammaCutCmd )
-    { fPPhysicsList->SetCutForGamma(fGammaCutCmd->GetNewDoubleValue(newValue));}
+	if(command == fGammaCutCmd)
+	{
+		fPPhysicsList->SetCutForGamma(fGammaCutCmd->GetNewDoubleValue(newValue));
+	}
 
-    if( command == fElectCutCmd )
-    { fPPhysicsList->SetCutForElectron(fElectCutCmd->GetNewDoubleValue(newValue));}
+	if(command == fElectCutCmd)
+	{
+		fPPhysicsList->SetCutForElectron(fElectCutCmd->GetNewDoubleValue(newValue));
+	}
 
-    if( command == fProtoCutCmd )
-    { fPPhysicsList->SetCutForPositron(fProtoCutCmd->GetNewDoubleValue(newValue));}
+	if(command == fProtoCutCmd)
+	{
+		fPPhysicsList->SetCutForPositron(fProtoCutCmd->GetNewDoubleValue(newValue));
+	}
 
-    if( command == fAllCutCmd )
-    {
-        G4double cut = fAllCutCmd->GetNewDoubleValue(newValue);
-        fPPhysicsList->SetCutForGamma(cut);
-        fPPhysicsList->SetCutForElectron(cut);
-        fPPhysicsList->SetCutForPositron(cut);
-    }
+	if(command == fAllCutCmd)
+	{
+		G4double cut = fAllCutCmd->GetNewDoubleValue(newValue);
+		fPPhysicsList->SetCutForGamma(cut);
+		fPPhysicsList->SetCutForElectron(cut);
+		fPPhysicsList->SetCutForPositron(cut);
+	}
 
-    if( command == fECutCmd )
-    { fPPhysicsList->SetTargetCut(fECutCmd->GetNewDoubleValue(newValue));}
+	if(command == fECutCmd)
+	{
+		fPPhysicsList->SetTargetCut(fECutCmd->GetNewDoubleValue(newValue));
+	}
 
-    if( command == fMCutCmd )
-    { fPPhysicsList->SetDetectorCut(fMCutCmd->GetNewDoubleValue(newValue));}
+	if(command == fMCutCmd)
+	{
+		fPPhysicsList->SetDetectorCut(fMCutCmd->GetNewDoubleValue(newValue));
+	}
 
-    if( command == fPListCmd )
-    { fPPhysicsList->SelectPhysicsList(newValue);}
+	if(command == fPListCmd)
+	{
+		fPPhysicsList->SelectPhysicsList(newValue);
+	}
 
-    if( command == fConstructOpCmd )
-    { fPPhysicsList->ConstructOp(fConstructOpCmd->GetNewBoolValue(newValue));}
-    
-    if( command == fSpiceStepperCmd )
-    { fPPhysicsList->SpiceStepper(fSpiceStepperCmd->GetNewBoolValue(newValue));}
+	if(command == fConstructOpCmd)
+	{
+		fPPhysicsList->ConstructOp(fConstructOpCmd->GetNewBoolValue(newValue));
+	}
+
+	if(command == fSpiceStepperCmd)
+	{
+		fPPhysicsList->SpiceStepper(fSpiceStepperCmd->GetNewBoolValue(newValue));
+	}
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......

--- a/src/PrimaryGeneratorAction.cc
+++ b/src/PrimaryGeneratorAction.cc
@@ -53,9 +53,9 @@
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
-PrimaryGeneratorAction::PrimaryGeneratorAction(HistoManager* histoManager)
+	PrimaryGeneratorAction::PrimaryGeneratorAction(HistoManager* histoManager)
 : G4VUserPrimaryGeneratorAction(),
-	fParticleGun(NULL),
+	fParticleGun(nullptr),
 	fDetector(histoManager->GetDetectorConstruction()),
 	fHistoManager(histoManager)
 {
@@ -119,9 +119,9 @@ void PrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
 		prob = 1.0/((G4double)(fNumberOfDecayingLaBrDetectors));
 		sumProb = 0.0;
 		G4double randomDet = G4UniformRand();
-		for( G4int j = 0 ; j < fNumberOfDecayingLaBrDetectors ; j++ ) {  // get the number of particles in decay and loop over them
+		for(G4int j = 0 ; j < fNumberOfDecayingLaBrDetectors ; j++) {  // get the number of particles in decay and loop over them
 			sumProb = sumProb + prob;
-			if(randomDet <= sumProb ) {
+			if(randomDet <= sumProb) {
 				detnumber = j;
 				break;
 			}
@@ -134,10 +134,9 @@ void PrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
 		G4double thisEnergy;
 		G4double randomEnergy = G4UniformRand();
 
-		if(randomEnergy <= prob ) {
+		if(randomEnergy <= prob) {
 			thisEnergy = 788.742*keV;
-		}
-		else {
+		} else {
 			thisEnergy = 1435.795*keV;
 		}
 
@@ -169,7 +168,7 @@ void PrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
 
 		// random direction
 		G4double randcostheta = 2.*G4UniformRand()-1.0;
-		G4double randsintheta = sqrt( 1. - randcostheta*randcostheta );
+		G4double randsintheta = sqrt(1. - randcostheta*randcostheta);
 		G4double randphi      = (360.*deg)*G4UniformRand();
 		G4ThreeVector thisDirection = G4ThreeVector(randsintheta*cos(randphi), randsintheta*sin(randphi), randcostheta);
 
@@ -177,24 +176,18 @@ void PrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
 		fParticleGun->SetParticlePosition(thisPosition);
 		fParticleGun->SetParticleMomentumDirection(thisDirection);
 		fParticleGun->SetParticleEnergy(thisEnergy);
-	}
-
-	else  {
-			// Changed so that most grsi "/Detsys/gun/" commands still effect gun when using
-			// Underlying geant4 commands such as '/gun/particle ion" & "/gun/ion"
+	} else  {
+		// Changed so that most grsi "/Detsys/gun/" commands still effect gun when using
+		// Underlying geant4 commands such as '/gun/particle ion" & "/gun/ion"
 		if(fEffParticleBool) {
 			G4ParticleDefinition* effPart;
 			if(fEffParticle == "electron" || fEffParticle == "e-") {
 				effPart = G4ParticleTable::GetParticleTable()->FindParticle("e-");
-			}
-			else if(fEffParticle == "positron" || fEffParticle == "e+") {
+			} else if(fEffParticle == "positron" || fEffParticle == "e+") {
 				effPart = G4ParticleTable::GetParticleTable()->FindParticle("e+");
-			}
-			else if (fEffParticle == "neutron"){
+			} else if(fEffParticle == "neutron"){
 				effPart = G4ParticleTable::GetParticleTable()->FindParticle("neutron");
-			}
-// 			else if (fEffParticle == "gamma" || fEffParticle == "photon"){
-			else{
+			} else {
 				effPart = G4ParticleTable::GetParticleTable()->FindParticle("gamma");
 			}
 			fParticleGun->SetParticleDefinition(effPart);
@@ -223,7 +216,7 @@ void PrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
 
 		if(fTargetDistro){
 			z = fLayerStart+G4UniformRand()*fLayerLength;
-		}else if(fNeedFileDistro){
+		} else if(fNeedFileDistro){
 			z += fBeamDistribution->GetRandom();
 		}
 
@@ -257,7 +250,7 @@ void PrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
 			//G4cout<<"Random "<< G4endl; //may offer the solution, an altered 2pi rando. Using 4pi for efficiency
 			// random direction if no preference provided
 			effRandCosTheta = 2.*G4UniformRand()-1.0; //cos(theta) = 2cos^2(0.5theta)-1 ??
-			effRandSinTheta = sqrt( 1. - effRandCosTheta*effRandCosTheta ); //from sin^2(theta)+cos^2(theta)=1
+			effRandSinTheta = sqrt(1. - effRandCosTheta*effRandCosTheta); //from sin^2(theta)+cos^2(theta)=1
 			effRandPhi      = (360.*deg)*G4UniformRand();
 			effdirection = G4ThreeVector(effRandSinTheta*cos(effRandPhi), effRandSinTheta*sin(effRandPhi), effRandCosTheta);
 			//converts from Spherical polar(physics def.) to cartesian via (rsin(theta)cos(phi),rsin(theta)cos(phi),rcos(theta)) r=1,unit length
@@ -289,7 +282,7 @@ void PrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
 	fParticleGun->GeneratePrimaryVertex(anEvent);
 }
 
-void PrimaryGeneratorAction::PassEfficiencyPosition( G4ThreeVector  num){
+void PrimaryGeneratorAction::PassEfficiencyPosition(G4ThreeVector  num){
 	fDetector->PassEfficiencyPosition(num);
 }
 

--- a/src/PrimaryGeneratorMessenger.cc
+++ b/src/PrimaryGeneratorMessenger.cc
@@ -50,72 +50,72 @@
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
 PrimaryGeneratorMessenger::PrimaryGeneratorMessenger(PrimaryGeneratorAction* Gun)
-    :fAction(Gun)
+:fAction(Gun)
 {
-  
-    fNumberOfDecayingLaBrDetectorsCmd = new G4UIcmdWithAnInteger("/DetSys/gun/numberOfDecayingLaBrDetectors",this);
-    fNumberOfDecayingLaBrDetectorsCmd->SetGuidance("Set the number of radioactive LaBr detectors");
-    fNumberOfDecayingLaBrDetectorsCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
 
-    fEfficiencyEnergyCmd = new G4UIcmdWithADoubleAndUnit("/DetSys/gun/efficiencyEnergy",this);
-    fEfficiencyEnergyCmd->SetGuidance("Set gamma efficiency energy");
-    fEfficiencyEnergyCmd->SetUnitCategory("Energy");
-    fEfficiencyEnergyCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
+	fNumberOfDecayingLaBrDetectorsCmd = new G4UIcmdWithAnInteger("/DetSys/gun/numberOfDecayingLaBrDetectors",this);
+	fNumberOfDecayingLaBrDetectorsCmd->SetGuidance("Set the number of radioactive LaBr detectors");
+	fNumberOfDecayingLaBrDetectorsCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
 
-    fEfficiencyDirectionCmd = new G4UIcmdWith3Vector("/DetSys/gun/direction",this);
-    fEfficiencyDirectionCmd->SetGuidance("Set momentum direction.");
-    fEfficiencyDirectionCmd->SetGuidance("Direction needs not to be a unit vector.");
-    fEfficiencyDirectionCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
+	fEfficiencyEnergyCmd = new G4UIcmdWithADoubleAndUnit("/DetSys/gun/efficiencyEnergy",this);
+	fEfficiencyEnergyCmd->SetGuidance("Set gamma efficiency energy");
+	fEfficiencyEnergyCmd->SetUnitCategory("Energy");
+	fEfficiencyEnergyCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
 
-    fEfficiencyPositionCmd = new G4UIcmdWith3VectorAndUnit("/DetSys/gun/position",this);
-    fEfficiencyPositionCmd->SetGuidance("Set position.");
-    fEfficiencyPositionCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
+	fEfficiencyDirectionCmd = new G4UIcmdWith3Vector("/DetSys/gun/direction",this);
+	fEfficiencyDirectionCmd->SetGuidance("Set momentum direction.");
+	fEfficiencyDirectionCmd->SetGuidance("Direction needs not to be a unit vector.");
+	fEfficiencyDirectionCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
 
-    fEfficiencyParticleCmd = new G4UIcmdWithAString("/DetSys/gun/particle",this);
-    fEfficiencyParticleCmd->SetGuidance("Set particle.");
-    fEfficiencyParticleCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
+	fEfficiencyPositionCmd = new G4UIcmdWith3VectorAndUnit("/DetSys/gun/position",this);
+	fEfficiencyPositionCmd->SetGuidance("Set position.");
+	fEfficiencyPositionCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
 
-    fEfficiencyPolarizationCmd = new G4UIcmdWith3Vector("/DetSys/gun/polarization",this);
-    fEfficiencyPolarizationCmd->SetGuidance("Set gamma polarization direction.");
-    fEfficiencyPolarizationCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
-   
-    fConeAngleCmd = new G4UIcmdWithADoubleAndUnit("/DetSys/gun/coneMaxAngle",this);//SPICE cone angle value
-    fConeAngleCmd->SetGuidance("Set cone value for outer theta - use deg (0-90)");
-    fConeAngleCmd->SetUnitCategory("Angle");
-    fConeAngleCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
-    
-    fConeMinAngleCmd = new G4UIcmdWithADoubleAndUnit("/DetSys/gun/coneMinAngle",this);//SPICE cone angle value
-    fConeMinAngleCmd->SetGuidance("Set cone value for inner theta - use deg (0-90) - default is 0 if none specified");
-    fConeMinAngleCmd->SetUnitCategory("Angle");
-    fConeMinAngleCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
-     
-    fBeamSpotSigmaCmd = new G4UIcmdWithADoubleAndUnit("/DetSys/gun/BeamSpot",this);//Beam spot sigma
-    fBeamSpotSigmaCmd->SetGuidance("Set sigma for a realistic beamspot");
-    fBeamSpotSigmaCmd->SetUnitCategory("Length");
-    fBeamSpotSigmaCmd->AvailableForStates(G4State_PreInit,G4State_Idle);   
+	fEfficiencyParticleCmd = new G4UIcmdWithAString("/DetSys/gun/particle",this);
+	fEfficiencyParticleCmd->SetGuidance("Set particle.");
+	fEfficiencyParticleCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
 
-    fBeamDistroCmd = new G4UIcmdWithAnInteger("/Detsys/gun/TargetLayer",this);//with target, can apply a distribution
-    fBeamDistroCmd->SetGuidance("Set beam distribution within a target layer, zero indexed");
-    fBeamDistroCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
-    
-    fBeamFileCmd = new G4UIcmdWithAString("/Detsys/gun/FileDistro",this);//with target, can apply a distribution
-    fBeamFileCmd->SetGuidance("Set beam distribution within a target using definitions in a data file");
-    fBeamFileCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
-    
+	fEfficiencyPolarizationCmd = new G4UIcmdWith3Vector("/DetSys/gun/polarization",this);
+	fEfficiencyPolarizationCmd->SetGuidance("Set gamma polarization direction.");
+	fEfficiencyPolarizationCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
+
+	fConeAngleCmd = new G4UIcmdWithADoubleAndUnit("/DetSys/gun/coneMaxAngle",this);//SPICE cone angle value
+	fConeAngleCmd->SetGuidance("Set cone value for outer theta - use deg (0-90)");
+	fConeAngleCmd->SetUnitCategory("Angle");
+	fConeAngleCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
+
+	fConeMinAngleCmd = new G4UIcmdWithADoubleAndUnit("/DetSys/gun/coneMinAngle",this);//SPICE cone angle value
+	fConeMinAngleCmd->SetGuidance("Set cone value for inner theta - use deg (0-90) - default is 0 if none specified");
+	fConeMinAngleCmd->SetUnitCategory("Angle");
+	fConeMinAngleCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
+
+	fBeamSpotSigmaCmd = new G4UIcmdWithADoubleAndUnit("/DetSys/gun/BeamSpot",this);//Beam spot sigma
+	fBeamSpotSigmaCmd->SetGuidance("Set sigma for a realistic beamspot");
+	fBeamSpotSigmaCmd->SetUnitCategory("Length");
+	fBeamSpotSigmaCmd->AvailableForStates(G4State_PreInit,G4State_Idle);   
+
+	fBeamDistroCmd = new G4UIcmdWithAnInteger("/Detsys/gun/TargetLayer",this);//with target, can apply a distribution
+	fBeamDistroCmd->SetGuidance("Set beam distribution within a target layer, zero indexed");
+	fBeamDistroCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
+
+	fBeamFileCmd = new G4UIcmdWithAString("/Detsys/gun/FileDistro",this);//with target, can apply a distribution
+	fBeamFileCmd->SetGuidance("Set beam distribution within a target using definitions in a data file");
+	fBeamFileCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
+
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
 PrimaryGeneratorMessenger::~PrimaryGeneratorMessenger() {
-    delete fNumberOfDecayingLaBrDetectorsCmd;
-    delete fEfficiencyEnergyCmd;
-    delete fEfficiencyDirectionCmd;
-    delete fEfficiencyPolarizationCmd;
-    delete fConeAngleCmd;
-    delete fConeMinAngleCmd;
-    delete fBeamSpotSigmaCmd;
-    delete fBeamDistroCmd;
-    delete fBeamFileCmd;
+	delete fNumberOfDecayingLaBrDetectorsCmd;
+	delete fEfficiencyEnergyCmd;
+	delete fEfficiencyDirectionCmd;
+	delete fEfficiencyPolarizationCmd;
+	delete fConeAngleCmd;
+	delete fConeMinAngleCmd;
+	delete fBeamSpotSigmaCmd;
+	delete fBeamDistroCmd;
+	delete fBeamFileCmd;
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
@@ -125,7 +125,7 @@ void PrimaryGeneratorMessenger::SetNewValue(G4UIcommand* command, G4String newVa
 		fAction->SetNumberOfDecayingLaBrDetectors(fNumberOfDecayingLaBrDetectorsCmd->GetNewIntValue(newValue));
 		return;
 	}
-	if(command == fEfficiencyEnergyCmd ) {
+	if(command == fEfficiencyEnergyCmd) {
 		fAction->SetEfficiencyEnergy(fEfficiencyEnergyCmd->GetNewDoubleValue(newValue));
 		return;
 	}

--- a/src/RunAction.cc
+++ b/src/RunAction.cc
@@ -41,7 +41,7 @@
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
 RunAction::RunAction(HistoManager* histoManager)
-    : G4UserRunAction()
+: G4UserRunAction()
 {
 	fHistoManager = histoManager;
 }

--- a/src/RunAction.cc
+++ b/src/RunAction.cc
@@ -61,6 +61,7 @@ void RunAction::BeginOfRunAction(const G4Run* aRun)
 	}
 	if(fHistoManager != nullptr) {
 		fHistoManager->Book();
+		fHistoManager->GetDetectorConstruction()->SetProperties();
 	}
 }
 

--- a/src/SteppingAction.cc
+++ b/src/SteppingAction.cc
@@ -60,10 +60,8 @@ SteppingAction::~SteppingAction() { }
 
 void SteppingAction::UserSteppingAction(const G4Step* aStep) {
 	G4bool trackSteps   = false;
-	G4int processType   = 0;
-	G4int evntNb;
-
-	G4String particleName;
+	G4int processType   = -1;
+	G4int evntNb        = 0;
 
 	// Get volume of the current step
 	G4VPhysicalVolume* volume = aStep->GetPreStepPoint()->GetTouchableHandle()->GetVolume();
@@ -86,7 +84,6 @@ void SteppingAction::UserSteppingAction(const G4Step* aStep) {
 		const G4Isotope* target = NULL;
 		target = hadrProcess->GetTargetIsotope();
 		if(target != NULL) {
-			//	G4cout<<particleName<<", "<<process->GetProcessName()<<" on "<<target->GetName()<<G4endl;
 			targetZ = target->GetZ();
 		}
 	}
@@ -94,15 +91,12 @@ void SteppingAction::UserSteppingAction(const G4Step* aStep) {
 	// this can be modified to add more processes
 	if(theTrack->GetCreatorProcess() != NULL) {
 		G4String processName = theTrack->GetCreatorProcess()->GetProcessName();
-		//G4cout<<"found secondary, particle "<<particleName<<", creation process "<<process<<G4endl;
-		if (processName == "RadioactiveDecay")      processType = 1;
-		else if (processName == "eIoni")            processType = 2;
-		else if (processName == "msc")              processType = 3;
-		else if (processName == "Scintillation")    processType = 4;
-		else if (processName == "Cerenkov")         processType = 5;
-		else  processType = 0;
-	} else {
-		processType = -1;
+		if(processName == "RadioactiveDecay")      processType = 1;
+		else if(processName == "eIoni")            processType = 2;
+		else if(processName == "msc")              processType = 3;
+		else if(processName == "Scintillation")    processType = 4;
+		else if(processName == "Cerenkov")         processType = 5;
+		else                                       processType = 0;
 	}
 
 	evntNb =  fEventAction->GetEventNumber();
@@ -111,14 +105,10 @@ void SteppingAction::UserSteppingAction(const G4Step* aStep) {
 	G4int trackID = theTrack->GetTrackID();
 	G4int parentID = theTrack->GetParentID();
 
-	G4StepPoint* point1 = aStep->GetPreStepPoint();
-	G4StepPoint* point2 = aStep->GetPostStepPoint();
-
-	G4ThreeVector pos1 = point1->GetPosition();
-	G4ThreeVector pos2 = point2->GetPosition();
-
-	//G4double time1 = point1->GetGlobalTime();
-	G4double time2 = point2->GetGlobalTime();
+	//G4StepPoint* prePoint = aStep->GetPreStepPoint();
+	G4StepPoint* postPoint = aStep->GetPostStepPoint();
+	G4ThreeVector postPos = postPoint->GetPosition();
+	G4double postTime = postPoint->GetGlobalTime();
 
 	// check if this volume has its properties set, i.e. it's an active detector
 	if((edep > 0 || (fDetector->GridCell() && ekin > 0)) && fDetector->HasProperties(volume)) {
@@ -144,10 +134,10 @@ void SteppingAction::UserSteppingAction(const G4Step* aStep) {
 		// check edep again in case we use the grid cell but haven't hit it
 		if(edep <= 0) return;
 
-		fEventAction->AddHitTracker(prop, evntNb, trackID, parentID, stepNumber, particleType, processType, edep, pos2, time2, targetZ);
+		fEventAction->AddHitTracker(prop, evntNb, trackID, parentID, stepNumber, particleType, processType, edep, postPos, postTime, targetZ);
 
 		if(trackSteps) {
-			fEventAction->AddStepTracker(prop, evntNb, trackID, parentID, stepNumber, particleType, processType, edep, pos2, time2, targetZ);
+			fEventAction->AddStepTracker(prop, evntNb, trackID, parentID, stepNumber, particleType, processType, edep, postPos, postTime, targetZ);
 		}
 	}// if(fDetector->HasProperties(volume))
 }

--- a/src/SteppingAction.cc
+++ b/src/SteppingAction.cc
@@ -65,7 +65,6 @@ void SteppingAction::UserSteppingAction(const G4Step* aStep) {
 	G4int evntNb;
 
 	G4String particleName;
-	G4String mnemonic = "XXX00XX00X";
 
 	// Get volume of the current step
 	G4VPhysicalVolume* volume = aStep->GetPreStepPoint()->GetTouchableHandle()->GetVolume();
@@ -155,10 +154,10 @@ void SteppingAction::UserSteppingAction(const G4Step* aStep) {
 		// check edep again in case we use the grid cell but haven't hit it
 		if(edep <= 0) return;
 
-		fEventAction->AddHitTracker(prop.mnemonic, evntNb, trackID, parentID, stepNumber, particleType, processType, prop.systemID, prop.crystalNumber-1, prop.detectorNumber-1, edep, pos2.x(), pos2.y(), pos2.z(), time2, targetZ);
+		fEventAction->AddHitTracker(prop, evntNb, trackID, parentID, stepNumber, particleType, processType, edep, pos2, time2, targetZ);
 
 		if(trackSteps) {
-			fEventAction->AddStepTracker(evntNb, trackID, parentID, stepNumber, particleType, processType, prop.systemID, prop.crystalNumber-1, prop.detectorNumber-1, edep, pos2.x(), pos2.y(), pos2.z(), time2, targetZ);
+			fEventAction->AddStepTracker(prop, evntNb, trackID, parentID, stepNumber, particleType, processType, edep, pos2, time2, targetZ);
 		}
 	}// if(fDetector->HasProperties(volume))
 }

--- a/src/SteppingAction.cc
+++ b/src/SteppingAction.cc
@@ -59,104 +59,107 @@ SteppingAction::~SteppingAction() { }
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
 void SteppingAction::UserSteppingAction(const G4Step* aStep) {
-    G4bool trackSteps   = false;
-    G4int particleType  = 0;
-    G4int processType   = 0;
-    G4int evntNb;
+	G4bool trackSteps   = false;
+	G4int particleType  = 0;
+	G4int processType   = 0;
+	G4int evntNb;
 
-    G4String particleName;
-    G4String mnemonic = "XXX00XX00X";
+	G4String particleName;
+	G4String mnemonic = "XXX00XX00X";
 
-    // Get volume of the current step
-    G4VPhysicalVolume* volume = aStep->GetPreStepPoint()->GetTouchableHandle()->GetVolume();
+	// Get volume of the current step
+	G4VPhysicalVolume* volume = aStep->GetPreStepPoint()->GetTouchableHandle()->GetVolume();
 
-    // collect energy and track length step by step
-    // As it's called more than once, get the Track and assign to variable
-    G4double edep = aStep->GetTotalEnergyDeposit();
-    G4double ekin = aStep->GetPreStepPoint()->GetKineticEnergy();
+	// collect energy and track length step by step
+	// As it's called more than once, get the Track and assign to variable
+	G4double edep = aStep->GetTotalEnergyDeposit();
+	G4double ekin = aStep->GetPreStepPoint()->GetKineticEnergy();
 
-    G4Track* theTrack = aStep->GetTrack();
-    G4int stepNumber = theTrack->GetCurrentStepNumber();
+	G4Track* theTrack = aStep->GetTrack();
+	G4int stepNumber = theTrack->GetCurrentStepNumber();
 
-    // Track particle type in EVERY step
-    //G4cout << "Particle name = " << aStep->GetTrack()->GetParticleDefinition()->GetParticleName() << G4endl;
-    particleName = aStep->GetTrack()->GetParticleDefinition()->GetParticleName();
-    if (particleName == "gamma")         particleType = 1;
-    else if (particleName == "e-")       particleType = 2;
-    else if (particleName == "e+")       particleType = 3;
-    else if (particleName == "proton")   particleType = 4;
-    else if (particleName == "neutron")  particleType = 5;
-    else if (particleName == "deuteron") particleType = 6;
-    else if (particleName == "C12")      particleType = 7;
-    else particleType = 0;
+	// Track particle type in EVERY step
+	//G4cout << "Particle name = " << aStep->GetTrack()->GetParticleDefinition()->GetParticleName() << G4endl;
+	particleName = aStep->GetTrack()->GetParticleDefinition()->GetParticleName();
+	if (particleName == "gamma")         particleType = 1;
+	else if (particleName == "e-")       particleType = 2;
+	else if (particleName == "e+")       particleType = 3;
+	else if (particleName == "proton")   particleType = 4;
+	else if (particleName == "neutron")  particleType = 5;
+	else if (particleName == "deuteron") particleType = 6;
+	else if (particleName == "C12")      particleType = 7;
+	else particleType = 0;
 
-	 const G4VProcess* process = aStep->GetPostStepPoint()->GetProcessDefinedStep();
-	 G4int targetZ = -1;
-	 if(process != NULL && process->GetProcessType() == fHadronic) {
+	const G4VProcess* process = aStep->GetPostStepPoint()->GetProcessDefinedStep();
+	G4int targetZ = -1;
+	if(process != NULL && process->GetProcessType() == fHadronic) {
 		G4HadronicProcess* hadrProcess = (G4HadronicProcess*) process;
 		const G4Isotope* target = NULL;
 		target = hadrProcess->GetTargetIsotope();
 		if(target != NULL) {
-		  //	G4cout<<particleName<<", "<<process->GetProcessName()<<" on "<<target->GetName()<<G4endl;
-		  targetZ = target->GetZ();
+			//	G4cout<<particleName<<", "<<process->GetProcessName()<<" on "<<target->GetName()<<G4endl;
+			targetZ = target->GetZ();
 		}
-	 }
+	}
 
-    // this can be modified to add more processes
-	 if(theTrack->GetCreatorProcess() != NULL) {
+	// this can be modified to add more processes
+	if(theTrack->GetCreatorProcess() != NULL) {
 		G4String processName = theTrack->GetCreatorProcess()->GetProcessName();
 		//G4cout<<"found secondary, particle "<<particleName<<", creation process "<<process<<G4endl;
-      if (processName == "RadioactiveDecay")      processType = 1;
-      else if (processName == "eIoni")            processType = 2;
-      else if (processName == "msc")              processType = 3;
-      else if (processName == "Scintillation")    processType = 4;
-      else if (processName == "Cerenkov")         processType = 5;
-      else  processType = 0;
-	 } else {
+		if (processName == "RadioactiveDecay")      processType = 1;
+		else if (processName == "eIoni")            processType = 2;
+		else if (processName == "msc")              processType = 3;
+		else if (processName == "Scintillation")    processType = 4;
+		else if (processName == "Cerenkov")         processType = 5;
+		else  processType = 0;
+	} else {
 		processType = -1;
-	 }
+	}
 
-    evntNb =  fEventAction->GetEventNumber();
+	evntNb =  fEventAction->GetEventNumber();
 
-    // Get initial momentum direction & energy of particle
-    G4int trackID = theTrack->GetTrackID();
-    G4int parentID = theTrack->GetParentID();
+	// Get initial momentum direction & energy of particle
+	G4int trackID = theTrack->GetTrackID();
+	G4int parentID = theTrack->GetParentID();
 
-    G4StepPoint* point1 = aStep->GetPreStepPoint();
-    G4StepPoint* point2 = aStep->GetPostStepPoint();
+	G4StepPoint* point1 = aStep->GetPreStepPoint();
+	G4StepPoint* point2 = aStep->GetPostStepPoint();
 
-    G4ThreeVector pos1 = point1->GetPosition();
-    G4ThreeVector pos2 = point2->GetPosition();
+	G4ThreeVector pos1 = point1->GetPosition();
+	G4ThreeVector pos2 = point2->GetPosition();
 
-    //G4double time1 = point1->GetGlobalTime();
-    G4double time2 = point2->GetGlobalTime();
+	//G4double time1 = point1->GetGlobalTime();
+	G4double time2 = point2->GetGlobalTime();
 
-	 // check if this volume has its properties set, i.e. it's an active detector
-	 if(fDetector->HasProperties(volume)) {
-		 DetectorProperties prop = fDetector->GetProperties(volume);
+	// check if this volume has its properties set, i.e. it's an active detector
+	if((edep > 0 || (fDetector->GridCell() && ekin > 0)) && fDetector->HasProperties(volume)) {
+		DetectorProperties prop = fDetector->GetProperties(volume);
 
-		 if(fDetector->GridCell()) {
-			 G4String volumeName = volume->GetName();
-			 if(volumeName.find("gridcellLog") != G4String::npos) {
-				 // use ekin as edep
-				 edep = ekin;
-				 // Now kill the track!
-				 theTrack->SetTrackStatus(fStopAndKill);
-			 }
-		 }
-		 if(fDetector->Spice()) {
-			 G4double stepl = 0.;
-			 if(theTrack->GetDefinition()->GetPDGCharge() != 0.) {
-				 stepl = aStep->GetStepLength();
-			 }
-			 fEventAction->SpiceDet(edep, stepl, prop.detectorNumber, prop.crystalNumber);
-		 }
+		if(fDetector->GridCell()) {
+			G4String volumeName = volume->GetName();
+			if(volumeName.find("gridcellLog") != G4String::npos) {
+				// use ekin as edep
+				edep = ekin;
+				// Now kill the track!
+				theTrack->SetTrackStatus(fStopAndKill);
+			}
+		}
+		if(fDetector->Spice()) {
+			G4double stepl = 0.;
+			if(theTrack->GetDefinition()->GetPDGCharge() != 0.) {
+				stepl = aStep->GetStepLength();
+			}
+			fEventAction->SpiceDet(edep, stepl, prop.detectorNumber, prop.crystalNumber);
+		}
 
-		 fEventAction->AddHitTracker(prop.mnemonic, evntNb, trackID, parentID, stepNumber, particleType, processType, prop.systemID, prop.crystalNumber-1, prop.detectorNumber-1, edep, pos2.x(), pos2.y(), pos2.z(), time2, targetZ);
+		// check edep again in case we use the grid cell but haven't hit it
+		if(edep <= 0) return;
 
-		 if(trackSteps) {
-			 fEventAction->AddStepTracker(evntNb, trackID, parentID, stepNumber, particleType, processType, prop.systemID, prop.crystalNumber-1, prop.detectorNumber-1, edep, pos2.x(), pos2.y(), pos2.z(), time2, targetZ);
-		 }
-	 }// if(fDetector->HasProperties(volume))
+		fEventAction->AddHitTracker(prop.mnemonic, evntNb, trackID, parentID, stepNumber, particleType, processType, prop.systemID, prop.crystalNumber-1, prop.detectorNumber-1, edep, pos2.x(), pos2.y(), pos2.z(), time2, targetZ);
+
+		if(trackSteps) {
+			fEventAction->AddStepTracker(evntNb, trackID, parentID, stepNumber, particleType, processType, prop.systemID, prop.crystalNumber-1, prop.detectorNumber-1, edep, pos2.x(), pos2.y(), pos2.z(), time2, targetZ);
+		}
+	}// if(fDetector->HasProperties(volume))
 }
 

--- a/src/SteppingAction.cc
+++ b/src/SteppingAction.cc
@@ -60,7 +60,6 @@ SteppingAction::~SteppingAction() { }
 
 void SteppingAction::UserSteppingAction(const G4Step* aStep) {
 	G4bool trackSteps   = false;
-	G4int particleType  = 0;
 	G4int processType   = 0;
 	G4int evntNb;
 
@@ -78,16 +77,7 @@ void SteppingAction::UserSteppingAction(const G4Step* aStep) {
 	G4int stepNumber = theTrack->GetCurrentStepNumber();
 
 	// Track particle type in EVERY step
-	//G4cout << "Particle name = " << aStep->GetTrack()->GetParticleDefinition()->GetParticleName() << G4endl;
-	particleName = aStep->GetTrack()->GetParticleDefinition()->GetParticleName();
-	if (particleName == "gamma")         particleType = 1;
-	else if (particleName == "e-")       particleType = 2;
-	else if (particleName == "e+")       particleType = 3;
-	else if (particleName == "proton")   particleType = 4;
-	else if (particleName == "neutron")  particleType = 5;
-	else if (particleName == "deuteron") particleType = 6;
-	else if (particleName == "C12")      particleType = 7;
-	else particleType = 0;
+	G4int particleType  = aStep->GetTrack()->GetParticleDefinition()->GetPDGEncoding();
 
 	const G4VProcess* process = aStep->GetPostStepPoint()->GetProcessDefinedStep();
 	G4int targetZ = -1;

--- a/src/SteppingAction.cc
+++ b/src/SteppingAction.cc
@@ -46,9 +46,9 @@
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
 SteppingAction::SteppingAction(DetectorConstruction* detcon,
-                               EventAction* evt)
-    : G4UserSteppingAction(),
-      fDetector(detcon), fEventAction(evt)
+		EventAction* evt)
+: G4UserSteppingAction(),
+	fDetector(detcon), fEventAction(evt)
 {
 }
 
@@ -79,17 +79,17 @@ void SteppingAction::UserSteppingAction(const G4Step* aStep) {
 
 	const G4VProcess* process = aStep->GetPostStepPoint()->GetProcessDefinedStep();
 	G4int targetZ = -1;
-	if(process != NULL && process->GetProcessType() == fHadronic) {
+	if(process != nullptr && process->GetProcessType() == fHadronic) {
 		G4HadronicProcess* hadrProcess = (G4HadronicProcess*) process;
-		const G4Isotope* target = NULL;
+		const G4Isotope* target = nullptr;
 		target = hadrProcess->GetTargetIsotope();
-		if(target != NULL) {
+		if(target != nullptr) {
 			targetZ = target->GetZ();
 		}
 	}
 
 	// this can be modified to add more processes
-	if(theTrack->GetCreatorProcess() != NULL) {
+	if(theTrack->GetCreatorProcess() != nullptr) {
 		G4String processName = theTrack->GetCreatorProcess()->GetProcessName();
 		if(processName == "RadioactiveDecay")      processType = 1;
 		else if(processName == "eIoni")            processType = 2;

--- a/src/TabulatedMagneticField.cc
+++ b/src/TabulatedMagneticField.cc
@@ -6,13 +6,13 @@
 #include <algorithm> //for max_element
 
 TabulatedMagneticField::TabulatedMagneticField(const char* filename, G4double zOffset, G4double zRotation) //called in 'nonuniformfield'
-	: fZoffset(zOffset), fZrotation(zRotation), fInvertX(false), fInvertY(false), fInvertZ(false)
+: fZoffset(zOffset), fZrotation(zRotation), fInvertX(false), fInvertY(false), fInvertZ(false)
 {    
 	G4double lenUnit= mm;
 	G4double fieldUnit= tesla; 
 	G4cout<<"\n-----------------------------------------------------------"
- 		   <<"\n      Magnetic field"
-		   <<"\n-----------------------------------------------------------";
+		<<"\n      Magnetic field"
+		<<"\n-----------------------------------------------------------";
 
 	G4cout<<"\n ---> " "Reading the field grid from "<<filename<<" ... "<<std::endl; 
 
@@ -145,7 +145,7 @@ void TabulatedMagneticField::GetFieldValue(const G4double point[4], G4double* Bf
 	//
 
 	// Rotate the position here : Mhd : 25 Mar 2015 
-	G4ThreeVector R( x,  y,  z); 
+	G4ThreeVector R(x,  y,  z); 
 	R.rotateZ(-fZrotation*deg); // rotation made in the opposite direction of the lens
 	x = R.getX();
 	y = R.getY();
@@ -153,8 +153,8 @@ void TabulatedMagneticField::GetFieldValue(const G4double point[4], G4double* Bf
 
 	// Check that the point is within the defined region 
 	if(x>=fMinx && x<=fMaxx &&
-	   y>=fMiny && y<=fMaxy && 
-	   z>=fMinz && z<=fMaxz) {
+			y>=fMiny && y<=fMaxy && 
+			z>=fMinz && z<=fMaxz) {
 
 		// Position of given point within region, normalized to the range
 		// [0,1]


### PR DESCRIPTION
- Added map to DetectorConstruction that holds the new struct
  DetectorProperties (mnemonic, systemId, detectorNumber, and
  crystalNumber).
- Map is populated at BeginOfRun function (which calls
  DetectorConstruction::SetProperties()) via examining all daughter
  volumes of the world volume.
- Changed names of SPICE and TRIFIC detectors to include '_' between
  name and instance number.
- Removed parsing of volume names from the stepping action.
- Replaced custom particle type with PDG encoding.

The last point might create the need for some changes in programs that process the simulation data!