### PR TITLE
Geant4.10.04 Issue 65 Fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ DetectionSystemGriffinSuppressed.cc
 DetectorConstructionSuppressed.cc
 testXYZ.cc
 .DS_Store
+myBuild
+suppressed

--- a/include/DetectionSystemGriffin.hh
+++ b/include/DetectionSystemGriffin.hh
@@ -50,7 +50,10 @@ public:
     void Build() ;
     // For detector specific dead layers
     void BuildDeadLayerSpecificCrystal(G4int det);
-    void BuildEverythingButCrystals();
+
+    //begin CRN 
+    void BuildEverythingButCrystals(G4int det);
+    // end CRN 
     G4double GetCrystalDistanceFromOrigin() {return fCrystalDistFromOrigin;}
 
     G4double TransX(G4double x, G4double y, G4double z, G4double theta, G4double phi);

--- a/include/DetectionSystemGriffin.hh
+++ b/include/DetectionSystemGriffin.hh
@@ -287,7 +287,9 @@ private:
     G4LogicalVolume* fAirBoxLog;
 
     // methods to construct all of the components of the detector
-    void ConstructNewSuppressorCasingWithShells();
+    // begin CRN 
+    void ConstructNewSuppressorCasingWithShells(G4int det, G4int cry);
+    // end CRN
     void BuildelectrodeMatElectrodes();
     void ConstructComplexDetectorBlockWithDeadLayer();
 
@@ -458,7 +460,9 @@ private:
     G4Colour fGriffinDeadLayerColours[4];
 
     // internal methods
-    void BuildOneDetector();
+    // begin CRN 
+    void BuildOneDetector(G4int det, G4int cry);
+    //end CRN 
     //    void PlaceDetector(G4int detectorNumber);
 };
 

--- a/include/DetectionSystemGriffin.hh
+++ b/include/DetectionSystemGriffin.hh
@@ -51,9 +51,7 @@ public:
     // For detector specific dead layers
     void BuildDeadLayerSpecificCrystal(G4int det);
 
-    //begin CRN 
     void BuildEverythingButCrystals(G4int det);
-    // end CRN 
     G4double GetCrystalDistanceFromOrigin() {return fCrystalDistFromOrigin;}
 
     G4double TransX(G4double x, G4double y, G4double z, G4double theta, G4double phi);
@@ -287,9 +285,7 @@ private:
     G4LogicalVolume* fAirBoxLog;
 
     // methods to construct all of the components of the detector
-    // begin CRN 
     void ConstructNewSuppressorCasingWithShells(G4int det);
-    // end CRN
     void BuildelectrodeMatElectrodes();
     void ConstructComplexDetectorBlockWithDeadLayer();
 
@@ -460,9 +456,7 @@ private:
     G4Colour fGriffinDeadLayerColours[4];
 
     // internal methods
-    // begin CRN 
     void BuildOneDetector(G4int det);
-    //end CRN 
     //    void PlaceDetector(G4int detectorNumber);
 };
 

--- a/include/DetectionSystemGriffin.hh
+++ b/include/DetectionSystemGriffin.hh
@@ -288,7 +288,7 @@ private:
 
     // methods to construct all of the components of the detector
     // begin CRN 
-    void ConstructNewSuppressorCasingWithShells(G4int det, G4int cry);
+    void ConstructNewSuppressorCasingWithShells(G4int det);
     // end CRN
     void BuildelectrodeMatElectrodes();
     void ConstructComplexDetectorBlockWithDeadLayer();
@@ -461,7 +461,7 @@ private:
 
     // internal methods
     // begin CRN 
-    void BuildOneDetector(G4int det, G4int cry);
+    void BuildOneDetector(G4int det);
     //end CRN 
     //    void PlaceDetector(G4int detectorNumber);
 };

--- a/src/DetectionSystemGriffin.cc
+++ b/src/DetectionSystemGriffin.cc
@@ -121,11 +121,9 @@ DetectionSystemGriffin::~DetectionSystemGriffin() {
 void DetectionSystemGriffin::Build() { 
 
     fSurfCheck = true;
-    // begin CRN 
     G4int det = 1;
 
     BuildOneDetector(det);
-    // end CRN
 
 }//end ::Build
 
@@ -545,9 +543,7 @@ void DetectionSystemGriffin::BuildOneDetector(G4int det) {
 
 } // end BuildOneDetector()
 
-//begin CRN 
 void DetectionSystemGriffin::BuildEverythingButCrystals(G4int det) {
-// end CRN 
     // Build assembly volumes
     fAssembly                           = new G4AssemblyVolume();
     fLeftSuppressorCasingAssembly       = new G4AssemblyVolume();
@@ -571,9 +567,7 @@ void DetectionSystemGriffin::BuildEverythingButCrystals(G4int det) {
 
     // Include BGOs?
     if(fBGOSelector == 1) {
-        // begin CRN 
         ConstructNewSuppressorCasingWithShells(det);
-        // end CRN 
     } else if(fBGOSelector == 0) {
         //G4cout<<"Not building BGO "<<G4endl;
     } else {
@@ -1659,10 +1653,8 @@ G4Tubs* DetectionSystemGriffin::StructureMatColdFinger() {
 // as per the design in the specifications. Also, there is a layer
 // of structureMat that surrounds the physical pieces.
 ///////////////////////////////////////////////////////////////////////
-// begin CRN 
 void DetectionSystemGriffin::ConstructNewSuppressorCasingWithShells(G4int det) {
     G4String strdet = G4UIcommand::ConvertToString(det);
-    // end CRN 
     G4int i;
     G4double x0, y0, z0, x, y, z;
 
@@ -1761,7 +1753,6 @@ void DetectionSystemGriffin::ConstructNewSuppressorCasingWithShells(G4int det) {
     ////////////////////////////////////////////////////////////////////////////////////////
     // now we add the side pieces of suppressor that taper off towards the front of the can
     ////////////////////////////////////////////////////////////////////////////////////////
-    // begin CRN 
     G4String rightSuppressorLogName = "rightSuppressor_" + strdet + "_log";
     G4String leftSuppressorLogName = "leftSuppressor_" + strdet + "_log";
 
@@ -1787,7 +1778,6 @@ void DetectionSystemGriffin::ConstructNewSuppressorCasingWithShells(G4int det) {
 
     fLeftSuppressorLog = new G4LogicalVolume(leftSuppressor, materialBGO, leftSuppressorLogName, 0, 0, 0);
     fLeftSuppressorLog->SetVisAttributes(innardsVisAtt);
-    // end CRN 
 
     fRightSuppressorCasingAssembly->AddPlacedVolume(fRightSuppressorLog, fMoveNull, fRotateNull);
     fLeftSuppressorCasingAssembly->AddPlacedVolume(fLeftSuppressorLog, fMoveNull, fRotateNull);
@@ -1854,30 +1844,24 @@ void DetectionSystemGriffin::ConstructNewSuppressorCasingWithShells(G4int det) {
     ////////////////////////////////////////////////////////////////////////////////////////
     // now we add the side pieces of suppressor that extend out in front of the can when it's in the back position
     ////////////////////////////////////////////////////////////////////////////////////////
-    // begin CRN 
     G4String rightSuppressorExtensionLogName = "rightSuppressorExtension_" + strdet + "_log";
     G4String leftSuppressorExtensionLogName = "leftSuppressorExtension_" + strdet + "_log";
 
     G4String rightSuppressorShellExtensionLogName = "rightSuppressorShellExtension_" + strdet + "_log";
     G4String leftSuppressorShellExtensionLogName = "leftSuppressorShellExtension_" + strdet + "_log";
-    // end CRN
 
     // Define the shell right logical volume
     // G4SubtractionSolid* rightSuppressorShellExtension = ShellForRightSuppressorExtension();
     G4SubtractionSolid* rightSuppressorShellExtension = ShellForSuppressorExtension("right");
 
-    // begin CRN
     fRightSuppressorShellExtensionLog = new G4LogicalVolume(rightSuppressorShellExtension,
             materialBGO, rightSuppressorShellExtensionLogName, 0, 0, 0);
-    // end CRN
     fRightSuppressorShellExtensionLog->SetVisAttributes(SuppressorVisAtt);
 
     G4SubtractionSolid* rightSuppressorExtension = SideSuppressorExtension("right", false); // Right, non-chopping // CALLED
 
-    // begin CRN
     fRightSuppressorExtensionLog = new G4LogicalVolume(rightSuppressorExtension, materialBGO,
             rightSuppressorExtensionLogName, 0, 0, 0);
-    // end CRN
     fRightSuppressorExtensionLog->SetVisAttributes(innardsVisAtt);
 
     // Define the left shell logical volume
@@ -1885,18 +1869,14 @@ void DetectionSystemGriffin::ConstructNewSuppressorCasingWithShells(G4int det) {
     G4SubtractionSolid* leftSuppressorShellExtension = ShellForSuppressorExtension("left");
 
 
-    // begin CRN
     fLeftSuppressorShellExtensionLog = new G4LogicalVolume(leftSuppressorShellExtension,
             materialBGO, leftSuppressorShellExtensionLogName, 0, 0, 0);
-    //end CRN 
     fLeftSuppressorShellExtensionLog->SetVisAttributes(SuppressorVisAtt);
 
     G4SubtractionSolid* leftSuppressorExtension = SideSuppressorExtension("left", false); // Left, Non-chopping // CALLED
 
-    // begin CRN
     fLeftSuppressorExtensionLog = new G4LogicalVolume(leftSuppressorExtension, materialBGO,
             leftSuppressorExtensionLogName, 0, 0, 0);
-    // end CRN
     fLeftSuppressorExtensionLog->SetVisAttributes(innardsVisAtt);
 
     fRightSuppressorExtensionAssembly->AddPlacedVolume(fRightSuppressorExtensionLog, fMoveNull, fRotateNull);

--- a/src/DetectionSystemGriffin.cc
+++ b/src/DetectionSystemGriffin.cc
@@ -1753,8 +1753,8 @@ void DetectionSystemGriffin::ConstructNewSuppressorCasingWithShells(G4int det) {
     ////////////////////////////////////////////////////////////////////////////////////////
     // now we add the side pieces of suppressor that taper off towards the front of the can
     ////////////////////////////////////////////////////////////////////////////////////////
-    G4String rightSuppressorLogName = "rightSuppressor_" + strdet + "_log";
-    G4String leftSuppressorLogName = "leftSuppressor_" + strdet + "_log";
+    G4String rightSuppressorLogName = "rightSuppressorCasing_" + strdet + "_log";
+    G4String leftSuppressorLogName = "leftSuppressorCasing_" + strdet + "_log";
 
     // Define the structureMat shell logical volume
     G4SubtractionSolid* rightSuppressorShell = ShellForFrontSlantSuppressor("right");

--- a/src/DetectionSystemGriffin.cc
+++ b/src/DetectionSystemGriffin.cc
@@ -45,73 +45,73 @@
 ///////////////////////////////////////////////////////////////////////
 
 DetectionSystemGriffin::~DetectionSystemGriffin() {
-	// LogicalVolumes in ConstructNewHeavyMet
-	delete fHevimetLog;
+    // LogicalVolumes in ConstructNewHeavyMet
+    delete fHevimetLog;
 
-	// LogicalVolumes in ConstructNewSuppressorCasing
-	delete fLeftSuppressorExtensionLog;
-	delete fRightSuppressorExtensionLog;
-	delete fLeftSuppressorLog;
-	delete fRightSuppressorLog;
-	delete fBackQuarterSuppressorLog;
+    // LogicalVolumes in ConstructNewSuppressorCasing
+    delete fLeftSuppressorExtensionLog;
+    delete fRightSuppressorExtensionLog;
+    delete fLeftSuppressorLog;
+    delete fRightSuppressorLog;
+    delete fBackQuarterSuppressorLog;
 
-	delete fBackQuarterSuppressorShellLog;
-	delete fRightSuppressorShellLog;
-	delete fLeftSuppressorShellLog;
-	delete fRightSuppressorShellExtensionLog;
-	delete fLeftSuppressorShellExtensionLog;
-	// LogicalVolumes in ConstructBGOCasing
+    delete fBackQuarterSuppressorShellLog;
+    delete fRightSuppressorShellLog;
+    delete fLeftSuppressorShellLog;
+    delete fRightSuppressorShellExtensionLog;
+    delete fLeftSuppressorShellExtensionLog;
+    // LogicalVolumes in ConstructBGOCasing
 
-	delete fBGOCasingLog;
-	delete fBackBGOLog;
+    delete fBGOCasingLog;
+    delete fBackBGOLog;
 
-	// LogicalVolumes in ConstructColdFinger
-	delete fCoolingSideBlockLog;
-	delete fStructureMatColdFingerLog;
-	delete fCoolingBarLog;
-	delete fFetAirHoleLog;
-	delete fTrianglePostLog;
-	delete fExtraColdBlockLog;
-	delete fFingerLog;
-	delete fEndPlateLog;
+    // LogicalVolumes in ConstructColdFinger
+    delete fCoolingSideBlockLog;
+    delete fStructureMatColdFingerLog;
+    delete fCoolingBarLog;
+    delete fFetAirHoleLog;
+    delete fTrianglePostLog;
+    delete fExtraColdBlockLog;
+    delete fFingerLog;
+    delete fEndPlateLog;
 
-	// LogicalVolumes in ConstructComplexDetectorBlock
-	delete fGermaniumHoleLog;
-	delete fGermaniumBlock1Log;
-	delete fInnerDeadLayerLog;
-	delete fInterCrystalElectrodeMatBackLog;
-	delete fInterCrystalElectrodeMatFrontLog;
+    // LogicalVolumes in ConstructComplexDetectorBlock
+    delete fGermaniumHoleLog;
+    delete fGermaniumBlock1Log;
+    delete fInnerDeadLayerLog;
+    delete fInterCrystalElectrodeMatBackLog;
+    delete fInterCrystalElectrodeMatFrontLog;
 
-	// LogicalVolumes in ConstructBasicDetectorBlock
-	delete fGermaniumBlockLog;
+    // LogicalVolumes in ConstructBasicDetectorBlock
+    delete fGermaniumBlockLog;
 
-	// LogicalVolumes in ConstructDetector
-	delete fTankLog;
-	delete fTankLid1Log;
-	delete fTankLid2Log;
-	delete fFingerShellLog;
-	delete fRearPlateLog;
-	delete fBottomSidePanelLog;
-	delete fTopSidePanelLog;
-	delete fLeftSidePanelLog;
-	delete fRightSidePanelLog;
-	delete fLowerLeftTubeLog;
-	delete fUpperLeftTubeLog;
-	delete fLowerRightTubeLog;
-	delete fUpperRightTubeLog;
-	delete fLowerLeftConeLog;
-	delete fUpperLeftConeLog;
-	delete fLowerRightConeLog;
-	delete fUpperRightConeLog;
-	delete fBottomWedgeLog;
-	delete fTopWedgeLog;
-	delete fLeftWedgeLog;
-	delete fRightWedgeLog;
-	delete fBottomBentPieceLog;
-	delete fTopBentPieceLog;
-	delete fLeftBentPieceLog;
-	delete fRightBentPieceLog;
-	delete fFrontFaceLog;
+    // LogicalVolumes in ConstructDetector
+    delete fTankLog;
+    delete fTankLid1Log;
+    delete fTankLid2Log;
+    delete fFingerShellLog;
+    delete fRearPlateLog;
+    delete fBottomSidePanelLog;
+    delete fTopSidePanelLog;
+    delete fLeftSidePanelLog;
+    delete fRightSidePanelLog;
+    delete fLowerLeftTubeLog;
+    delete fUpperLeftTubeLog;
+    delete fLowerRightTubeLog;
+    delete fUpperRightTubeLog;
+    delete fLowerLeftConeLog;
+    delete fUpperLeftConeLog;
+    delete fLowerRightConeLog;
+    delete fUpperRightConeLog;
+    delete fBottomWedgeLog;
+    delete fTopWedgeLog;
+    delete fLeftWedgeLog;
+    delete fRightWedgeLog;
+    delete fBottomBentPieceLog;
+    delete fTopBentPieceLog;
+    delete fLeftBentPieceLog;
+    delete fRightBentPieceLog;
+    delete fFrontFaceLog;
 }// end ::~DetectionSystemGriffin
 
 ///////////////////////////////////////////////////////////////////////
@@ -120,368 +120,368 @@ DetectionSystemGriffin::~DetectionSystemGriffin() {
 ///////////////////////////////////////////////////////////////////////
 void DetectionSystemGriffin::Build() { 
 
-	fSurfCheck = true;
+    fSurfCheck = true;
 
-	BuildOneDetector();
+    BuildOneDetector();
 
 }//end ::Build
 
 G4double DetectionSystemGriffin::TransX(G4double x, G4double y, G4double z, G4double theta, G4double phi) {
-	return (x*cos(theta)+z*sin(theta))*cos(phi)-y*sin(phi);
+    return (x*cos(theta)+z*sin(theta))*cos(phi)-y*sin(phi);
 }
 
 G4double DetectionSystemGriffin::TransY(G4double x, G4double y, G4double z, G4double theta, G4double phi) {
-	return (x*cos(theta)+z*sin(theta))*sin(phi)+y*cos(phi);
+    return (x*cos(theta)+z*sin(theta))*sin(phi)+y*cos(phi);
 }
 
 G4double DetectionSystemGriffin::TransZ(G4double x, G4double z, G4double theta) {
-	return -x*sin(theta)+z*cos(theta);
+    return -x*sin(theta)+z*cos(theta);
 }
 
 G4int DetectionSystemGriffin::PlaceEverythingButCrystals(G4LogicalVolume* expHallLog, G4int detectorNumber, G4int positionNumber, G4bool posTigress) {
-	if(expHallLog == nullptr) {
-		std::cerr<<__PRETTY_FUNCTION__<<": expHallLog == nullptr!"<<std::endl;
-		exit(1);
-	}
+    if(expHallLog == nullptr) {
+        std::cerr<<__PRETTY_FUNCTION__<<": expHallLog == nullptr!"<<std::endl;
+        exit(1);
+    }
 
-	G4double theta  = fCoords[positionNumber][0]*deg;
-	G4double phi    = fCoords[positionNumber][1]*deg;
-	G4double alpha  = fCoords[positionNumber][2]*deg; // yaw
-	G4double beta   = fCoords[positionNumber][3]*deg; // pitch
-	G4double gamma  = fCoords[positionNumber][4]*deg; // roll
+    G4double theta  = fCoords[positionNumber][0]*deg;
+    G4double phi    = fCoords[positionNumber][1]*deg;
+    G4double alpha  = fCoords[positionNumber][2]*deg; // yaw
+    G4double beta   = fCoords[positionNumber][3]*deg; // pitch
+    G4double gamma  = fCoords[positionNumber][4]*deg; // roll
 
-	//In GRIFFIN upstream is now downstream relative to TIGRESS. However, we want to maintain the same numbering scheme as TIGRESS. Net result is that the lampshade angles change by 45 degrees.
-	if(posTigress && (positionNumber < 4 || positionNumber > 11)) {
-		phi       = fCoords[positionNumber][1]*deg - 45.0*deg;
-		gamma     = fCoords[positionNumber][4]*deg - 45.0*deg;
-	}
+    //In GRIFFIN upstream is now downstream relative to TIGRESS. However, we want to maintain the same numbering scheme as TIGRESS. Net result is that the lampshade angles change by 45 degrees.
+    if(posTigress && (positionNumber < 4 || positionNumber > 11)) {
+        phi       = fCoords[positionNumber][1]*deg - 45.0*deg;
+        gamma     = fCoords[positionNumber][4]*deg - 45.0*deg;
+    }
 
-	G4double x;
-	G4double y;
-	G4double z;
+    G4double x;
+    G4double y;
+    G4double z;
 
-	G4double x0, y0, z0;
+    G4double x0, y0, z0;
 
-	G4int i;
+    G4int i;
 
-	G4RotationMatrix* rotate = new G4RotationMatrix;    // rotation matrix corresponding to direction vector
-	rotate->rotateX(M_PI/2.0);
-	rotate->rotateX(alpha);
-	rotate->rotateY(beta);
-	rotate->rotateZ(gamma);
+    G4RotationMatrix* rotate = new G4RotationMatrix;    // rotation matrix corresponding to direction vector
+    rotate->rotateX(M_PI/2.0);
+    rotate->rotateX(alpha);
+    rotate->rotateY(beta);
+    rotate->rotateZ(gamma);
 
-	// positioning
-	G4double distFromOrigin = fAirBoxBackLength/2.0 +fAirBoxFrontLength + fNewRhombiRadius ;
-	G4double distFromOriginDet = fAirBoxBackLengthDet/2.0 +fAirBoxFrontLengthDet + fNewRhombiRadiusDet ;
+    // positioning
+    G4double distFromOrigin = fAirBoxBackLength/2.0 +fAirBoxFrontLength + fNewRhombiRadius ;
+    G4double distFromOriginDet = fAirBoxBackLengthDet/2.0 +fAirBoxFrontLengthDet + fNewRhombiRadiusDet ;
 
-	x = 0;
-	y = 0;
-	z = distFromOriginDet;
+    x = 0;
+    y = 0;
+    z = distFromOriginDet;
 
-	G4ThreeVector move(DetectionSystemGriffin::TransX(x,y,z,theta,phi), DetectionSystemGriffin::TransY(x,y,z,theta,phi), DetectionSystemGriffin::TransZ(x,z,theta));
-	fAssembly->MakeImprint(expHallLog, move, rotate, 0, fSurfCheck);
-	fBackAndSideSuppressorShellAssembly->MakeImprint(expHallLog, move, rotate, 0, fSurfCheck);
+    G4ThreeVector move(DetectionSystemGriffin::TransX(x,y,z,theta,phi), DetectionSystemGriffin::TransY(x,y,z,theta,phi), DetectionSystemGriffin::TransZ(x,z,theta));
+    fAssembly->MakeImprint(expHallLog, move, rotate, 0, fSurfCheck);
+    fBackAndSideSuppressorShellAssembly->MakeImprint(expHallLog, move, rotate, 0, fSurfCheck);
 
-	z = distFromOrigin ; // This isolates the motion of the extension suppressors from the rest of the suppressors.
+    z = distFromOrigin ; // This isolates the motion of the extension suppressors from the rest of the suppressors.
 
-	move = G4ThreeVector(DetectionSystemGriffin::TransX(x,y,z,theta,phi), DetectionSystemGriffin::TransY(x,y,z,theta,phi), DetectionSystemGriffin::TransZ(x,z,theta));
+    move = G4ThreeVector(DetectionSystemGriffin::TransX(x,y,z,theta,phi), DetectionSystemGriffin::TransY(x,y,z,theta,phi), DetectionSystemGriffin::TransZ(x,z,theta));
 
-	fExtensionSuppressorShellAssembly->MakeImprint(expHallLog, move, rotate, 0, fSurfCheck);
-	fHevimetAssembly->MakeImprint(expHallLog, move, rotate, 0, fSurfCheck) ;
+    fExtensionSuppressorShellAssembly->MakeImprint(expHallLog, move, rotate, 0, fSurfCheck);
+    fHevimetAssembly->MakeImprint(expHallLog, move, rotate, 0, fSurfCheck) ;
 
-	fCopyNumber = fBackSuppressorCopyNumber + detectorNumber*4;
+    fCopyNumber = fBackSuppressorCopyNumber + detectorNumber*4;
 
-	// Back Suppressors
-	if(fIncludeBackSuppressors) {
-		x0 = (fDetectorTotalWidth/4.0);
-		y0 = (fDetectorTotalWidth/4.0);
-		z0 = (fBackBGOThickness - fCanFaceThickness)/2.0 + fSuppressorShellThickness
-			+ fDetectorTotalLength + fBGOCanSeperation + fShift + fAppliedBackShift + distFromOriginDet;
+    // Back Suppressors
+    if(fIncludeBackSuppressors) {
+        x0 = (fDetectorTotalWidth/4.0);
+        y0 = (fDetectorTotalWidth/4.0);
+        z0 = (fBackBGOThickness - fCanFaceThickness)/2.0 + fSuppressorShellThickness
+            + fDetectorTotalLength + fBGOCanSeperation + fShift + fAppliedBackShift + distFromOriginDet;
 
-		G4RotationMatrix* rotateBackQuarterSuppressor[4];
-		G4ThreeVector moveBackQuarterSuppressor[4];
+        G4RotationMatrix* rotateBackQuarterSuppressor[4];
+        G4ThreeVector moveBackQuarterSuppressor[4];
 
-		for(i=0; i<4; i++) {
-			rotateBackQuarterSuppressor[i] = new G4RotationMatrix;
-			rotateBackQuarterSuppressor[i]->rotateX(M_PI/2.0-M_PI/2.0*i);
-			rotateBackQuarterSuppressor[i]->rotateX(alpha);
-			rotateBackQuarterSuppressor[i]->rotateY(beta);
-			rotateBackQuarterSuppressor[i]->rotateZ(gamma);
+        for(i=0; i<4; i++) {
+            rotateBackQuarterSuppressor[i] = new G4RotationMatrix;
+            rotateBackQuarterSuppressor[i]->rotateX(M_PI/2.0-M_PI/2.0*i);
+            rotateBackQuarterSuppressor[i]->rotateX(alpha);
+            rotateBackQuarterSuppressor[i]->rotateY(beta);
+            rotateBackQuarterSuppressor[i]->rotateZ(gamma);
 
-			x = -x0*pow(-1, floor((i+1)/2));
-			y = -y0*pow(-1, floor((i+2)/2));
-			z = z0;
+            x = -x0*pow(-1, floor((i+1)/2));
+            y = -y0*pow(-1, floor((i+2)/2));
+            z = z0;
 
-			moveBackQuarterSuppressor[i] = G4ThreeVector(DetectionSystemGriffin::TransX(x,y,z,theta,phi),DetectionSystemGriffin::TransY(x,y,z,theta,phi),DetectionSystemGriffin::TransZ(x,z,theta));
+            moveBackQuarterSuppressor[i] = G4ThreeVector(DetectionSystemGriffin::TransX(x,y,z,theta,phi),DetectionSystemGriffin::TransY(x,y,z,theta,phi),DetectionSystemGriffin::TransZ(x,z,theta));
 
-			fSuppressorBackAssembly->MakeImprint(expHallLog, moveBackQuarterSuppressor[i], rotateBackQuarterSuppressor[i], fCopyNumber++, fSurfCheck);
-		}
-	}
+            fSuppressorBackAssembly->MakeImprint(expHallLog, moveBackQuarterSuppressor[i], rotateBackQuarterSuppressor[i], fCopyNumber++, fSurfCheck);
+        }
+    }
 
-	// Now Side Suppressors
-	/////////////////////////////////////////////////////////////////////
-	// Note : Left and Right are read from the BACK of the detector
-	// Suppressors 1 and 2 cover germanium 1
-	// Suppressors 3 and 4 cover germanium 2
-	// Suppressors 5 and 6 cover germanium 3
-	// Suppressors 7 and 8 cover germanium 4
-	/////////////////////////////////////////////////////////////////////
-	fCopyNumber = fRightSuppressorSideCopyNumber + detectorNumber*4;
-	fCopyNumberTwo = fLeftSuppressorSideCopyNumber + detectorNumber*4;
+    // Now Side Suppressors
+    /////////////////////////////////////////////////////////////////////
+    // Note : Left and Right are read from the BACK of the detector
+    // Suppressors 1 and 2 cover germanium 1
+    // Suppressors 3 and 4 cover germanium 2
+    // Suppressors 5 and 6 cover germanium 3
+    // Suppressors 7 and 8 cover germanium 4
+    /////////////////////////////////////////////////////////////////////
+    fCopyNumber = fRightSuppressorSideCopyNumber + detectorNumber*4;
+    fCopyNumberTwo = fLeftSuppressorSideCopyNumber + detectorNumber*4;
 
-	// Replacement for sideSuppressorLength
-	G4double shellSideSuppressorLength = fSideSuppressorLength + (fSuppressorShellThickness*2.0);
+    // Replacement for sideSuppressorLength
+    G4double shellSideSuppressorLength = fSideSuppressorLength + (fSuppressorShellThickness*2.0);
 
-	// Replacement for suppressorExtensionLength
-	G4double shellSuppressorExtensionLength = fSuppressorExtensionLength + (fSuppressorShellThickness*2.0)*(1.0/tan(fBentEndAngle)
-			- tan(fBentEndAngle));
+    // Replacement for suppressorExtensionLength
+    G4double shellSuppressorExtensionLength = fSuppressorExtensionLength + (fSuppressorShellThickness*2.0)*(1.0/tan(fBentEndAngle)
+            - tan(fBentEndAngle));
 
-	// Replacement for suppressorExtensionAngle: must totally recalculate
-	G4double shellSuppressorExtensionAngle = atan(((fSuppressorBackRadius
-					+ fBentEndLength +(fBGOCanSeperation
-						+ fSideBGOThickness + fSuppressorShellThickness*2.0)
-					/ tan(fBentEndAngle)
-					- (fSuppressorExtensionThickness + fSuppressorShellThickness * 2.0)
-					* sin(fBentEndAngle))
-				* tan(fBentEndAngle) -(fSuppressorForwardRadius + fHevimetTipThickness)
-				* sin(fBentEndAngle))/(shellSuppressorExtensionLength));
+    // Replacement for suppressorExtensionAngle: must totally recalculate
+    G4double shellSuppressorExtensionAngle = atan(((fSuppressorBackRadius
+                    + fBentEndLength +(fBGOCanSeperation
+                        + fSideBGOThickness + fSuppressorShellThickness*2.0)
+                    / tan(fBentEndAngle)
+                    - (fSuppressorExtensionThickness + fSuppressorShellThickness * 2.0)
+                    * sin(fBentEndAngle))
+                * tan(fBentEndAngle) -(fSuppressorForwardRadius + fHevimetTipThickness)
+                * sin(fBentEndAngle))/(shellSuppressorExtensionLength));
 
-	// these two parameters are for shifting the extensions back and out when in their BACK position
-	G4double extensionBackShift = fAirBoxFrontLength
-		- (fHevimetTipThickness + shellSuppressorExtensionLength
-				+ (fSuppressorExtensionThickness + fSuppressorShellThickness*2.0)
-				* tan(fBentEndAngle))
-		* cos(fBentEndAngle);
+    // these two parameters are for shifting the extensions back and out when in their BACK position
+    G4double extensionBackShift = fAirBoxFrontLength
+        - (fHevimetTipThickness + shellSuppressorExtensionLength
+                + (fSuppressorExtensionThickness + fSuppressorShellThickness*2.0)
+                * tan(fBentEndAngle))
+        * cos(fBentEndAngle);
 
-	G4double extensionRadialShift = extensionBackShift*tan(fBentEndAngle);
+    G4double extensionRadialShift = extensionBackShift*tan(fBentEndAngle);
 
-	if(fIncludeSideSuppressors) {
-		G4RotationMatrix* rotateSideSuppressor[8];
-		G4ThreeVector moveInnerSuppressor[8];
+    if(fIncludeSideSuppressors) {
+        G4RotationMatrix* rotateSideSuppressor[8];
+        G4ThreeVector moveInnerSuppressor[8];
 
-		x0 = fSideBGOThickness/2.0 + fSuppressorShellThickness + fDetectorTotalWidth/2.0 +fBGOCanSeperation;
-		y0 = (fDetectorTotalWidth/2.0 +fBGOCanSeperation + fSideBGOThickness/2.0)/2.0;
-		z0 = (shellSideSuppressorLength/2.0 -fCanFaceThickness/2.0 + fBentEndLength
-				+(fBGOCanSeperation + fBGOChoppedTip)/tan(fBentEndAngle) + fShift
-				+ fAppliedBackShift - fSuppressorShellThickness/2.0 + distFromOriginDet);
+        x0 = fSideBGOThickness/2.0 + fSuppressorShellThickness + fDetectorTotalWidth/2.0 +fBGOCanSeperation;
+        y0 = (fDetectorTotalWidth/2.0 +fBGOCanSeperation + fSideBGOThickness/2.0)/2.0;
+        z0 = (shellSideSuppressorLength/2.0 -fCanFaceThickness/2.0 + fBentEndLength
+                +(fBGOCanSeperation + fBGOChoppedTip)/tan(fBentEndAngle) + fShift
+                + fAppliedBackShift - fSuppressorShellThickness/2.0 + distFromOriginDet);
 
-		for(i=0; i<4; i++) {
-			rotateSideSuppressor[2*i] = new G4RotationMatrix;
-			rotateSideSuppressor[2*i]->rotateZ(M_PI/2.0);
-			rotateSideSuppressor[2*i]->rotateY(M_PI/2.0);
-			rotateSideSuppressor[2*i]->rotateX(M_PI/2.0-M_PI/2.0*i);
-			rotateSideSuppressor[2*i]->rotateX(alpha);
-			rotateSideSuppressor[2*i]->rotateY(beta);
-			rotateSideSuppressor[2*i]->rotateZ(gamma);
+        for(i=0; i<4; i++) {
+            rotateSideSuppressor[2*i] = new G4RotationMatrix;
+            rotateSideSuppressor[2*i]->rotateZ(M_PI/2.0);
+            rotateSideSuppressor[2*i]->rotateY(M_PI/2.0);
+            rotateSideSuppressor[2*i]->rotateX(M_PI/2.0-M_PI/2.0*i);
+            rotateSideSuppressor[2*i]->rotateX(alpha);
+            rotateSideSuppressor[2*i]->rotateY(beta);
+            rotateSideSuppressor[2*i]->rotateZ(gamma);
 
-			x = x0*cos((i-1)*M_PI/2.0) + y0*sin((i-1)*M_PI/2);
-			y = -x0*sin((i-1)*M_PI/2.0) + y0*cos((i-1)*M_PI/2);
-			z = z0;
+            x = x0*cos((i-1)*M_PI/2.0) + y0*sin((i-1)*M_PI/2);
+            y = -x0*sin((i-1)*M_PI/2.0) + y0*cos((i-1)*M_PI/2);
+            z = z0;
 
-			moveInnerSuppressor[i*2] = G4ThreeVector(DetectionSystemGriffin::TransX(x,y,z,theta,phi),DetectionSystemGriffin::TransY(x,y,z,theta,phi),DetectionSystemGriffin::TransZ(x,z,theta));
+            moveInnerSuppressor[i*2] = G4ThreeVector(DetectionSystemGriffin::TransX(x,y,z,theta,phi),DetectionSystemGriffin::TransY(x,y,z,theta,phi),DetectionSystemGriffin::TransZ(x,z,theta));
 
-			fRightSuppressorCasingAssembly->MakeImprint(expHallLog, moveInnerSuppressor[2*i], rotateSideSuppressor[2*i], fCopyNumber++, fSurfCheck);
+            fRightSuppressorCasingAssembly->MakeImprint(expHallLog, moveInnerSuppressor[2*i], rotateSideSuppressor[2*i], fCopyNumber++, fSurfCheck);
 
-			rotateSideSuppressor[2*i+1] = new G4RotationMatrix;
-			rotateSideSuppressor[2*i+1]->rotateY(-M_PI/2.0);
-			rotateSideSuppressor[2*i+1]->rotateX(-M_PI/2.0*(i+2));
-			rotateSideSuppressor[2*i+1]->rotateX(alpha);
-			rotateSideSuppressor[2*i+1]->rotateY(beta);
-			rotateSideSuppressor[2*i+1]->rotateZ(gamma);
+            rotateSideSuppressor[2*i+1] = new G4RotationMatrix;
+            rotateSideSuppressor[2*i+1]->rotateY(-M_PI/2.0);
+            rotateSideSuppressor[2*i+1]->rotateX(-M_PI/2.0*(i+2));
+            rotateSideSuppressor[2*i+1]->rotateX(alpha);
+            rotateSideSuppressor[2*i+1]->rotateY(beta);
+            rotateSideSuppressor[2*i+1]->rotateZ(gamma);
 
-			x = x0*sin(i*M_PI/2.0) + y0*cos(i*M_PI/2);
-			y = x0*cos(i*M_PI/2.0) - y0*sin(i*M_PI/2);
-			z = z0;
+            x = x0*sin(i*M_PI/2.0) + y0*cos(i*M_PI/2);
+            y = x0*cos(i*M_PI/2.0) - y0*sin(i*M_PI/2);
+            z = z0;
 
-			moveInnerSuppressor[i*2+1] = G4ThreeVector(DetectionSystemGriffin::TransX(x,y,z,theta,phi),DetectionSystemGriffin::TransY(x,y,z,theta,phi),DetectionSystemGriffin::TransZ(x,z,theta));
+            moveInnerSuppressor[i*2+1] = G4ThreeVector(DetectionSystemGriffin::TransX(x,y,z,theta,phi),DetectionSystemGriffin::TransY(x,y,z,theta,phi),DetectionSystemGriffin::TransZ(x,z,theta));
 
-			fLeftSuppressorCasingAssembly->MakeImprint(expHallLog, moveInnerSuppressor[2*i+1], rotateSideSuppressor[2*i+1], fCopyNumberTwo++, fSurfCheck);
-		}
-	}
+            fLeftSuppressorCasingAssembly->MakeImprint(expHallLog, moveInnerSuppressor[2*i+1], rotateSideSuppressor[2*i+1], fCopyNumberTwo++, fSurfCheck);
+        }
+    }
 
-	// now we add the side pieces of suppressor that extend out in front of the can when it's in the back position
-	fCopyNumber = fRightSuppressorExtensionCopyNumber + detectorNumber*4;
-	fCopyNumberTwo = fLeftSuppressorExtensionCopyNumber + detectorNumber*4;
+    // now we add the side pieces of suppressor that extend out in front of the can when it's in the back position
+    fCopyNumber = fRightSuppressorExtensionCopyNumber + detectorNumber*4;
+    fCopyNumberTwo = fLeftSuppressorExtensionCopyNumber + detectorNumber*4;
 
-	G4RotationMatrix* rotateExtension[8];
-	G4ThreeVector moveInnerExtension[8];
+    G4RotationMatrix* rotateExtension[8];
+    G4ThreeVector moveInnerExtension[8];
 
-	x0 =  - ((fSuppressorExtensionThickness/2.0 + fSuppressorShellThickness)
-			/ cos(fBentEndAngle)
-			+ (shellSuppressorExtensionLength/2.0 - (fSuppressorExtensionThickness
-					+ fSuppressorShellThickness*2.0)
-				* tan(fBentEndAngle)/2.0) * sin(fBentEndAngle) - (fSuppressorBackRadius
-				+ fBentEndLength + (fBGOCanSeperation + fSideBGOThickness
-					+ fSuppressorShellThickness*2.0)
-				/ tan(fBentEndAngle) - (fSuppressorExtensionThickness
-					+ fSuppressorShellThickness*2.0)
-				* sin(fBentEndAngle))
-			* tan(fBentEndAngle));
+    x0 =  - ((fSuppressorExtensionThickness/2.0 + fSuppressorShellThickness)
+            / cos(fBentEndAngle)
+            + (shellSuppressorExtensionLength/2.0 - (fSuppressorExtensionThickness
+                    + fSuppressorShellThickness*2.0)
+                * tan(fBentEndAngle)/2.0) * sin(fBentEndAngle) - (fSuppressorBackRadius
+                + fBentEndLength + (fBGOCanSeperation + fSideBGOThickness
+                    + fSuppressorShellThickness*2.0)
+                / tan(fBentEndAngle) - (fSuppressorExtensionThickness
+                    + fSuppressorShellThickness*2.0)
+                * sin(fBentEndAngle))
+            * tan(fBentEndAngle));
 
-	y0 =  (shellSuppressorExtensionLength*tan(shellSuppressorExtensionAngle)/2.0
-			+ (fSuppressorForwardRadius
-				+ fHevimetTipThickness)*sin(fBentEndAngle) - fBGOCanSeperation*2.0 - fDetectorPlacementCxn)/2.0;
+    y0 =  (shellSuppressorExtensionLength*tan(shellSuppressorExtensionAngle)/2.0
+            + (fSuppressorForwardRadius
+                + fHevimetTipThickness)*sin(fBentEndAngle) - fBGOCanSeperation*2.0 - fDetectorPlacementCxn)/2.0;
 
-	z0 =  - fCanFaceThickness/2.0 -(shellSuppressorExtensionLength/2.0
-			- (fSuppressorExtensionThickness
-				+ fSuppressorShellThickness*2.0)
-			* tan(fBentEndAngle)/2.0)
-		* cos(fBentEndAngle) +fBentEndLength +(fBGOCanSeperation
-				+ fSideBGOThickness
-				+ fSuppressorShellThickness*2.0)/tan(fBentEndAngle)
-		- (fSuppressorExtensionThickness + fSuppressorShellThickness*2.0)
-		* sin(fBentEndAngle) +fSuppShift + fSuppressorBackRadius
-		- fSuppressorForwardRadius
-		- fSuppressorShellThickness/2.0 + distFromOrigin;
-
-
-	if(!(fSuppressorPositionSelector) && fIncludeExtensionSuppressors)
-	{
-		// If the detectors are forward, put the extensions in the back position
-		// the placement of the extensions matches the placement of the sideSuppressor pieces
-
-		x0 += extensionRadialShift ;
-
-		z0 += extensionBackShift ;
+    z0 =  - fCanFaceThickness/2.0 -(shellSuppressorExtensionLength/2.0
+            - (fSuppressorExtensionThickness
+                + fSuppressorShellThickness*2.0)
+            * tan(fBentEndAngle)/2.0)
+        * cos(fBentEndAngle) +fBentEndLength +(fBGOCanSeperation
+                + fSideBGOThickness
+                + fSuppressorShellThickness*2.0)/tan(fBentEndAngle)
+        - (fSuppressorExtensionThickness + fSuppressorShellThickness*2.0)
+        * sin(fBentEndAngle) +fSuppShift + fSuppressorBackRadius
+        - fSuppressorForwardRadius
+        - fSuppressorShellThickness/2.0 + distFromOrigin;
 
 
-		for(i=0; i<4; i++)
-		{
-			rotateExtension[2*i] = new G4RotationMatrix;
-			rotateExtension[2*i]->rotateZ(M_PI/2.0);
-			rotateExtension[2*i]->rotateY(fBentEndAngle);
-			rotateExtension[2*i]->rotateX(M_PI/2.0 - M_PI/2.0*i);
-			rotateExtension[2*i]->rotateX(alpha);
-			rotateExtension[2*i]->rotateY(beta);
-			rotateExtension[2*i]->rotateZ(gamma);
+    if(!(fSuppressorPositionSelector) && fIncludeExtensionSuppressors)
+    {
+        // If the detectors are forward, put the extensions in the back position
+        // the placement of the extensions matches the placement of the sideSuppressor pieces
 
-			x = x0*cos((i-1)*M_PI/2.0) + y0*sin((i-1)*M_PI/2);
-			y = -x0*sin((i-1)*M_PI/2.0) + y0*cos((i-1)*M_PI/2);
-			z = z0;
+        x0 += extensionRadialShift ;
 
-			moveInnerExtension[2*i] = G4ThreeVector(DetectionSystemGriffin::TransX(x,y,z,theta,phi),DetectionSystemGriffin::TransY(x,y,z,theta,phi),DetectionSystemGriffin::TransZ(x,z,theta));
-			fRightSuppressorExtensionAssembly->MakeImprint(expHallLog, moveInnerExtension[2*i], rotateExtension[2*i], fCopyNumber++, fSurfCheck);
+        z0 += extensionBackShift ;
 
-			rotateExtension[2*i+1] = new G4RotationMatrix;
-			rotateExtension[2*i+1]->rotateY(M_PI/2.0);
-			rotateExtension[2*i+1]->rotateZ(M_PI/2.0 + fBentEndAngle);
-			rotateExtension[2*i+1]->rotateX(-M_PI/2.0*i);
-			rotateExtension[2*i+1]->rotateX(alpha);
-			rotateExtension[2*i+1]->rotateY(beta);
-			rotateExtension[2*i+1]->rotateZ(gamma);
 
-			x = x0*sin(i*M_PI/2.0) + y0*cos(i*M_PI/2);
-			y = x0*cos(i*M_PI/2.0) - y0*sin(i*M_PI/2);
-			z = z0;
+        for(i=0; i<4; i++)
+        {
+            rotateExtension[2*i] = new G4RotationMatrix;
+            rotateExtension[2*i]->rotateZ(M_PI/2.0);
+            rotateExtension[2*i]->rotateY(fBentEndAngle);
+            rotateExtension[2*i]->rotateX(M_PI/2.0 - M_PI/2.0*i);
+            rotateExtension[2*i]->rotateX(alpha);
+            rotateExtension[2*i]->rotateY(beta);
+            rotateExtension[2*i]->rotateZ(gamma);
 
-			moveInnerExtension[2*i+1] = G4ThreeVector(DetectionSystemGriffin::TransX(x,y,z,theta,phi),DetectionSystemGriffin::TransY(x,y,z,theta,phi),DetectionSystemGriffin::TransZ(x,z,theta));
-			fLeftSuppressorExtensionAssembly->MakeImprint(expHallLog, moveInnerExtension[2*i+1], rotateExtension[2*i+1], fCopyNumberTwo++, fSurfCheck);
-		}
+            x = x0*cos((i-1)*M_PI/2.0) + y0*sin((i-1)*M_PI/2);
+            y = -x0*sin((i-1)*M_PI/2.0) + y0*cos((i-1)*M_PI/2);
+            z = z0;
 
-	}//end if(detectors forward) statement
+            moveInnerExtension[2*i] = G4ThreeVector(DetectionSystemGriffin::TransX(x,y,z,theta,phi),DetectionSystemGriffin::TransY(x,y,z,theta,phi),DetectionSystemGriffin::TransZ(x,z,theta));
+            fRightSuppressorExtensionAssembly->MakeImprint(expHallLog, moveInnerExtension[2*i], rotateExtension[2*i], fCopyNumber++, fSurfCheck);
 
-	// Otherwise, put them forward
-	else if((fSuppressorPositionSelector == 1) && fIncludeExtensionSuppressors)
-	{
+            rotateExtension[2*i+1] = new G4RotationMatrix;
+            rotateExtension[2*i+1]->rotateY(M_PI/2.0);
+            rotateExtension[2*i+1]->rotateZ(M_PI/2.0 + fBentEndAngle);
+            rotateExtension[2*i+1]->rotateX(-M_PI/2.0*i);
+            rotateExtension[2*i+1]->rotateX(alpha);
+            rotateExtension[2*i+1]->rotateY(beta);
+            rotateExtension[2*i+1]->rotateZ(gamma);
 
-		for(i=0; i<4; i++)
-		{
+            x = x0*sin(i*M_PI/2.0) + y0*cos(i*M_PI/2);
+            y = x0*cos(i*M_PI/2.0) - y0*sin(i*M_PI/2);
+            z = z0;
 
-			rotateExtension[2*i] = new G4RotationMatrix;
-			rotateExtension[2*i]->rotateZ(M_PI/2.0);
-			rotateExtension[2*i]->rotateY(fBentEndAngle);
-			rotateExtension[2*i]->rotateX(M_PI/2.0-M_PI/2.0*i);
-			rotateExtension[2*i]->rotateX(alpha);
-			rotateExtension[2*i]->rotateY(beta);
-			rotateExtension[2*i]->rotateZ(gamma);
+            moveInnerExtension[2*i+1] = G4ThreeVector(DetectionSystemGriffin::TransX(x,y,z,theta,phi),DetectionSystemGriffin::TransY(x,y,z,theta,phi),DetectionSystemGriffin::TransZ(x,z,theta));
+            fLeftSuppressorExtensionAssembly->MakeImprint(expHallLog, moveInnerExtension[2*i+1], rotateExtension[2*i+1], fCopyNumberTwo++, fSurfCheck);
+        }
 
-			x = x0*cos((i-1)*M_PI/2.0) + y0*sin((i-1)*M_PI/2);
-			y = -x0*sin((i-1)*M_PI/2.0) + y0*cos((i-1)*M_PI/2);
-			z = z0;
+    }//end if(detectors forward) statement
 
-			moveInnerExtension[2*i] = G4ThreeVector(DetectionSystemGriffin::TransX(x,y,z,theta,phi),DetectionSystemGriffin::TransY(x,y,z,theta,phi),DetectionSystemGriffin::TransZ(x,z,theta));
-			fRightSuppressorExtensionAssembly->MakeImprint(expHallLog, moveInnerExtension[2*i], rotateExtension[2*i], fCopyNumber++, fSurfCheck);
+    // Otherwise, put them forward
+    else if((fSuppressorPositionSelector == 1) && fIncludeExtensionSuppressors)
+    {
 
-			rotateExtension[2*i+1] = new G4RotationMatrix;
-			rotateExtension[2*i+1]->rotateY(M_PI/2.0);
-			rotateExtension[2*i+1]->rotateZ(M_PI/2.0 + fBentEndAngle);
-			rotateExtension[2*i+1]->rotateX(-M_PI/2.0*i);
-			rotateExtension[2*i+1]->rotateX(alpha);
-			rotateExtension[2*i+1]->rotateY(beta);
-			rotateExtension[2*i+1]->rotateZ(gamma);
+        for(i=0; i<4; i++)
+        {
 
-			x = x0*sin(i*M_PI/2.0) + y0*cos(i*M_PI/2);
-			y = x0*cos(i*M_PI/2.0) - y0*sin(i*M_PI/2);
-			z = z0;
+            rotateExtension[2*i] = new G4RotationMatrix;
+            rotateExtension[2*i]->rotateZ(M_PI/2.0);
+            rotateExtension[2*i]->rotateY(fBentEndAngle);
+            rotateExtension[2*i]->rotateX(M_PI/2.0-M_PI/2.0*i);
+            rotateExtension[2*i]->rotateX(alpha);
+            rotateExtension[2*i]->rotateY(beta);
+            rotateExtension[2*i]->rotateZ(gamma);
 
-			moveInnerExtension[2*i+1] = G4ThreeVector(DetectionSystemGriffin::TransX(x,y,z,theta,phi),DetectionSystemGriffin::TransY(x,y,z,theta,phi),DetectionSystemGriffin::TransZ(x,z,theta));
-			fLeftSuppressorExtensionAssembly->MakeImprint(expHallLog, moveInnerExtension[2*i+1], rotateExtension[2*i+1], fCopyNumberTwo++, fSurfCheck);
-		}
+            x = x0*cos((i-1)*M_PI/2.0) + y0*sin((i-1)*M_PI/2);
+            y = -x0*sin((i-1)*M_PI/2.0) + y0*cos((i-1)*M_PI/2);
+            z = z0;
 
-	}//end if(detectors back) statement
-	return 1;
+            moveInnerExtension[2*i] = G4ThreeVector(DetectionSystemGriffin::TransX(x,y,z,theta,phi),DetectionSystemGriffin::TransY(x,y,z,theta,phi),DetectionSystemGriffin::TransZ(x,z,theta));
+            fRightSuppressorExtensionAssembly->MakeImprint(expHallLog, moveInnerExtension[2*i], rotateExtension[2*i], fCopyNumber++, fSurfCheck);
+
+            rotateExtension[2*i+1] = new G4RotationMatrix;
+            rotateExtension[2*i+1]->rotateY(M_PI/2.0);
+            rotateExtension[2*i+1]->rotateZ(M_PI/2.0 + fBentEndAngle);
+            rotateExtension[2*i+1]->rotateX(-M_PI/2.0*i);
+            rotateExtension[2*i+1]->rotateX(alpha);
+            rotateExtension[2*i+1]->rotateY(beta);
+            rotateExtension[2*i+1]->rotateZ(gamma);
+
+            x = x0*sin(i*M_PI/2.0) + y0*cos(i*M_PI/2);
+            y = x0*cos(i*M_PI/2.0) - y0*sin(i*M_PI/2);
+            z = z0;
+
+            moveInnerExtension[2*i+1] = G4ThreeVector(DetectionSystemGriffin::TransX(x,y,z,theta,phi),DetectionSystemGriffin::TransY(x,y,z,theta,phi),DetectionSystemGriffin::TransZ(x,z,theta));
+            fLeftSuppressorExtensionAssembly->MakeImprint(expHallLog, moveInnerExtension[2*i+1], rotateExtension[2*i+1], fCopyNumberTwo++, fSurfCheck);
+        }
+
+    }//end if(detectors back) statement
+    return 1;
 } // End PlaceEverythingButCrystals
 
 G4int DetectionSystemGriffin::PlaceDeadLayerSpecificCrystal(G4LogicalVolume* expHallLog, G4int detectorNumber, G4int positionNumber, G4bool posTigress) {
 
-	G4double theta  = fCoords[positionNumber][0]*deg;
-	G4double phi    = fCoords[positionNumber][1]*deg;
-	G4double alpha  = fCoords[positionNumber][2]*deg; // yaw
-	G4double beta   = fCoords[positionNumber][3]*deg; // pitch
-	G4double gamma  = fCoords[positionNumber][4]*deg; // roll
+    G4double theta  = fCoords[positionNumber][0]*deg;
+    G4double phi    = fCoords[positionNumber][1]*deg;
+    G4double alpha  = fCoords[positionNumber][2]*deg; // yaw
+    G4double beta   = fCoords[positionNumber][3]*deg; // pitch
+    G4double gamma  = fCoords[positionNumber][4]*deg; // roll
 
-	//In GRIFFIN upstream is now downstream relative to TIGRESS. However, we want to maintain the same numbering scheme as TIGRESS. Net result is that the lampshade angles change by 45 degrees.
-	if(posTigress && (positionNumber < 4 || positionNumber > 11)) {
-		phi       = fCoords[positionNumber][1]*deg - 45.0*deg;
-		gamma     = fCoords[positionNumber][4]*deg - 45.0*deg;
-	}
+    //In GRIFFIN upstream is now downstream relative to TIGRESS. However, we want to maintain the same numbering scheme as TIGRESS. Net result is that the lampshade angles change by 45 degrees.
+    if(posTigress && (positionNumber < 4 || positionNumber > 11)) {
+        phi       = fCoords[positionNumber][1]*deg - 45.0*deg;
+        gamma     = fCoords[positionNumber][4]*deg - 45.0*deg;
+    }
 
-	G4double x;
-	G4double y;
-	G4double z;
+    G4double x;
+    G4double y;
+    G4double z;
 
-	G4double x0, y0, z0;
+    G4double x0, y0, z0;
 
-	G4int i;
+    G4int i;
 
-	// positioning
-	G4double distFromOriginDet = fAirBoxBackLengthDet/2.0 +fAirBoxFrontLengthDet + fNewRhombiRadiusDet;
+    // positioning
+    G4double distFromOriginDet = fAirBoxBackLengthDet/2.0 +fAirBoxFrontLengthDet + fNewRhombiRadiusDet;
 
-	x0 = (fGermaniumWidth + fGermaniumSeparation)/2.0;
-	y0 = (fGermaniumWidth + fGermaniumSeparation)/2.0;
-	z0 = fGermaniumLength/2.0 + fCanFaceThickness/2.0 + fGermaniumDistFromCanFace + fShift + fAppliedBackShift + distFromOriginDet;
+    x0 = (fGermaniumWidth + fGermaniumSeparation)/2.0;
+    y0 = (fGermaniumWidth + fGermaniumSeparation)/2.0;
+    z0 = fGermaniumLength/2.0 + fCanFaceThickness/2.0 + fGermaniumDistFromCanFace + fShift + fAppliedBackShift + distFromOriginDet;
 
-	/////////////////////////////////////////////////////////////////////
-	// now we place all 4 of the 1/4 detectors using the LogicalVolume
-	// of the 1st, ensuring that they too will have the hole
-	/////////////////////////////////////////////////////////////////////
-	fCopyNumber = fGermaniumCopyNumber + detectorNumber*4;
+    /////////////////////////////////////////////////////////////////////
+    // now we place all 4 of the 1/4 detectors using the LogicalVolume
+    // of the 1st, ensuring that they too will have the hole
+    /////////////////////////////////////////////////////////////////////
+    fCopyNumber = fGermaniumCopyNumber + detectorNumber*4;
 
-	G4RotationMatrix* rotateGermanium[4];
-	G4ThreeVector moveGermanium[4];
+    G4RotationMatrix* rotateGermanium[4];
+    G4ThreeVector moveGermanium[4];
 
-	for(i=0; i<4; i++){
-		rotateGermanium[i] = new G4RotationMatrix;
-		rotateGermanium[i]->rotateY(-M_PI/2.0);
-		rotateGermanium[i]->rotateX(M_PI/2.0-M_PI/2.0*i);
-		rotateGermanium[i]->rotateX(alpha);
-		rotateGermanium[i]->rotateY(beta);
-		rotateGermanium[i]->rotateZ(gamma);
+    for(i=0; i<4; i++){
+        rotateGermanium[i] = new G4RotationMatrix;
+        rotateGermanium[i]->rotateY(-M_PI/2.0);
+        rotateGermanium[i]->rotateX(M_PI/2.0-M_PI/2.0*i);
+        rotateGermanium[i]->rotateX(alpha);
+        rotateGermanium[i]->rotateY(beta);
+        rotateGermanium[i]->rotateZ(gamma);
 
-		x = -x0*pow(-1, floor((i+1)/2));
-		y = -y0*pow(-1, floor((i+2)/2));
-		z = z0;
+        x = -x0*pow(-1, floor((i+1)/2));
+        y = -y0*pow(-1, floor((i+2)/2));
+        z = z0;
 
-		moveGermanium[i] = G4ThreeVector(DetectionSystemGriffin::TransX(x,y,z,theta,phi), DetectionSystemGriffin::TransY(x,y,z,theta,phi), DetectionSystemGriffin::TransZ(x,z,theta));
+        moveGermanium[i] = G4ThreeVector(DetectionSystemGriffin::TransX(x,y,z,theta,phi), DetectionSystemGriffin::TransY(x,y,z,theta,phi), DetectionSystemGriffin::TransZ(x,z,theta));
 
-		fGermaniumAssemblyCry[i]->MakeImprint(expHallLog, moveGermanium[i], rotateGermanium[i], fCopyNumber++, fSurfCheck);
-	}
+        fGermaniumAssemblyCry[i]->MakeImprint(expHallLog, moveGermanium[i], rotateGermanium[i], fCopyNumber++, fSurfCheck);
+    }
 
-	/////////////////////////////////////////////////////////////////////
-	// end germaniumBlock1Log
-	/////////////////////////////////////////////////////////////////////
+    /////////////////////////////////////////////////////////////////////
+    // end germaniumBlock1Log
+    /////////////////////////////////////////////////////////////////////
 
-	return 1;
+    return 1;
 } // end PlaceDeadLayerSpecificCrystal()
 
 
@@ -489,109 +489,112 @@ G4int DetectionSystemGriffin::PlaceDeadLayerSpecificCrystal(G4LogicalVolume* exp
 // BuildOneDetector()
 ///////////////////////////////////////////////////////////////////////
 void DetectionSystemGriffin::BuildOneDetector() {
-	// Build assembly volumes
-	// Holds all pieces that are not a detector (ie. the can, nitrogen tank, cold finger, electrodes, etc.)
-	fAssembly                           = new G4AssemblyVolume();
+    // Build assembly volumes
+    // Holds all pieces that are not a detector (ie. the can, nitrogen tank, cold finger, electrodes, etc.)
+    fAssembly                           = new G4AssemblyVolume();
 
-	// Holds germanium cores
-	fGermaniumAssembly                  = new G4AssemblyVolume();
+    // Holds germanium cores
+    fGermaniumAssembly                  = new G4AssemblyVolume();
 
-	// Holds left suppressors
-	fLeftSuppressorCasingAssembly       = new G4AssemblyVolume();
+    // Holds left suppressors
+    fLeftSuppressorCasingAssembly       = new G4AssemblyVolume();
 
-	// Holds right suppressors
-	fRightSuppressorCasingAssembly      = new G4AssemblyVolume();
+    // Holds right suppressors
+    fRightSuppressorCasingAssembly      = new G4AssemblyVolume();
 
-	// holds left suppressor extensions
-	fLeftSuppressorExtensionAssembly    = new G4AssemblyVolume();
+    // holds left suppressor extensions
+    fLeftSuppressorExtensionAssembly    = new G4AssemblyVolume();
 
-	// holds right suppressor extensions
-	fRightSuppressorExtensionAssembly   = new G4AssemblyVolume();
+    // holds right suppressor extensions
+    fRightSuppressorExtensionAssembly   = new G4AssemblyVolume();
 
-	// Holds back suppressors
-	fSuppressorBackAssembly             = new G4AssemblyVolume();
+    // Holds back suppressors
+    fSuppressorBackAssembly             = new G4AssemblyVolume();
 
-	// Holds the extension suppressor shells
-	fExtensionSuppressorShellAssembly   = new G4AssemblyVolume() ;
+    // Holds the extension suppressor shells
+    fExtensionSuppressorShellAssembly   = new G4AssemblyVolume() ;
 
-	// Holds the back and side suppressor shells
-	fBackAndSideSuppressorShellAssembly = new G4AssemblyVolume() ;
+    // Holds the back and side suppressor shells
+    fBackAndSideSuppressorShellAssembly = new G4AssemblyVolume() ;
 
-	// Holds the Hevimets
-	fHevimetAssembly                    = new G4AssemblyVolume() ;
+    // Holds the Hevimets
+    fHevimetAssembly                    = new G4AssemblyVolume() ;
 
-	ConstructComplexDetectorBlockWithDeadLayer();
-	BuildelectrodeMatElectrodes();
+    ConstructComplexDetectorBlockWithDeadLayer();
+    BuildelectrodeMatElectrodes();
 
-	ConstructDetector();
+    ConstructDetector();
 
-	// Include BGOs?
-	if(fBGOSelector == 1) {
-		ConstructNewSuppressorCasingWithShells() ;
-	} else if(fBGOSelector == 0) {
-		//G4cout<<"Not building BGO "<<G4endl ;
-	} else {
-		G4cout<<"Error 234235"<<G4endl ;
-		exit(1);
-	}
+    // Include BGOs?
+    if(fBGOSelector == 1) {
+        ConstructNewSuppressorCasingWithShells() ;
+    } else if(fBGOSelector == 0) {
+        //G4cout<<"Not building BGO "<<G4endl ;
+    } else {
+        G4cout<<"Error 234235"<<G4endl ;
+        exit(1);
+    }
 
-	ConstructColdFinger();
+    ConstructColdFinger();
 
-	if(fSuppressorPositionSelector && fHevimetSelector)
-		ConstructNewHeavyMet();
+    if(fSuppressorPositionSelector && fHevimetSelector)
+        ConstructNewHeavyMet();
 
 } // end BuildOneDetector()
 
 void DetectionSystemGriffin::BuildEverythingButCrystals() {
-	// Build assembly volumes
-	fAssembly                           = new G4AssemblyVolume();
-	fLeftSuppressorCasingAssembly       = new G4AssemblyVolume();
-	fRightSuppressorCasingAssembly      = new G4AssemblyVolume();
-	fLeftSuppressorExtensionAssembly    = new G4AssemblyVolume();
-	fRightSuppressorExtensionAssembly   = new G4AssemblyVolume();
-	fSuppressorBackAssembly             = new G4AssemblyVolume();
+    // Build assembly volumes
+    fAssembly                           = new G4AssemblyVolume();
+    fLeftSuppressorCasingAssembly       = new G4AssemblyVolume();
+    fRightSuppressorCasingAssembly      = new G4AssemblyVolume();
+    fLeftSuppressorExtensionAssembly    = new G4AssemblyVolume();
+    fRightSuppressorExtensionAssembly   = new G4AssemblyVolume();
+    fSuppressorBackAssembly             = new G4AssemblyVolume();
 
-	// Holds the extension suppressor shells
-	fExtensionSuppressorShellAssembly   = new G4AssemblyVolume() ;
+    // Holds the extension suppressor shells
+    fExtensionSuppressorShellAssembly   = new G4AssemblyVolume() ;
 
-	// Holds the back and side suppressor shells
-	fBackAndSideSuppressorShellAssembly = new G4AssemblyVolume() ;
+    // Holds the back and side suppressor shells
+    fBackAndSideSuppressorShellAssembly = new G4AssemblyVolume() ;
 
-	// Holds the hevimets
-	fHevimetAssembly                    = new G4AssemblyVolume() ;
+    // Holds the hevimets
+    fHevimetAssembly                    = new G4AssemblyVolume() ;
 
-	BuildelectrodeMatElectrodes();
+    BuildelectrodeMatElectrodes();
 
-	ConstructDetector();
+    ConstructDetector();
 
-	// Include BGOs?
-	if(fBGOSelector == 1) {
-		ConstructNewSuppressorCasingWithShells();
-	} else if(fBGOSelector == 0) {
-		//G4cout<<"Not building BGO "<<G4endl;
-	} else {
-		G4cout<<"Error 234235"<<G4endl;
-		exit(1);
-	}
+    // Include BGOs?
+    if(fBGOSelector == 1) {
+        // begin CRN 
+        G4int cry = 0;
+        ConstructNewSuppressorCasingWithShells(det, cry);
+        // end CRN 
+    } else if(fBGOSelector == 0) {
+        //G4cout<<"Not building BGO "<<G4endl;
+    } else {
+        G4cout<<"Error 234235"<<G4endl;
+        exit(1);
+    }
 
-	ConstructColdFinger();
+    ConstructColdFinger();
 
-	if(fSuppressorPositionSelector &&  fHevimetSelector)
-		ConstructNewHeavyMet();
+    if(fSuppressorPositionSelector &&  fHevimetSelector)
+        ConstructNewHeavyMet();
 
 
 } // end BuildEverythingButCrystals()
 
 
 void DetectionSystemGriffin::BuildDeadLayerSpecificCrystal(G4int det) {
-	fGermaniumAssemblyCry[0] = new G4AssemblyVolume();
-	fGermaniumAssemblyCry[1] = new G4AssemblyVolume();
-	fGermaniumAssemblyCry[2] = new G4AssemblyVolume();
-	fGermaniumAssemblyCry[3] = new G4AssemblyVolume();
+    fGermaniumAssemblyCry[0] = new G4AssemblyVolume();
+    fGermaniumAssemblyCry[1] = new G4AssemblyVolume();
+    fGermaniumAssemblyCry[2] = new G4AssemblyVolume();
+    fGermaniumAssemblyCry[3] = new G4AssemblyVolume();
 
-	for(G4int i=0; i<4; i++) {
-		ConstructComplexDetectorBlockWithDetectorSpecificDeadLayer(det,i);
-	}
+    for(G4int i=0; i<4; i++) {
+        ConstructComplexDetectorBlockWithDetectorSpecificDeadLayer(det,i);
+    }
 }
 
 
@@ -599,52 +602,52 @@ void DetectionSystemGriffin::BuildDeadLayerSpecificCrystal(G4int det) {
 // ConstructComplexDetectorBlock builds four quarters of germanium
 ///////////////////////////////////////////////////////////////////////
 void DetectionSystemGriffin::ConstructComplexDetectorBlock() {
-	G4Material* materialGe = G4Material::GetMaterial("G4_Ge");
-	if(!materialGe) {
-		G4cout<<" ----> Material G4_Ge not found, cannot build the detector shell! "<<G4endl;
-		exit(1);
-	}
-	G4Material* materialVacuum = G4Material::GetMaterial("Vacuum");
-	if(!materialVacuum) {
-		G4cout<<" ----> Material Vacuum not found, cannot build the detector shell! "<<G4endl;
-		exit(1);
-	}
+    G4Material* materialGe = G4Material::GetMaterial("G4_Ge");
+    if(!materialGe) {
+        G4cout<<" ----> Material G4_Ge not found, cannot build the detector shell! "<<G4endl;
+        exit(1);
+    }
+    G4Material* materialVacuum = G4Material::GetMaterial("Vacuum");
+    if(!materialVacuum) {
+        G4cout<<" ----> Material Vacuum not found, cannot build the detector shell! "<<G4endl;
+        exit(1);
+    }
 
-	G4VisAttributes* germaniumBlock1VisAtt = new G4VisAttributes(G4Colour(1.0,0.0,0.0));
-	germaniumBlock1VisAtt->SetVisibility(true);
+    G4VisAttributes* germaniumBlock1VisAtt = new G4VisAttributes(G4Colour(1.0,0.0,0.0));
+    germaniumBlock1VisAtt->SetVisibility(true);
 
-	G4VisAttributes* deadLayerVisAtt = new G4VisAttributes(G4Colour(0.80, 0.0, 0.0));
-	deadLayerVisAtt->SetVisibility(true);
+    G4VisAttributes* deadLayerVisAtt = new G4VisAttributes(G4Colour(0.80, 0.0, 0.0));
+    deadLayerVisAtt->SetVisibility(true);
 
-	G4VisAttributes* airVisAtt = new G4VisAttributes(G4Colour(0.8,0.8,0.8));
-	airVisAtt->SetVisibility(true);
+    G4VisAttributes* airVisAtt = new G4VisAttributes(G4Colour(0.8,0.8,0.8));
+    airVisAtt->SetVisibility(true);
 
-	G4VisAttributes* electrodeMatVisAtt = new G4VisAttributes(G4Colour(1.0,1.0,0.0));
-	electrodeMatVisAtt->SetVisibility(true);
+    G4VisAttributes* electrodeMatVisAtt = new G4VisAttributes(G4Colour(1.0,1.0,0.0));
+    electrodeMatVisAtt->SetVisibility(true);
 
-	G4SubtractionSolid* detector1 = QuarterDetector();
+    G4SubtractionSolid* detector1 = QuarterDetector();
 
-	fGermaniumBlock1Log = new G4LogicalVolume(detector1, materialGe, "germaniumBlock1Log", 0, 0, 0);
-	fGermaniumBlock1Log->SetVisAttributes(germaniumBlock1VisAtt);
+    fGermaniumBlock1Log = new G4LogicalVolume(detector1, materialGe, "germaniumBlock1Log", 0, 0, 0);
+    fGermaniumBlock1Log->SetVisAttributes(germaniumBlock1VisAtt);
 
-	fGermaniumAssembly->AddPlacedVolume(fGermaniumBlock1Log, fMoveNull, fRotateNull);
+    fGermaniumAssembly->AddPlacedVolume(fGermaniumBlock1Log, fMoveNull, fRotateNull);
 
-	// now we make the hole that will go in the back of each quarter detector,
-	G4double startAngle = 0.0*M_PI;
-	G4double finalAngle = 2.0*M_PI;
-	G4double holeRadius = fGermaniumHoleRadius;
-	G4double holeHalfLengthZ = (fGermaniumLength -fGermaniumHoleDistFromFace)/2.0;
+    // now we make the hole that will go in the back of each quarter detector,
+    G4double startAngle = 0.0*M_PI;
+    G4double finalAngle = 2.0*M_PI;
+    G4double holeRadius = fGermaniumHoleRadius;
+    G4double holeHalfLengthZ = (fGermaniumLength -fGermaniumHoleDistFromFace)/2.0;
 
 
-	G4Tubs* holeTubs = new G4Tubs("holeTubs", 0.0, holeRadius, holeHalfLengthZ, startAngle, finalAngle);
+    G4Tubs* holeTubs = new G4Tubs("holeTubs", 0.0, holeRadius, holeHalfLengthZ, startAngle, finalAngle);
 
-	G4ThreeVector moveHole(fGermaniumShift, -(fGermaniumShift),
-			-((fGermaniumHoleDistFromFace)));
+    G4ThreeVector moveHole(fGermaniumShift, -(fGermaniumShift),
+            -((fGermaniumHoleDistFromFace)));
 
-	fGermaniumHoleLog = new G4LogicalVolume(holeTubs, materialVacuum, "germaniumHoleLog", 0, 0, 0);
-	fGermaniumHoleLog->SetVisAttributes(airVisAtt);
+    fGermaniumHoleLog = new G4LogicalVolume(holeTubs, materialVacuum, "germaniumHoleLog", 0, 0, 0);
+    fGermaniumHoleLog->SetVisAttributes(airVisAtt);
 
-	fGermaniumAssembly->AddPlacedVolume(fGermaniumHoleLog, moveHole, fRotateNull);
+    fGermaniumAssembly->AddPlacedVolume(fGermaniumHoleLog, moveHole, fRotateNull);
 
 }//end ::ConstructComplexDetectorBlock
 
@@ -653,191 +656,191 @@ void DetectionSystemGriffin::ConstructComplexDetectorBlock() {
 // germanium, with dead layers
 ///////////////////////////////////////////////////////////////////////
 void DetectionSystemGriffin::ConstructComplexDetectorBlockWithDeadLayer() {
-	G4Material* materialGe = G4Material::GetMaterial("G4_Ge");
-	if(!materialGe) {
-		G4cout<<" ----> Material G4_Ge not found, cannot build the detector shell! "<<G4endl;
-		exit(1);
-	}
-	G4Material* materialVacuum = G4Material::GetMaterial("Vacuum");
-	if(!materialVacuum) {
-		G4cout<<" ----> Material Vacuum not found, cannot build the detector shell! "<<G4endl;
-		exit(1);
-	}
+    G4Material* materialGe = G4Material::GetMaterial("G4_Ge");
+    if(!materialGe) {
+        G4cout<<" ----> Material G4_Ge not found, cannot build the detector shell! "<<G4endl;
+        exit(1);
+    }
+    G4Material* materialVacuum = G4Material::GetMaterial("Vacuum");
+    if(!materialVacuum) {
+        G4cout<<" ----> Material Vacuum not found, cannot build the detector shell! "<<G4endl;
+        exit(1);
+    }
 
-	G4VisAttributes* germaniumBlock1VisAtt = new G4VisAttributes(G4Colour(1.0,0.0,0.0));
-	germaniumBlock1VisAtt->SetVisibility(true);
+    G4VisAttributes* germaniumBlock1VisAtt = new G4VisAttributes(G4Colour(1.0,0.0,0.0));
+    germaniumBlock1VisAtt->SetVisibility(true);
 
-	G4VisAttributes* deadLayerVisAtt = new G4VisAttributes(G4Colour(0.80, 0.0, 0.0));
-	deadLayerVisAtt->SetVisibility(true);
+    G4VisAttributes* deadLayerVisAtt = new G4VisAttributes(G4Colour(0.80, 0.0, 0.0));
+    deadLayerVisAtt->SetVisibility(true);
 
-	G4VisAttributes* airVisAtt = new G4VisAttributes(G4Colour(0.8,0.8,0.8));
-	airVisAtt->SetVisibility(true);
+    G4VisAttributes* airVisAtt = new G4VisAttributes(G4Colour(0.8,0.8,0.8));
+    airVisAtt->SetVisibility(true);
 
-	G4VisAttributes* electrodeMatVisAtt = new G4VisAttributes(G4Colour(1.0,1.0,0.0));
-	electrodeMatVisAtt->SetVisibility(true);
+    G4VisAttributes* electrodeMatVisAtt = new G4VisAttributes(G4Colour(1.0,1.0,0.0));
+    electrodeMatVisAtt->SetVisibility(true);
 
-	G4SubtractionSolid* detector1 = QuarterDetector();
+    G4SubtractionSolid* detector1 = QuarterDetector();
 
-	fGermaniumBlock1Log = new G4LogicalVolume(detector1, materialGe, "germaniumBlock1Log", 0, 0, 0);
-	fGermaniumBlock1Log->SetVisAttributes(germaniumBlock1VisAtt);
+    fGermaniumBlock1Log = new G4LogicalVolume(detector1, materialGe, "germaniumBlock1Log", 0, 0, 0);
+    fGermaniumBlock1Log->SetVisAttributes(germaniumBlock1VisAtt);
 
-	fGermaniumAssembly->AddPlacedVolume(fGermaniumBlock1Log, fMoveNull, fRotateNull);
+    fGermaniumAssembly->AddPlacedVolume(fGermaniumBlock1Log, fMoveNull, fRotateNull);
 
-	/////////////////////////////////////////////////////////////////////
-	// Since if we are using this method, the inner dead layer must be
-	// simulated, make a cylinder of germanium, place the air cylinder
-	// inside it, and then place the whole thing in the crystal
-	/////////////////////////////////////////////////////////////////////
-	G4double startAngle = 0.0*M_PI;
-	G4double finalAngle = 2.0*M_PI;
-	G4double deadLayerRadius = fGermaniumHoleRadius + fInnerDeadLayerThickness;
-	G4double deadLayerHalfLengthZ = (fGermaniumLength
-			- fGermaniumHoleDistFromFace
-			+ fInnerDeadLayerThickness)/2.0;
+    /////////////////////////////////////////////////////////////////////
+    // Since if we are using this method, the inner dead layer must be
+    // simulated, make a cylinder of germanium, place the air cylinder
+    // inside it, and then place the whole thing in the crystal
+    /////////////////////////////////////////////////////////////////////
+    G4double startAngle = 0.0*M_PI;
+    G4double finalAngle = 2.0*M_PI;
+    G4double deadLayerRadius = fGermaniumHoleRadius + fInnerDeadLayerThickness;
+    G4double deadLayerHalfLengthZ = (fGermaniumLength
+            - fGermaniumHoleDistFromFace
+            + fInnerDeadLayerThickness)/2.0;
 
-	G4Tubs* deadLayerTubs = new G4Tubs("deadLayerTubs", fGermaniumHoleRadius,
-			deadLayerRadius, deadLayerHalfLengthZ, startAngle,finalAngle);
+    G4Tubs* deadLayerTubs = new G4Tubs("deadLayerTubs", fGermaniumHoleRadius,
+            deadLayerRadius, deadLayerHalfLengthZ, startAngle,finalAngle);
 
-	G4ThreeVector moveDeadLayer(fGermaniumShift, -(fGermaniumShift),
-			-((fGermaniumHoleDistFromFace
-					- fInnerDeadLayerThickness)/2.0));
+    G4ThreeVector moveDeadLayer(fGermaniumShift, -(fGermaniumShift),
+            -((fGermaniumHoleDistFromFace
+                    - fInnerDeadLayerThickness)/2.0));
 
-	fInnerDeadLayerLog = new G4LogicalVolume(deadLayerTubs, materialGe, "innerDeadLayerLog", 0, 0, 0);
-	fInnerDeadLayerLog->SetVisAttributes(deadLayerVisAtt);
+    fInnerDeadLayerLog = new G4LogicalVolume(deadLayerTubs, materialGe, "innerDeadLayerLog", 0, 0, 0);
+    fInnerDeadLayerLog->SetVisAttributes(deadLayerVisAtt);
 
-	fGermaniumAssembly->AddPlacedVolume(fInnerDeadLayerLog, moveDeadLayer, fRotateNull);
+    fGermaniumAssembly->AddPlacedVolume(fInnerDeadLayerLog, moveDeadLayer, fRotateNull);
 
-	// dead layer cap
-	deadLayerRadius = fGermaniumHoleRadius;
-	G4double deadLayerCapHalfLengthZ = (fInnerDeadLayerThickness)/2.0;
+    // dead layer cap
+    deadLayerRadius = fGermaniumHoleRadius;
+    G4double deadLayerCapHalfLengthZ = (fInnerDeadLayerThickness)/2.0;
 
-	G4Tubs* deadLayerCap = new G4Tubs("deadLayerCap", 0.0,
-			deadLayerRadius, deadLayerCapHalfLengthZ, startAngle,finalAngle);
+    G4Tubs* deadLayerCap = new G4Tubs("deadLayerCap", 0.0,
+            deadLayerRadius, deadLayerCapHalfLengthZ, startAngle,finalAngle);
 
-	G4ThreeVector moveDeadLayerCap(fGermaniumShift, -(fGermaniumShift),
-			-((fGermaniumHoleDistFromFace - fInnerDeadLayerThickness)/2.0 - deadLayerHalfLengthZ + fInnerDeadLayerThickness/2.0));
+    G4ThreeVector moveDeadLayerCap(fGermaniumShift, -(fGermaniumShift),
+            -((fGermaniumHoleDistFromFace - fInnerDeadLayerThickness)/2.0 - deadLayerHalfLengthZ + fInnerDeadLayerThickness/2.0));
 
-	fInnerDeadLayerCapLog = new G4LogicalVolume(deadLayerCap, materialGe, "innerDeadLayerCapLog", 0, 0, 0);
-	fInnerDeadLayerCapLog->SetVisAttributes(deadLayerVisAtt);
+    fInnerDeadLayerCapLog = new G4LogicalVolume(deadLayerCap, materialGe, "innerDeadLayerCapLog", 0, 0, 0);
+    fInnerDeadLayerCapLog->SetVisAttributes(deadLayerVisAtt);
 
-	fGermaniumAssembly->AddPlacedVolume(fInnerDeadLayerCapLog, moveDeadLayerCap, fRotateNull);
+    fGermaniumAssembly->AddPlacedVolume(fInnerDeadLayerCapLog, moveDeadLayerCap, fRotateNull);
 
 
-	// now we make the hole that will go in the back of each quarter detector,
-	// and place it inside the dead layer cylinder
-	startAngle = 0.0*M_PI;
-	finalAngle = 2.0*M_PI;
-	G4double holeRadius = fGermaniumHoleRadius;
-	G4double holeHalfLengthZ = (fGermaniumLength -fGermaniumHoleDistFromFace)/2.0;
+    // now we make the hole that will go in the back of each quarter detector,
+    // and place it inside the dead layer cylinder
+    startAngle = 0.0*M_PI;
+    finalAngle = 2.0*M_PI;
+    G4double holeRadius = fGermaniumHoleRadius;
+    G4double holeHalfLengthZ = (fGermaniumLength -fGermaniumHoleDistFromFace)/2.0;
 
-	G4Tubs* holeTubs = new G4Tubs("holeTubs", 0.0, holeRadius, holeHalfLengthZ, startAngle, finalAngle);
+    G4Tubs* holeTubs = new G4Tubs("holeTubs", 0.0, holeRadius, holeHalfLengthZ, startAngle, finalAngle);
 
-	G4ThreeVector moveHole(fGermaniumShift, -(fGermaniumShift),
-			-((fGermaniumHoleDistFromFace
-					- fInnerDeadLayerThickness)/2.0)
-			-(fInnerDeadLayerThickness/2.0));
+    G4ThreeVector moveHole(fGermaniumShift, -(fGermaniumShift),
+            -((fGermaniumHoleDistFromFace
+                    - fInnerDeadLayerThickness)/2.0)
+            -(fInnerDeadLayerThickness/2.0));
 
-	fGermaniumHoleLog = new G4LogicalVolume(holeTubs, materialVacuum, "germaniumHoleLog", 0, 0, 0);
-	fGermaniumHoleLog->SetVisAttributes(airVisAtt);
+    fGermaniumHoleLog = new G4LogicalVolume(holeTubs, materialVacuum, "germaniumHoleLog", 0, 0, 0);
+    fGermaniumHoleLog->SetVisAttributes(airVisAtt);
 
-	fGermaniumAssembly->AddPlacedVolume(fGermaniumHoleLog, moveHole, fRotateNull);
+    fGermaniumAssembly->AddPlacedVolume(fGermaniumHoleLog, moveHole, fRotateNull);
 
 }//end ::ConstructComplexDetectorBlockWithDeadLayer
 
 void DetectionSystemGriffin::ConstructComplexDetectorBlockWithDetectorSpecificDeadLayer(G4int det, G4int cry) {
-	G4String strdet = G4UIcommand::ConvertToString(det);
-	G4String strcry = G4UIcommand::ConvertToString(cry);
+    G4String strdet = G4UIcommand::ConvertToString(det);
+    G4String strcry = G4UIcommand::ConvertToString(cry);
 
-	G4Material* materialGe = G4Material::GetMaterial("G4_Ge");
-	if(!materialGe) {
-		G4cout<<" ----> Material G4_Ge not found, cannot build the detector shell! "<<G4endl;
-		exit(1);
-	}
-	G4Material* materialVacuum = G4Material::GetMaterial("Vacuum");
-	if(!materialVacuum) {
-		G4cout<<" ----> Material Vacuum not found, cannot build the detector shell! "<<G4endl;
-		exit(1);
-	}
+    G4Material* materialGe = G4Material::GetMaterial("G4_Ge");
+    if(!materialGe) {
+        G4cout<<" ----> Material G4_Ge not found, cannot build the detector shell! "<<G4endl;
+        exit(1);
+    }
+    G4Material* materialVacuum = G4Material::GetMaterial("Vacuum");
+    if(!materialVacuum) {
+        G4cout<<" ----> Material Vacuum not found, cannot build the detector shell! "<<G4endl;
+        exit(1);
+    }
 
-	G4VisAttributes* germaniumBlock1VisAtt = new G4VisAttributes(fGriffinCrystalColours[cry]);
-	germaniumBlock1VisAtt->SetVisibility(true);
+    G4VisAttributes* germaniumBlock1VisAtt = new G4VisAttributes(fGriffinCrystalColours[cry]);
+    germaniumBlock1VisAtt->SetVisibility(true);
 
-	G4VisAttributes* deadLayerVisAtt = new G4VisAttributes(fGriffinDeadLayerColours[cry]);
-	deadLayerVisAtt->SetVisibility(true);
+    G4VisAttributes* deadLayerVisAtt = new G4VisAttributes(fGriffinDeadLayerColours[cry]);
+    deadLayerVisAtt->SetVisibility(true);
 
-	G4VisAttributes* airVisAtt = new G4VisAttributes(G4Colour(0.8,0.8,0.8));
-	airVisAtt->SetVisibility(true);
+    G4VisAttributes* airVisAtt = new G4VisAttributes(G4Colour(0.8,0.8,0.8));
+    airVisAtt->SetVisibility(true);
 
-	G4VisAttributes* electrodeMatVisAtt = new G4VisAttributes(G4Colour(1.0,1.0,0.0));
-	electrodeMatVisAtt->SetVisibility(true);
+    G4VisAttributes* electrodeMatVisAtt = new G4VisAttributes(G4Colour(1.0,1.0,0.0));
+    electrodeMatVisAtt->SetVisibility(true);
 
-	G4SubtractionSolid* detector1 = QuarterSpecificDeadLayerDetector(det, cry);
+    G4SubtractionSolid* detector1 = QuarterSpecificDeadLayerDetector(det, cry);
 
-	G4String germaniumBlock1Name = "germaniumDlsBlock1_" + strdet + "_" + strcry + "_log" ;
+    G4String germaniumBlock1Name = "germaniumDlsBlock1_" + strdet + "_" + strcry + "_log" ;
 
-	fGermaniumBlock1Log = new G4LogicalVolume(detector1, materialGe, germaniumBlock1Name, 0, 0, 0);
-	fGermaniumBlock1Log->SetVisAttributes(germaniumBlock1VisAtt);
+    fGermaniumBlock1Log = new G4LogicalVolume(detector1, materialGe, germaniumBlock1Name, 0, 0, 0);
+    fGermaniumBlock1Log->SetVisAttributes(germaniumBlock1VisAtt);
 
-	fGermaniumAssemblyCry[cry]->AddPlacedVolume(fGermaniumBlock1Log, fMoveNull, fRotateNull);
+    fGermaniumAssemblyCry[cry]->AddPlacedVolume(fGermaniumBlock1Log, fMoveNull, fRotateNull);
 
-	/////////////////////////////////////////////////////////////////////
-	// Since if we are using this method, the inner dead layer must be
-	// simulated, make a cylinder of germanium, place the air cylinder
-	// inside it, and then place the whole thing in the crystal
-	/////////////////////////////////////////////////////////////////////
-	G4double startAngle = 0.0*M_PI;
-	G4double finalAngle = 2.0*M_PI;
-	G4double deadLayerRadius = fGermaniumHoleRadius + fGriffinDeadLayers[det][cry];
-	G4double deadLayerHalfLengthZ = (fGermaniumLength
-			- fGermaniumHoleDistFromFace
-			+ fGriffinDeadLayers[det][cry])/2.0;
+    /////////////////////////////////////////////////////////////////////
+    // Since if we are using this method, the inner dead layer must be
+    // simulated, make a cylinder of germanium, place the air cylinder
+    // inside it, and then place the whole thing in the crystal
+    /////////////////////////////////////////////////////////////////////
+    G4double startAngle = 0.0*M_PI;
+    G4double finalAngle = 2.0*M_PI;
+    G4double deadLayerRadius = fGermaniumHoleRadius + fGriffinDeadLayers[det][cry];
+    G4double deadLayerHalfLengthZ = (fGermaniumLength
+            - fGermaniumHoleDistFromFace
+            + fGriffinDeadLayers[det][cry])/2.0;
 
-	G4Tubs* deadLayerTubs = new G4Tubs("deadLayerTubs", fGermaniumHoleRadius,
-			deadLayerRadius, deadLayerHalfLengthZ, startAngle,finalAngle);
+    G4Tubs* deadLayerTubs = new G4Tubs("deadLayerTubs", fGermaniumHoleRadius,
+            deadLayerRadius, deadLayerHalfLengthZ, startAngle,finalAngle);
 
-	G4ThreeVector moveDeadLayer(fGermaniumShift, -(fGermaniumShift),
-			-((fGermaniumHoleDistFromFace
-					- fGriffinDeadLayers[det][cry])/2.0));
+    G4ThreeVector moveDeadLayer(fGermaniumShift, -(fGermaniumShift),
+            -((fGermaniumHoleDistFromFace
+                    - fGriffinDeadLayers[det][cry])/2.0));
 
-	fInnerDeadLayerLog = new G4LogicalVolume(deadLayerTubs, materialGe, "innerDeadLayerLog", 0, 0, 0);
-	fInnerDeadLayerLog->SetVisAttributes(deadLayerVisAtt);
+    fInnerDeadLayerLog = new G4LogicalVolume(deadLayerTubs, materialGe, "innerDeadLayerLog", 0, 0, 0);
+    fInnerDeadLayerLog->SetVisAttributes(deadLayerVisAtt);
 
-	fGermaniumAssemblyCry[cry]->AddPlacedVolume(fInnerDeadLayerLog, moveDeadLayer, fRotateNull);
+    fGermaniumAssemblyCry[cry]->AddPlacedVolume(fInnerDeadLayerLog, moveDeadLayer, fRotateNull);
 
-	// dead layer cap
-	deadLayerRadius = fGermaniumHoleRadius;
-	G4double deadLayerCapHalfLengthZ = (fGriffinDeadLayers[det][cry])/2.0;
+    // dead layer cap
+    deadLayerRadius = fGermaniumHoleRadius;
+    G4double deadLayerCapHalfLengthZ = (fGriffinDeadLayers[det][cry])/2.0;
 
-	G4Tubs* deadLayerCap = new G4Tubs("deadLayerCap", 0.0,
-			deadLayerRadius, deadLayerCapHalfLengthZ, startAngle,finalAngle);
+    G4Tubs* deadLayerCap = new G4Tubs("deadLayerCap", 0.0,
+            deadLayerRadius, deadLayerCapHalfLengthZ, startAngle,finalAngle);
 
-	G4ThreeVector moveDeadLayerCap(fGermaniumShift, -(fGermaniumShift),
-			-((fGermaniumHoleDistFromFace - fGriffinDeadLayers[det][cry])/2.0 - deadLayerHalfLengthZ + fGriffinDeadLayers[det][cry]/2.0));
+    G4ThreeVector moveDeadLayerCap(fGermaniumShift, -(fGermaniumShift),
+            -((fGermaniumHoleDistFromFace - fGriffinDeadLayers[det][cry])/2.0 - deadLayerHalfLengthZ + fGriffinDeadLayers[det][cry]/2.0));
 
-	fInnerDeadLayerCapLog = new G4LogicalVolume(deadLayerCap, materialGe, "innerDeadLayerCapLog", 0, 0, 0);
-	fInnerDeadLayerCapLog->SetVisAttributes(deadLayerVisAtt);
+    fInnerDeadLayerCapLog = new G4LogicalVolume(deadLayerCap, materialGe, "innerDeadLayerCapLog", 0, 0, 0);
+    fInnerDeadLayerCapLog->SetVisAttributes(deadLayerVisAtt);
 
-	fGermaniumAssemblyCry[cry]->AddPlacedVolume(fInnerDeadLayerCapLog, moveDeadLayerCap, fRotateNull);
+    fGermaniumAssemblyCry[cry]->AddPlacedVolume(fInnerDeadLayerCapLog, moveDeadLayerCap, fRotateNull);
 
 
-	// now we make the hole that will go in the back of each quarter detector,
-	// and place it inside the dead layer cylinder
-	startAngle = 0.0*M_PI;
-	finalAngle = 2.0*M_PI;
-	G4double holeRadius = fGermaniumHoleRadius;
-	G4double holeHalfLengthZ = (fGermaniumLength -fGermaniumHoleDistFromFace)/2.0;
+    // now we make the hole that will go in the back of each quarter detector,
+    // and place it inside the dead layer cylinder
+    startAngle = 0.0*M_PI;
+    finalAngle = 2.0*M_PI;
+    G4double holeRadius = fGermaniumHoleRadius;
+    G4double holeHalfLengthZ = (fGermaniumLength -fGermaniumHoleDistFromFace)/2.0;
 
-	G4Tubs* holeTubs = new G4Tubs("holeTubs", 0.0, holeRadius, holeHalfLengthZ, startAngle, finalAngle);
+    G4Tubs* holeTubs = new G4Tubs("holeTubs", 0.0, holeRadius, holeHalfLengthZ, startAngle, finalAngle);
 
-	G4ThreeVector moveHole(fGermaniumShift, -(fGermaniumShift),
-			-((fGermaniumHoleDistFromFace
-					- fGriffinDeadLayers[det][cry])/2.0)
-			-(fGriffinDeadLayers[det][cry]/2.0));
+    G4ThreeVector moveHole(fGermaniumShift, -(fGermaniumShift),
+            -((fGermaniumHoleDistFromFace
+                    - fGriffinDeadLayers[det][cry])/2.0)
+            -(fGriffinDeadLayers[det][cry]/2.0));
 
-	fGermaniumHoleLog = new G4LogicalVolume(holeTubs, materialVacuum, "germaniumHoleLog", 0, 0, 0);
-	fGermaniumHoleLog->SetVisAttributes(airVisAtt);
+    fGermaniumHoleLog = new G4LogicalVolume(holeTubs, materialVacuum, "germaniumHoleLog", 0, 0, 0);
+    fGermaniumHoleLog->SetVisAttributes(airVisAtt);
 
-	fGermaniumAssemblyCry[cry]->AddPlacedVolume(fGermaniumHoleLog, moveHole, fRotateNull);
+    fGermaniumAssemblyCry[cry]->AddPlacedVolume(fGermaniumHoleLog, moveHole, fRotateNull);
 
 }//end ::ConstructComplexDetectorBlockWithDetectorSpecificDeadLayer
 
@@ -847,48 +850,48 @@ void DetectionSystemGriffin::ConstructComplexDetectorBlockWithDetectorSpecificDe
 ///////////////////////////////////////////////////////////////////////
 void DetectionSystemGriffin::BuildelectrodeMatElectrodes() {
 
-	G4Material* electrodeMat = G4Material::GetMaterial(fElectrodeMaterial);
-	if(!electrodeMat) {
-		G4cout<<" ----> Electrode material "<<fElectrodeMaterial<<" not found, cannot build the detector shell! "<<G4endl;
-		exit(1);
-	}
+    G4Material* electrodeMat = G4Material::GetMaterial(fElectrodeMaterial);
+    if(!electrodeMat) {
+        G4cout<<" ----> Electrode material "<<fElectrodeMaterial<<" not found, cannot build the detector shell! "<<G4endl;
+        exit(1);
+    }
 
-	G4VisAttributes* electrodeMatVisAtt = new G4VisAttributes(G4Colour(1.0,1.0,0.0));
-	electrodeMatVisAtt->SetVisibility(true);
+    G4VisAttributes* electrodeMatVisAtt = new G4VisAttributes(G4Colour(1.0,1.0,0.0));
+    electrodeMatVisAtt->SetVisibility(true);
 
-	// electrodeMat layers between crystals - back part
-	G4RotationMatrix* rotateElectrodeMatBack = new G4RotationMatrix;
-	rotateElectrodeMatBack->rotateZ(M_PI/2.0);
-	G4ThreeVector moveInterCrystalElectrodeMatBack(fGermaniumLength/2.0
-			+ fGermaniumBentLength/2.0
-			+ fCanFaceThickness/2.0
-			+ fGermaniumDistFromCanFace + fShift
-			+ fAppliedBackShift, 0,0);
+    // electrodeMat layers between crystals - back part
+    G4RotationMatrix* rotateElectrodeMatBack = new G4RotationMatrix;
+    rotateElectrodeMatBack->rotateZ(M_PI/2.0);
+    G4ThreeVector moveInterCrystalElectrodeMatBack(fGermaniumLength/2.0
+            + fGermaniumBentLength/2.0
+            + fCanFaceThickness/2.0
+            + fGermaniumDistFromCanFace + fShift
+            + fAppliedBackShift, 0,0);
 
-	G4UnionSolid* interCrystalElectrodeMatBack = InterCrystalelectrodeMatBack();
+    G4UnionSolid* interCrystalElectrodeMatBack = InterCrystalelectrodeMatBack();
 
-	fInterCrystalElectrodeMatBackLog = new G4LogicalVolume(interCrystalElectrodeMatBack,
-			electrodeMat, "interCrystalElectrodeMatBackLog", 0, 0, 0);
-	fInterCrystalElectrodeMatBackLog->SetVisAttributes(electrodeMatVisAtt);
+    fInterCrystalElectrodeMatBackLog = new G4LogicalVolume(interCrystalElectrodeMatBack,
+            electrodeMat, "interCrystalElectrodeMatBackLog", 0, 0, 0);
+    fInterCrystalElectrodeMatBackLog->SetVisAttributes(electrodeMatVisAtt);
 
-	fAssembly->AddPlacedVolume(fInterCrystalElectrodeMatBackLog, moveInterCrystalElectrodeMatBack, rotateElectrodeMatBack);
+    fAssembly->AddPlacedVolume(fInterCrystalElectrodeMatBackLog, moveInterCrystalElectrodeMatBack, rotateElectrodeMatBack);
 
-	// electrodeMat between crystals - front part
-	G4RotationMatrix* rotateElectrodeMatFront = new G4RotationMatrix;
-	rotateElectrodeMatFront->rotateY(M_PI/2.0);
-	G4UnionSolid* interCrystalElectrodeMatFront = InterCrystalelectrodeMatFront();
+    // electrodeMat between crystals - front part
+    G4RotationMatrix* rotateElectrodeMatFront = new G4RotationMatrix;
+    rotateElectrodeMatFront->rotateY(M_PI/2.0);
+    G4UnionSolid* interCrystalElectrodeMatFront = InterCrystalelectrodeMatFront();
 
-	G4ThreeVector moveInterCrystalElectrodeMatFront(fGermaniumBentLength/2.0
-			+ fElectrodeMatStartingDepth/2.0
-			+ fCanFaceThickness/2.0
-			+ fGermaniumDistFromCanFace + fShift
-			+ fAppliedBackShift, 0,0);
+    G4ThreeVector moveInterCrystalElectrodeMatFront(fGermaniumBentLength/2.0
+            + fElectrodeMatStartingDepth/2.0
+            + fCanFaceThickness/2.0
+            + fGermaniumDistFromCanFace + fShift
+            + fAppliedBackShift, 0,0);
 
-	fInterCrystalElectrodeMatFrontLog = new G4LogicalVolume(interCrystalElectrodeMatFront,
-			electrodeMat, "interCrystalElectrodeMatFrontLog", 0, 0, 0);
-	fInterCrystalElectrodeMatFrontLog->SetVisAttributes(electrodeMatVisAtt);
+    fInterCrystalElectrodeMatFrontLog = new G4LogicalVolume(interCrystalElectrodeMatFront,
+            electrodeMat, "interCrystalElectrodeMatFrontLog", 0, 0, 0);
+    fInterCrystalElectrodeMatFrontLog->SetVisAttributes(electrodeMatVisAtt);
 
-	fAssembly->AddPlacedVolume(fInterCrystalElectrodeMatFrontLog, moveInterCrystalElectrodeMatFront, rotateElectrodeMatFront);
+    fAssembly->AddPlacedVolume(fInterCrystalElectrodeMatFrontLog, moveInterCrystalElectrodeMatFront, rotateElectrodeMatFront);
 }//end ::BuildelectrodeMatElectrodes
 
 ///////////////////////////////////////////////////////////////////////
@@ -898,316 +901,316 @@ void DetectionSystemGriffin::BuildelectrodeMatElectrodes() {
 ///////////////////////////////////////////////////////////////////////
 void DetectionSystemGriffin::ConstructDetector()  {
 
-	G4double x0, y0, z0, yMov, zMov;
-	G4int i;
-	G4RotationMatrix* rotatePiece[4] ;
-	G4ThreeVector movePiece[4] ;
+    G4double x0, y0, z0, yMov, zMov;
+    G4int i;
+    G4RotationMatrix* rotatePiece[4] ;
+    G4ThreeVector movePiece[4] ;
 
-	G4Material* structureMat = G4Material::GetMaterial(fStructureMaterial);
-	if(!structureMat) {
-		G4cout<<" ----> Structure material "<<fStructureMaterial<<" not found, cannot build the detector shell! "<<G4endl;
-		exit(1);
-	}
-	G4Material* liquidN2Material = G4Material::GetMaterial("LiquidN2");
-	if(!liquidN2Material) {
-		G4cout<<" ----> Material LiquidN2 not found, cannot build the detector shell! "<<G4endl;
-		exit(1);
-	}
-	// first we make the can's front face
-	G4Box* frontFace = SquareFrontFace();
-	fFrontFaceLog = new G4LogicalVolume(frontFace, structureMat, "frontFaceLog", 0, 0, 0);
+    G4Material* structureMat = G4Material::GetMaterial(fStructureMaterial);
+    if(!structureMat) {
+        G4cout<<" ----> Structure material "<<fStructureMaterial<<" not found, cannot build the detector shell! "<<G4endl;
+        exit(1);
+    }
+    G4Material* liquidN2Material = G4Material::GetMaterial("LiquidN2");
+    if(!liquidN2Material) {
+        G4cout<<" ----> Material LiquidN2 not found, cannot build the detector shell! "<<G4endl;
+        exit(1);
+    }
+    // first we make the can's front face
+    G4Box* frontFace = SquareFrontFace();
+    fFrontFaceLog = new G4LogicalVolume(frontFace, structureMat, "frontFaceLog", 0, 0, 0);
 
-	G4ThreeVector moveFrontFace(fShift + fAppliedBackShift, 0, 0);
+    G4ThreeVector moveFrontFace(fShift + fAppliedBackShift, 0, 0);
 
-	fAssembly->AddPlacedVolume(fFrontFaceLog, moveFrontFace, fRotateNull);
+    fAssembly->AddPlacedVolume(fFrontFaceLog, moveFrontFace, fRotateNull);
 
-	// now we put on the four angled side pieces
+    // now we put on the four angled side pieces
 
-	x0 = ((fBentEndLength)/2.0) + fShift + fAppliedBackShift ;
+    x0 = ((fBentEndLength)/2.0) + fShift + fAppliedBackShift ;
 
-	z0 = ((fCanFaceThickness - fBentEndLength) * tan(fBentEndAngle)
-			+ fDetectorTotalWidth - fCanFaceThickness)/2.0 ;
+    z0 = ((fCanFaceThickness - fBentEndLength) * tan(fBentEndAngle)
+            + fDetectorTotalWidth - fCanFaceThickness)/2.0 ;
 
-	G4Para* sidePiece[4] ;
+    G4Para* sidePiece[4] ;
 
-	for(i = 0 ; i < 4 ; i++)
-	{
-		// Top, Right, Bottom, Left
-		sidePiece[i] = BentSidePiece() ;
-		rotatePiece[i] = new G4RotationMatrix ;
+    for(i = 0 ; i < 4 ; i++)
+    {
+        // Top, Right, Bottom, Left
+        sidePiece[i] = BentSidePiece() ;
+        rotatePiece[i] = new G4RotationMatrix ;
 
-		// The left side is slightly different than the others, so this if statement is required. The order of rotation matters.
-		if(i == 3)
-		{
-			rotatePiece[i]->rotateX(-M_PI/2.0 + i*M_PI/2.0) ;
-			rotatePiece[i]->rotateY(fBentEndAngle) ;
-		}
-		else
-		{
-			rotatePiece[i]->rotateY(-fBentEndAngle) ;
-			rotatePiece[i]->rotateX(-M_PI/2.0 + i*M_PI/2.0) ;
-		}
+        // The left side is slightly different than the others, so this if statement is required. The order of rotation matters.
+        if(i == 3)
+        {
+            rotatePiece[i]->rotateX(-M_PI/2.0 + i*M_PI/2.0) ;
+            rotatePiece[i]->rotateY(fBentEndAngle) ;
+        }
+        else
+        {
+            rotatePiece[i]->rotateY(-fBentEndAngle) ;
+            rotatePiece[i]->rotateX(-M_PI/2.0 + i*M_PI/2.0) ;
+        }
 
-		yMov = z0 * cos(i * M_PI/2.0) ;
-		zMov = z0 * sin(i * M_PI/2.0) ;
+        yMov = z0 * cos(i * M_PI/2.0) ;
+        zMov = z0 * sin(i * M_PI/2.0) ;
 
-		movePiece[i] = G4ThreeVector(x0, yMov, zMov) ;
-	}
+        movePiece[i] = G4ThreeVector(x0, yMov, zMov) ;
+    }
 
-	fTopBentPieceLog = new G4LogicalVolume(sidePiece[0], structureMat, "topBentPiece", 0, 0, 0);
-	fAssembly->AddPlacedVolume(fTopBentPieceLog, movePiece[0], rotatePiece[0]);
+    fTopBentPieceLog = new G4LogicalVolume(sidePiece[0], structureMat, "topBentPiece", 0, 0, 0);
+    fAssembly->AddPlacedVolume(fTopBentPieceLog, movePiece[0], rotatePiece[0]);
 
-	fRightBentPieceLog = new G4LogicalVolume(sidePiece[1], structureMat, "rightBentPiece", 0, 0, 0);
-	fAssembly->AddPlacedVolume(fRightBentPieceLog, movePiece[1], rotatePiece[1]);
+    fRightBentPieceLog = new G4LogicalVolume(sidePiece[1], structureMat, "rightBentPiece", 0, 0, 0);
+    fAssembly->AddPlacedVolume(fRightBentPieceLog, movePiece[1], rotatePiece[1]);
 
-	fBottomBentPieceLog = new G4LogicalVolume(sidePiece[2], structureMat, "bottomBentPiece", 0, 0, 0);
-	fAssembly->AddPlacedVolume(fBottomBentPieceLog, movePiece[2], rotatePiece[2]);
+    fBottomBentPieceLog = new G4LogicalVolume(sidePiece[2], structureMat, "bottomBentPiece", 0, 0, 0);
+    fAssembly->AddPlacedVolume(fBottomBentPieceLog, movePiece[2], rotatePiece[2]);
 
-	fLeftBentPieceLog = new G4LogicalVolume(sidePiece[3], structureMat, "leftBentPiece", 0, 0, 0);
-	fAssembly->AddPlacedVolume(fRightBentPieceLog, movePiece[3], rotatePiece[3]);
+    fLeftBentPieceLog = new G4LogicalVolume(sidePiece[3], structureMat, "leftBentPiece", 0, 0, 0);
+    fAssembly->AddPlacedVolume(fRightBentPieceLog, movePiece[3], rotatePiece[3]);
 
 
-	//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-	// now we add the wedges to the edges of the face. These complete the angled side pieces
-	G4Trap* sideWedge[4] ;
+    // now we add the wedges to the edges of the face. These complete the angled side pieces
+    G4Trap* sideWedge[4] ;
 
-	x0 = fShift +fAppliedBackShift ;
+    x0 = fShift +fAppliedBackShift ;
 
-	y0 = (fDetectorTotalWidth/2.0) - (fBentEndLength * tan(fBentEndAngle))
-		+ (fCanFaceThickness/2.0) *tan(fBentEndAngle)/2.0 ;
+    y0 = (fDetectorTotalWidth/2.0) - (fBentEndLength * tan(fBentEndAngle))
+        + (fCanFaceThickness/2.0) *tan(fBentEndAngle)/2.0 ;
 
-	for(i = 0 ; i < 4 ; i++) {
-		// Top, Right, Bottom, Left
-		sideWedge[i] = CornerWedge() ;
-		rotatePiece[i] = new G4RotationMatrix ;
+    for(i = 0 ; i < 4 ; i++) {
+        // Top, Right, Bottom, Left
+        sideWedge[i] = CornerWedge() ;
+        rotatePiece[i] = new G4RotationMatrix ;
 
-		rotatePiece[i]->rotateX(M_PI/2.0) ;
-		rotatePiece[i]->rotateY(-M_PI/2.0) ;
-		rotatePiece[i]->rotateX(-M_PI/2.0 + i*M_PI/2.0) ;
+        rotatePiece[i]->rotateX(M_PI/2.0) ;
+        rotatePiece[i]->rotateY(-M_PI/2.0) ;
+        rotatePiece[i]->rotateX(-M_PI/2.0 + i*M_PI/2.0) ;
 
-		yMov = y0 * cos(i*M_PI/2.0) ;
-		zMov = y0 * sin(i*M_PI/2.0) ;
+        yMov = y0 * cos(i*M_PI/2.0) ;
+        zMov = y0 * sin(i*M_PI/2.0) ;
 
-		movePiece[i] = G4ThreeVector(x0, yMov, zMov) ;
-	}
+        movePiece[i] = G4ThreeVector(x0, yMov, zMov) ;
+    }
 
-	fTopWedgeLog = new G4LogicalVolume(sideWedge[0], structureMat, "topWedgeLog", 0, 0, 0);
-	fAssembly->AddPlacedVolume(fTopWedgeLog, movePiece[0], rotatePiece[0]);
+    fTopWedgeLog = new G4LogicalVolume(sideWedge[0], structureMat, "topWedgeLog", 0, 0, 0);
+    fAssembly->AddPlacedVolume(fTopWedgeLog, movePiece[0], rotatePiece[0]);
 
-	fRightWedgeLog = new G4LogicalVolume(sideWedge[1], structureMat, "rightWedgeLog", 0, 0, 0);
-	fAssembly->AddPlacedVolume(fRightWedgeLog, movePiece[1], rotatePiece[1]);
+    fRightWedgeLog = new G4LogicalVolume(sideWedge[1], structureMat, "rightWedgeLog", 0, 0, 0);
+    fAssembly->AddPlacedVolume(fRightWedgeLog, movePiece[1], rotatePiece[1]);
 
-	fBottomWedgeLog = new G4LogicalVolume(sideWedge[2], structureMat, "bottomWedgeLog", 0, 0, 0);
-	fAssembly->AddPlacedVolume(fBottomWedgeLog, movePiece[2], rotatePiece[2]);
+    fBottomWedgeLog = new G4LogicalVolume(sideWedge[2], structureMat, "bottomWedgeLog", 0, 0, 0);
+    fAssembly->AddPlacedVolume(fBottomWedgeLog, movePiece[2], rotatePiece[2]);
 
-	fLeftWedgeLog = new G4LogicalVolume(sideWedge[3], structureMat, "leftWedgeLog", 0, 0, 0);
-	fAssembly->AddPlacedVolume(fLeftWedgeLog, movePiece[3], rotatePiece[3]);
+    fLeftWedgeLog = new G4LogicalVolume(sideWedge[3], structureMat, "leftWedgeLog", 0, 0, 0);
+    fAssembly->AddPlacedVolume(fLeftWedgeLog, movePiece[3], rotatePiece[3]);
 
 
-	//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-	// now we add the rounded corners, made from a quarter of a cone
+    // now we add the rounded corners, made from a quarter of a cone
 
-	// Correction factor used to move the corner cones so as to avoid
-	// holes left in the can caused by the bent side pieces
+    // Correction factor used to move the corner cones so as to avoid
+    // holes left in the can caused by the bent side pieces
 
-	G4double holeEliminator = fCanFaceThickness *(1.0 -tan(fBentEndAngle));
-	G4Cons* coneLocation[4] ;
+    G4double holeEliminator = fCanFaceThickness *(1.0 -tan(fBentEndAngle));
+    G4Cons* coneLocation[4] ;
 
-	x0 = fBentEndLength/2.0 + fShift + fAppliedBackShift ;
+    x0 = fBentEndLength/2.0 + fShift + fAppliedBackShift ;
 
-	y0 = (fDetectorTotalWidth/2.0) - (fBentEndLength * tan(fBentEndAngle)) - holeEliminator ;
+    y0 = (fDetectorTotalWidth/2.0) - (fBentEndLength * tan(fBentEndAngle)) - holeEliminator ;
 
-	for(i = 0 ; i < 4 ; i++)
-	{
-		// Lower Left, Upper Left, Upper Right, Lower Right
-		coneLocation[i] = RoundedEndEdge() ;
-		rotatePiece[i] = new G4RotationMatrix ;
+    for(i = 0 ; i < 4 ; i++)
+    {
+        // Lower Left, Upper Left, Upper Right, Lower Right
+        coneLocation[i] = RoundedEndEdge() ;
+        rotatePiece[i] = new G4RotationMatrix ;
 
-		rotatePiece[i]->rotateY(M_PI/2.0) ;
-		rotatePiece[i]->rotateX(-M_PI/2.0 + i*M_PI/2.0) ;
+        rotatePiece[i]->rotateY(M_PI/2.0) ;
+        rotatePiece[i]->rotateX(-M_PI/2.0 + i*M_PI/2.0) ;
 
-		yMov = y0 * (-cos(i*M_PI/2.0) + sin(i*M_PI/2.0)) ;
-		zMov = y0 * (-cos(i*M_PI/2.0) - sin(i*M_PI/2.0)) ;
+        yMov = y0 * (-cos(i*M_PI/2.0) + sin(i*M_PI/2.0)) ;
+        zMov = y0 * (-cos(i*M_PI/2.0) - sin(i*M_PI/2.0)) ;
 
-		movePiece[i] = G4ThreeVector(x0, yMov, zMov) ;
-	}
+        movePiece[i] = G4ThreeVector(x0, yMov, zMov) ;
+    }
 
-	fLowerLeftConeLog = new G4LogicalVolume(coneLocation[0], structureMat, "lowerLeftConeLog", 0, 0, 0);
-	fAssembly->AddPlacedVolume(fLowerLeftConeLog, movePiece[0],  rotatePiece[0]);
+    fLowerLeftConeLog = new G4LogicalVolume(coneLocation[0], structureMat, "lowerLeftConeLog", 0, 0, 0);
+    fAssembly->AddPlacedVolume(fLowerLeftConeLog, movePiece[0],  rotatePiece[0]);
 
-	fUpperLeftConeLog = new G4LogicalVolume(coneLocation[1], structureMat, "upperLeftConeLog", 0, 0, 0);
-	fAssembly->AddPlacedVolume(fUpperLeftConeLog, movePiece[1], rotatePiece[1]);
+    fUpperLeftConeLog = new G4LogicalVolume(coneLocation[1], structureMat, "upperLeftConeLog", 0, 0, 0);
+    fAssembly->AddPlacedVolume(fUpperLeftConeLog, movePiece[1], rotatePiece[1]);
 
-	fUpperRightConeLog = new G4LogicalVolume(coneLocation[2], structureMat, "upperRightConeLog", 0, 0, 0);
-	fAssembly->AddPlacedVolume(fUpperRightConeLog, movePiece[2], rotatePiece[2]);
+    fUpperRightConeLog = new G4LogicalVolume(coneLocation[2], structureMat, "upperRightConeLog", 0, 0, 0);
+    fAssembly->AddPlacedVolume(fUpperRightConeLog, movePiece[2], rotatePiece[2]);
 
-	fLowerRightConeLog = new G4LogicalVolume(coneLocation[3], structureMat, "lowerRightConeLog", 0, 0, 0);
-	fAssembly->AddPlacedVolume(fLowerRightConeLog, movePiece[3], rotatePiece[3]);
+    fLowerRightConeLog = new G4LogicalVolume(coneLocation[3], structureMat, "lowerRightConeLog", 0, 0, 0);
+    fAssembly->AddPlacedVolume(fLowerRightConeLog, movePiece[3], rotatePiece[3]);
 
 
-	//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-	/* now we add the corner tubes which extend the rounded corners to the back of the can
-	 *
-	 * This is extremely similar to the previous loop but they are not exactly the same. While it would be
-	 * possible to consolidate them into one, they would only share the rotation variables, so it
-	 * might not be a huge benefit.
-	 */
+    /* now we add the corner tubes which extend the rounded corners to the back of the can
+     *
+     * This is extremely similar to the previous loop but they are not exactly the same. While it would be
+     * possible to consolidate them into one, they would only share the rotation variables, so it
+     * might not be a huge benefit.
+     */
 
-	G4Tubs* tubeLocation[4] ;
+    G4Tubs* tubeLocation[4] ;
 
-	x0 = (fDetectorTotalLength +fBentEndLength
-			- fRearPlateThickness -fCanFaceThickness)/2.0
-		+ fShift +fAppliedBackShift ;
+    x0 = (fDetectorTotalLength +fBentEndLength
+            - fRearPlateThickness -fCanFaceThickness)/2.0
+        + fShift +fAppliedBackShift ;
 
-	y0 = (fDetectorTotalWidth/2.0) - (fBentEndLength * tan(fBentEndAngle)) ;
+    y0 = (fDetectorTotalWidth/2.0) - (fBentEndLength * tan(fBentEndAngle)) ;
 
-	for(i = 0 ; i < 4 ; i++)
-	{
-		// Lower Left, Upper Left, Upper Right, Lower Right
-		tubeLocation[i] = CornerTube() ;
-		rotatePiece[i] = new G4RotationMatrix ;
-		rotatePiece[i]->rotateY(M_PI/2.0) ;
-		rotatePiece[i]->rotateX(-M_PI/2.0 + i*M_PI/2.0) ;
+    for(i = 0 ; i < 4 ; i++)
+    {
+        // Lower Left, Upper Left, Upper Right, Lower Right
+        tubeLocation[i] = CornerTube() ;
+        rotatePiece[i] = new G4RotationMatrix ;
+        rotatePiece[i]->rotateY(M_PI/2.0) ;
+        rotatePiece[i]->rotateX(-M_PI/2.0 + i*M_PI/2.0) ;
 
-		yMov = y0 * (-cos(i*M_PI/2.0) + sin(i*M_PI/2.0)) ;
-		zMov = y0 * (-cos(i*M_PI/2.0) - sin(i*M_PI/2.0)) ;
+        yMov = y0 * (-cos(i*M_PI/2.0) + sin(i*M_PI/2.0)) ;
+        zMov = y0 * (-cos(i*M_PI/2.0) - sin(i*M_PI/2.0)) ;
 
-		movePiece[i] = G4ThreeVector(x0, yMov, zMov) ;
+        movePiece[i] = G4ThreeVector(x0, yMov, zMov) ;
 
-	}
+    }
 
-	fLowerLeftTubeLog = new G4LogicalVolume(tubeLocation[0], structureMat, "lowerLeftTubeLog", 0, 0, 0);
-	fAssembly->AddPlacedVolume(fLowerLeftTubeLog, movePiece[0], rotatePiece[0]);
+    fLowerLeftTubeLog = new G4LogicalVolume(tubeLocation[0], structureMat, "lowerLeftTubeLog", 0, 0, 0);
+    fAssembly->AddPlacedVolume(fLowerLeftTubeLog, movePiece[0], rotatePiece[0]);
 
-	fUpperLeftTubeLog = new G4LogicalVolume(tubeLocation[1], structureMat, "upperLeftTubeLog", 0, 0, 0);
-	fAssembly->AddPlacedVolume(fUpperLeftTubeLog, movePiece[1], rotatePiece[1]);
+    fUpperLeftTubeLog = new G4LogicalVolume(tubeLocation[1], structureMat, "upperLeftTubeLog", 0, 0, 0);
+    fAssembly->AddPlacedVolume(fUpperLeftTubeLog, movePiece[1], rotatePiece[1]);
 
-	fUpperRightTubeLog = new G4LogicalVolume(tubeLocation[2], structureMat, "upperRightTubeLog", 0, 0, 0);
-	fAssembly->AddPlacedVolume(fUpperRightTubeLog, movePiece[2], rotatePiece[2]);
+    fUpperRightTubeLog = new G4LogicalVolume(tubeLocation[2], structureMat, "upperRightTubeLog", 0, 0, 0);
+    fAssembly->AddPlacedVolume(fUpperRightTubeLog, movePiece[2], rotatePiece[2]);
 
-	fLowerRightTubeLog = new G4LogicalVolume(tubeLocation[3], structureMat, "lowerRightTubeLog", 0, 0, 0);
-	fAssembly->AddPlacedVolume(fLowerRightTubeLog, movePiece[3], rotatePiece[3]);
+    fLowerRightTubeLog = new G4LogicalVolume(tubeLocation[3], structureMat, "lowerRightTubeLog", 0, 0, 0);
+    fAssembly->AddPlacedVolume(fLowerRightTubeLog, movePiece[3], rotatePiece[3]);
 
 
-	//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-	// now we add the side panels that extend from the bent pieces to the back of the can
+    // now we add the side panels that extend from the bent pieces to the back of the can
 
 
-	G4Box* panelLocation[4] ;
+    G4Box* panelLocation[4] ;
 
-	x0 = (fDetectorTotalLength + fBentEndLength - fRearPlateThickness - fCanFaceThickness)/2.0
-		+ fShift + fAppliedBackShift ;
+    x0 = (fDetectorTotalLength + fBentEndLength - fRearPlateThickness - fCanFaceThickness)/2.0
+        + fShift + fAppliedBackShift ;
 
-	y0 = 0 ;
+    y0 = 0 ;
 
-	z0 = (fDetectorTotalWidth - fCanSideThickness)/2.0 ;
+    z0 = (fDetectorTotalWidth - fCanSideThickness)/2.0 ;
 
-	for(i = 0 ; i < 4 ; i++)
-	{
-		// Right, Top, Left, Bottom
-		panelLocation[i] = SidePanel() ;
-		rotatePiece[i] = new G4RotationMatrix ;
-		rotatePiece[i]->rotateX(M_PI/2.0 - i*M_PI/2.0) ;
+    for(i = 0 ; i < 4 ; i++)
+    {
+        // Right, Top, Left, Bottom
+        panelLocation[i] = SidePanel() ;
+        rotatePiece[i] = new G4RotationMatrix ;
+        rotatePiece[i]->rotateX(M_PI/2.0 - i*M_PI/2.0) ;
 
-		yMov = z0*sin(i*M_PI/2.0) ;
-		zMov = z0*cos(i*M_PI/2.0) ;
+        yMov = z0*sin(i*M_PI/2.0) ;
+        zMov = z0*cos(i*M_PI/2.0) ;
 
-		movePiece[i] = G4ThreeVector(x0, yMov, zMov) ;
+        movePiece[i] = G4ThreeVector(x0, yMov, zMov) ;
 
-	}
+    }
 
-	fRightSidePanelLog = new G4LogicalVolume(panelLocation[0], structureMat, "rightSidePanelLog", 0, 0, 0);
-	fAssembly->AddPlacedVolume(fRightSidePanelLog, movePiece[0], rotatePiece[0]);
+    fRightSidePanelLog = new G4LogicalVolume(panelLocation[0], structureMat, "rightSidePanelLog", 0, 0, 0);
+    fAssembly->AddPlacedVolume(fRightSidePanelLog, movePiece[0], rotatePiece[0]);
 
-	fTopSidePanelLog = new G4LogicalVolume(panelLocation[1], structureMat, "topSidePanelLog", 0, 0, 0);
-	fAssembly->AddPlacedVolume(fTopSidePanelLog, movePiece[1], fRotateNull);
+    fTopSidePanelLog = new G4LogicalVolume(panelLocation[1], structureMat, "topSidePanelLog", 0, 0, 0);
+    fAssembly->AddPlacedVolume(fTopSidePanelLog, movePiece[1], fRotateNull);
 
-	fLeftSidePanelLog = new G4LogicalVolume(panelLocation[2], structureMat, "leftSidePanelLog", 0, 0, 0);
-	fAssembly->AddPlacedVolume(fLeftSidePanelLog, movePiece[2], rotatePiece[2]);
+    fLeftSidePanelLog = new G4LogicalVolume(panelLocation[2], structureMat, "leftSidePanelLog", 0, 0, 0);
+    fAssembly->AddPlacedVolume(fLeftSidePanelLog, movePiece[2], rotatePiece[2]);
 
-	fBottomSidePanelLog = new G4LogicalVolume(panelLocation[3], structureMat, "bottomSidePanelLog", 0, 0, 0);
-	fAssembly->AddPlacedVolume(fBottomSidePanelLog, movePiece[3], rotatePiece[3]);
+    fBottomSidePanelLog = new G4LogicalVolume(panelLocation[3], structureMat, "bottomSidePanelLog", 0, 0, 0);
+    fAssembly->AddPlacedVolume(fBottomSidePanelLog, movePiece[3], rotatePiece[3]);
 
-	//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-	// now we add the rear plate, which has a hole for the cold finger to pass through
-	G4SubtractionSolid* rearPlate = RearPlate();
+    // now we add the rear plate, which has a hole for the cold finger to pass through
+    G4SubtractionSolid* rearPlate = RearPlate();
 
-	G4RotationMatrix* rotateRearPlate = new G4RotationMatrix;
-	rotateRearPlate->rotateY(M_PI/2.0);
+    G4RotationMatrix* rotateRearPlate = new G4RotationMatrix;
+    rotateRearPlate->rotateY(M_PI/2.0);
 
-	x0 = fDetectorTotalLength -fCanFaceThickness/2.0
-		- fRearPlateThickness/2.0 +fShift
-		+ fAppliedBackShift ;
+    x0 = fDetectorTotalLength -fCanFaceThickness/2.0
+        - fRearPlateThickness/2.0 +fShift
+        + fAppliedBackShift ;
 
-	G4ThreeVector moveRearPlate(fDetectorTotalLength -fCanFaceThickness/2.0
-			- fRearPlateThickness/2.0 +fShift
-			+ fAppliedBackShift, 0, 0);
+    G4ThreeVector moveRearPlate(fDetectorTotalLength -fCanFaceThickness/2.0
+            - fRearPlateThickness/2.0 +fShift
+            + fAppliedBackShift, 0, 0);
 
-	fRearPlateLog = new G4LogicalVolume(rearPlate, structureMat, "rearPlateLog", 0, 0, 0);
+    fRearPlateLog = new G4LogicalVolume(rearPlate, structureMat, "rearPlateLog", 0, 0, 0);
 
-	fAssembly->AddPlacedVolume(fRearPlateLog, moveRearPlate, rotateRearPlate);
+    fAssembly->AddPlacedVolume(fRearPlateLog, moveRearPlate, rotateRearPlate);
 
-	// we know add the cold finger shell, which extends out the back of the can
-	G4Tubs* fingerShell = ColdFingerShell();
+    // we know add the cold finger shell, which extends out the back of the can
+    G4Tubs* fingerShell = ColdFingerShell();
 
-	G4RotationMatrix* rotateFingerShell = new G4RotationMatrix;
-	rotateFingerShell->rotateY(M_PI/2.0);
+    G4RotationMatrix* rotateFingerShell = new G4RotationMatrix;
+    rotateFingerShell->rotateY(M_PI/2.0);
 
-	G4ThreeVector moveFingerShell(fColdFingerShellLength/2.0 -fCanFaceThickness/2.0
-			+ fDetectorTotalLength +fShift
-			+ fAppliedBackShift, 0, 0);
+    G4ThreeVector moveFingerShell(fColdFingerShellLength/2.0 -fCanFaceThickness/2.0
+            + fDetectorTotalLength +fShift
+            + fAppliedBackShift, 0, 0);
 
-	fFingerShellLog = new G4LogicalVolume(fingerShell, structureMat, "fingerShellLog", 0, 0, 0);
+    fFingerShellLog = new G4LogicalVolume(fingerShell, structureMat, "fingerShellLog", 0, 0, 0);
 
-	fAssembly->AddPlacedVolume(fFingerShellLog, moveFingerShell, rotateFingerShell);
+    fAssembly->AddPlacedVolume(fFingerShellLog, moveFingerShell, rotateFingerShell);
 
-	// lastly we add the liquid nitrogen tank at the back, past the cold finger shell
-	G4Tubs* tank = LiquidNitrogenTank();
+    // lastly we add the liquid nitrogen tank at the back, past the cold finger shell
+    G4Tubs* tank = LiquidNitrogenTank();
 
-	G4RotationMatrix* rotateTank = new G4RotationMatrix;
-	rotateTank->rotateY(M_PI/2.0);
+    G4RotationMatrix* rotateTank = new G4RotationMatrix;
+    rotateTank->rotateY(M_PI/2.0);
 
-	G4ThreeVector moveTank((fCoolantLength -fCanFaceThickness)/2.0 + fDetectorTotalLength
-			+ fColdFingerShellLength + fShift +fAppliedBackShift, 0, 0);
+    G4ThreeVector moveTank((fCoolantLength -fCanFaceThickness)/2.0 + fDetectorTotalLength
+            + fColdFingerShellLength + fShift +fAppliedBackShift, 0, 0);
 
-	fTankLog = new G4LogicalVolume(tank, structureMat, "tankLog", 0, 0, 0);
+    fTankLog = new G4LogicalVolume(tank, structureMat, "tankLog", 0, 0, 0);
 
-	fAssembly->AddPlacedVolume(fTankLog, moveTank, rotateTank);
+    fAssembly->AddPlacedVolume(fTankLog, moveTank, rotateTank);
 
-	// lids
-	G4Tubs* lid = LiquidNitrogenTankLid();
+    // lids
+    G4Tubs* lid = LiquidNitrogenTankLid();
 
-	G4RotationMatrix* rotateLid = new G4RotationMatrix;
-	rotateLid->rotateY(M_PI/2.0);
+    G4RotationMatrix* rotateLid = new G4RotationMatrix;
+    rotateLid->rotateY(M_PI/2.0);
 
-	G4ThreeVector moveLid1(fCoolantLength/2.0 - fCoolantThickness/2.0 + (fCoolantLength -fCanFaceThickness)/2.0 + fDetectorTotalLength
-			+ fColdFingerShellLength + fShift +fAppliedBackShift, 0, 0);
-	G4ThreeVector moveLid2(-1.0*fCoolantLength/2.0 + fCoolantThickness/2.0 + (fCoolantLength -fCanFaceThickness)/2.0 + fDetectorTotalLength
-			+ fColdFingerShellLength + fShift +fAppliedBackShift, 0, 0);
+    G4ThreeVector moveLid1(fCoolantLength/2.0 - fCoolantThickness/2.0 + (fCoolantLength -fCanFaceThickness)/2.0 + fDetectorTotalLength
+            + fColdFingerShellLength + fShift +fAppliedBackShift, 0, 0);
+    G4ThreeVector moveLid2(-1.0*fCoolantLength/2.0 + fCoolantThickness/2.0 + (fCoolantLength -fCanFaceThickness)/2.0 + fDetectorTotalLength
+            + fColdFingerShellLength + fShift +fAppliedBackShift, 0, 0);
 
-	fTankLid1Log = new G4LogicalVolume(lid, structureMat, "tankLid1Log", 0, 0, 0);
-	fTankLid2Log = new G4LogicalVolume(lid, structureMat, "tankLid2Log", 0, 0, 0);
+    fTankLid1Log = new G4LogicalVolume(lid, structureMat, "tankLid1Log", 0, 0, 0);
+    fTankLid2Log = new G4LogicalVolume(lid, structureMat, "tankLid2Log", 0, 0, 0);
 
-	fAssembly->AddPlacedVolume(fTankLid1Log, moveLid1, rotateLid);
-	fAssembly->AddPlacedVolume(fTankLid2Log, moveLid2, rotateLid);
+    fAssembly->AddPlacedVolume(fTankLid1Log, moveLid1, rotateLid);
+    fAssembly->AddPlacedVolume(fTankLid2Log, moveLid2, rotateLid);
 
-	// LN2
-	G4Tubs* liquidn2 = LiquidNitrogen();
+    // LN2
+    G4Tubs* liquidn2 = LiquidNitrogen();
 
-	G4RotationMatrix* rotateLiquidn2 = new G4RotationMatrix;
-	rotateLiquidn2->rotateY(M_PI/2.0);
+    G4RotationMatrix* rotateLiquidn2 = new G4RotationMatrix;
+    rotateLiquidn2->rotateY(M_PI/2.0);
 
-	G4ThreeVector moveLiquidn2((fCoolantLength -fCanFaceThickness)/2.0 + fDetectorTotalLength
-			+ fColdFingerShellLength + fShift +fAppliedBackShift, 0, 0);
+    G4ThreeVector moveLiquidn2((fCoolantLength -fCanFaceThickness)/2.0 + fDetectorTotalLength
+            + fColdFingerShellLength + fShift +fAppliedBackShift, 0, 0);
 
-	fTankLiquidLog = new G4LogicalVolume(liquidn2, liquidN2Material, "tankLiquidLog", 0, 0, 0);
+    fTankLiquidLog = new G4LogicalVolume(liquidn2, liquidN2Material, "tankLiquidLog", 0, 0, 0);
 
-	fAssembly->AddPlacedVolume(fTankLiquidLog, moveLiquidn2, rotateLiquidn2);
+    fAssembly->AddPlacedVolume(fTankLiquidLog, moveLiquidn2, rotateLiquidn2);
 }// end::ConstructDetector
 
 ///////////////////////////////////////////////////////////////////////
@@ -1219,429 +1222,429 @@ void DetectionSystemGriffin::ConstructDetector()  {
 ///////////////////////////////////////////////////////////////////////
 void DetectionSystemGriffin::ConstructColdFinger() {
 
-	G4Material* materialAir = G4Material::GetMaterial("Air");
-	if(!materialAir) {
-		G4cout<<" ----> Material Air not found, cannot build the detector shell! "<<G4endl;
-		exit(1);
-	}
-	G4Material* structureMat = G4Material::GetMaterial(fStructureMaterial);
-	if(!structureMat) {
-		G4cout<<" ----> Structure material "<<fStructureMaterial<<" not found, cannot build the detector shell! "<<G4endl;
-		exit(1);
-	}
-	G4Material* electrodeMat = G4Material::GetMaterial(fElectrodeMaterial);
-	if(!electrodeMat) {
-		G4cout<<" ----> Electrode material "<<fElectrodeMaterial<<" not found, cannot build the detector shell! "<<G4endl;
-		exit(1);
-	}
+    G4Material* materialAir = G4Material::GetMaterial("Air");
+    if(!materialAir) {
+        G4cout<<" ----> Material Air not found, cannot build the detector shell! "<<G4endl;
+        exit(1);
+    }
+    G4Material* structureMat = G4Material::GetMaterial(fStructureMaterial);
+    if(!structureMat) {
+        G4cout<<" ----> Structure material "<<fStructureMaterial<<" not found, cannot build the detector shell! "<<G4endl;
+        exit(1);
+    }
+    G4Material* electrodeMat = G4Material::GetMaterial(fElectrodeMaterial);
+    if(!electrodeMat) {
+        G4cout<<" ----> Electrode material "<<fElectrodeMaterial<<" not found, cannot build the detector shell! "<<G4endl;
+        exit(1);
+    }
 
-	G4VisAttributes* coldFingerVisAtt = new G4VisAttributes(G4Colour(0.0,0.0,1.0));
-	coldFingerVisAtt->SetVisibility(true);
+    G4VisAttributes* coldFingerVisAtt = new G4VisAttributes(G4Colour(0.0,0.0,1.0));
+    coldFingerVisAtt->SetVisibility(true);
 
-	G4VisAttributes* structureMatVisAtt = new G4VisAttributes(G4Colour(1.0,1.0,1.0));
-	structureMatVisAtt->SetVisibility(true);
+    G4VisAttributes* structureMatVisAtt = new G4VisAttributes(G4Colour(1.0,1.0,1.0));
+    structureMatVisAtt->SetVisibility(true);
 
-	G4VisAttributes* airVisAtt = new G4VisAttributes(G4Colour(0.8,0.8,0.8));
-	airVisAtt->SetVisibility(true);
+    G4VisAttributes* airVisAtt = new G4VisAttributes(G4Colour(0.8,0.8,0.8));
+    airVisAtt->SetVisibility(true);
 
-	G4Box* endPlate = EndPlate();
+    G4Box* endPlate = EndPlate();
 
-	// cut out holes
-	G4double airHoleDistance = fGermaniumSeparation/2.0
-		+ (fGermaniumWidth/2.0 - fGermaniumShift); //centre of the middle hole
+    // cut out holes
+    G4double airHoleDistance = fGermaniumSeparation/2.0
+        + (fGermaniumWidth/2.0 - fGermaniumShift); //centre of the middle hole
 
-	G4RotationMatrix* rotateFetAirHole = new G4RotationMatrix;
-	rotateFetAirHole->rotateY(M_PI/2.0);
+    G4RotationMatrix* rotateFetAirHole = new G4RotationMatrix;
+    rotateFetAirHole->rotateY(M_PI/2.0);
 
-	G4Tubs* fetAirHoleCut = AirHoleCut();
+    G4Tubs* fetAirHoleCut = AirHoleCut();
 
-	G4ThreeVector movePiece[8] ;
-	G4SubtractionSolid* endPlateCut[8] ;
-	G4int i ;
-	G4double x, y, z, y0, z0, y01, y02;
+    G4ThreeVector movePiece[8] ;
+    G4SubtractionSolid* endPlateCut[8] ;
+    G4int i ;
+    G4double x, y, z, y0, z0, y01, y02;
 
-	y0 = airHoleDistance ;
-	z0 = airHoleDistance ;
+    y0 = airHoleDistance ;
+    z0 = airHoleDistance ;
 
-	for(i = 0 ; i < 4 ; i++)
-	{
-		y = y0 * (-cos(i*M_PI/2.0) + sin(i*M_PI/2.0)) ;
-		z = z0 * (cos(i*M_PI/2.0) + sin(i*M_PI/2.0)) ;
-		movePiece[i] = G4ThreeVector(0 , y, z) ;
+    for(i = 0 ; i < 4 ; i++)
+    {
+        y = y0 * (-cos(i*M_PI/2.0) + sin(i*M_PI/2.0)) ;
+        z = z0 * (cos(i*M_PI/2.0) + sin(i*M_PI/2.0)) ;
+        movePiece[i] = G4ThreeVector(0 , y, z) ;
 
-		if(i == 0)
-			// Slightly different than the rest. Sorry I couldnt think of a better workaround
-			endPlateCut[i] = new G4SubtractionSolid("endPlateCut", endPlate, fetAirHoleCut, rotateFetAirHole, movePiece[i]) ;
-		else
-			endPlateCut[i] = new G4SubtractionSolid("endPlateCut", endPlateCut[i-1], fetAirHoleCut, rotateFetAirHole, movePiece[i]) ;
-	}
+        if(i == 0)
+            // Slightly different than the rest. Sorry I couldnt think of a better workaround
+            endPlateCut[i] = new G4SubtractionSolid("endPlateCut", endPlate, fetAirHoleCut, rotateFetAirHole, movePiece[i]) ;
+        else
+            endPlateCut[i] = new G4SubtractionSolid("endPlateCut", endPlateCut[i-1], fetAirHoleCut, rotateFetAirHole, movePiece[i]) ;
+    }
 
-	x = fColdFingerEndPlateThickness/2.0 +fCanFaceThickness/2.0
-		+ fGermaniumDistFromCanFace +fGermaniumLength
-		+ fColdFingerSpace +fShift +fAppliedBackShift ;
+    x = fColdFingerEndPlateThickness/2.0 +fCanFaceThickness/2.0
+        + fGermaniumDistFromCanFace +fGermaniumLength
+        + fColdFingerSpace +fShift +fAppliedBackShift ;
 
-	G4ThreeVector moveEndPlate(x, 0, 0) ;
+    G4ThreeVector moveEndPlate(x, 0, 0) ;
 
 
 
-	// Fix overlap.
+    // Fix overlap.
 
-	G4double cutTubeY0, cutYMov, cutZMov;
-	G4RotationMatrix* cutRotatePiece[4] ;
-	G4ThreeVector cutMovePiece[4] ;
-	G4Tubs* cutTubeLocation[4] ;
+    G4double cutTubeY0, cutYMov, cutZMov;
+    G4RotationMatrix* cutRotatePiece[4] ;
+    G4ThreeVector cutMovePiece[4] ;
+    G4Tubs* cutTubeLocation[4] ;
 
-	cutTubeY0 = (fDetectorTotalWidth/2.0) - (fBentEndLength * tan(fBentEndAngle)) ;
+    cutTubeY0 = (fDetectorTotalWidth/2.0) - (fBentEndLength * tan(fBentEndAngle)) ;
 
-	for(i = 0 ; i < 4 ; i++)
-	{
-		// Lower Left, Upper Left, Upper Right, Lower Right
-		cutTubeLocation[i] = CornerTube() ;
-		cutRotatePiece[i] = new G4RotationMatrix ;
-		cutRotatePiece[i]->rotateY(M_PI/2.0) ;
-		cutRotatePiece[i]->rotateZ(-M_PI/2.0 + (i-1)*M_PI/2.0) ;
+    for(i = 0 ; i < 4 ; i++)
+    {
+        // Lower Left, Upper Left, Upper Right, Lower Right
+        cutTubeLocation[i] = CornerTube() ;
+        cutRotatePiece[i] = new G4RotationMatrix ;
+        cutRotatePiece[i]->rotateY(M_PI/2.0) ;
+        cutRotatePiece[i]->rotateZ(-M_PI/2.0 + (i-1)*M_PI/2.0) ;
 
-		//cutRotatePiece[i]->rotateX(-M_PI/2.0 + i*M_PI/2.0) ;
+        //cutRotatePiece[i]->rotateX(-M_PI/2.0 + i*M_PI/2.0) ;
 
-		cutYMov = cutTubeY0 * (-cos(i*M_PI/2.0) + sin(i*M_PI/2.0)) ;
-		cutZMov = cutTubeY0 * (-cos(i*M_PI/2.0) - sin(i*M_PI/2.0)) ;
+        cutYMov = cutTubeY0 * (-cos(i*M_PI/2.0) + sin(i*M_PI/2.0)) ;
+        cutZMov = cutTubeY0 * (-cos(i*M_PI/2.0) - sin(i*M_PI/2.0)) ;
 
-		cutMovePiece[i] = G4ThreeVector(0, cutYMov, cutZMov) ;
+        cutMovePiece[i] = G4ThreeVector(0, cutYMov, cutZMov) ;
 
-		endPlateCut[i+4] = new G4SubtractionSolid("endPlateCut", endPlateCut[i+3], cutTubeLocation[i], cutRotatePiece[i], cutMovePiece[i]) ;
-	}
+        endPlateCut[i+4] = new G4SubtractionSolid("endPlateCut", endPlateCut[i+3], cutTubeLocation[i], cutRotatePiece[i], cutMovePiece[i]) ;
+    }
 
-	fEndPlateLog = new G4LogicalVolume(endPlateCut[7], structureMat, "endPlateLog", 0, 0, 0);
+    fEndPlateLog = new G4LogicalVolume(endPlateCut[7], structureMat, "endPlateLog", 0, 0, 0);
 
-	fEndPlateLog->SetVisAttributes(structureMatVisAtt);
+    fEndPlateLog->SetVisAttributes(structureMatVisAtt);
 
-	fAssembly->AddPlacedVolume(fEndPlateLog, moveEndPlate, 0);
+    fAssembly->AddPlacedVolume(fEndPlateLog, moveEndPlate, 0);
 
-	// Place holes in the old cold plate
-	G4Tubs* fetAirHole = AirHole();
+    // Place holes in the old cold plate
+    G4Tubs* fetAirHole = AirHole();
 
-	fFetAirHoleLog = new G4LogicalVolume(fetAirHole, materialAir, "fetAirHoleLog", 0, 0, 0);
-	fFetAirHoleLog->SetVisAttributes(airVisAtt);
+    fFetAirHoleLog = new G4LogicalVolume(fetAirHole, materialAir, "fetAirHoleLog", 0, 0, 0);
+    fFetAirHoleLog->SetVisAttributes(airVisAtt);
 
-	for(i = 0 ; i < 4 ; i++) {
-		y = y0 * (-cos(i*M_PI/2.0) + sin(i*M_PI/2.0)) ;
-		z = z0 * (cos(i*M_PI/2.0) + sin(i*M_PI/2.0)) ;
-		movePiece[i] = G4ThreeVector(x, y, z) ;
-		fAssembly->AddPlacedVolume(fFetAirHoleLog, movePiece[i], rotateFetAirHole) ;
-	}
+    for(i = 0 ; i < 4 ; i++) {
+        y = y0 * (-cos(i*M_PI/2.0) + sin(i*M_PI/2.0)) ;
+        z = z0 * (cos(i*M_PI/2.0) + sin(i*M_PI/2.0)) ;
+        movePiece[i] = G4ThreeVector(x, y, z) ;
+        fAssembly->AddPlacedVolume(fFetAirHoleLog, movePiece[i], rotateFetAirHole) ;
+    }
 
-	// Cold Finger
-	G4Tubs* fing = Finger();
+    // Cold Finger
+    G4Tubs* fing = Finger();
 
-	G4RotationMatrix* rotateFinger = new G4RotationMatrix;
-	rotateFinger->rotateY(M_PI/2.0);
+    G4RotationMatrix* rotateFinger = new G4RotationMatrix;
+    rotateFinger->rotateY(M_PI/2.0);
 
-	G4ThreeVector moveFinger((fColdFingerLength +fCanFaceThickness)/2.0
-			+ fGermaniumDistFromCanFace +fGermaniumLength
-			+ fColdFingerSpace +fColdFingerEndPlateThickness
-			+ fShift +fAppliedBackShift
-			+ fStructureMatColdFingerThickness/2.0 , 0, 0); //changed Jan 2005
+    G4ThreeVector moveFinger((fColdFingerLength +fCanFaceThickness)/2.0
+            + fGermaniumDistFromCanFace +fGermaniumLength
+            + fColdFingerSpace +fColdFingerEndPlateThickness
+            + fShift +fAppliedBackShift
+            + fStructureMatColdFingerThickness/2.0 , 0, 0); //changed Jan 2005
 
-	fFingerLog = new G4LogicalVolume(fing, electrodeMat, "fingerLog", 0, 0, 0);
-	fFingerLog->SetVisAttributes(coldFingerVisAtt);
+    fFingerLog = new G4LogicalVolume(fing, electrodeMat, "fingerLog", 0, 0, 0);
+    fFingerLog->SetVisAttributes(coldFingerVisAtt);
 
-	fAssembly->AddPlacedVolume(fFingerLog, moveFinger, rotateFinger);
+    fAssembly->AddPlacedVolume(fFingerLog, moveFinger, rotateFinger);
 
-	// The extra block of structureMat that's in the diagram "Cut C"
-	G4SubtractionSolid* extraColdBlock = ExtraColdBlock();
-	G4RotationMatrix* rotateExtraColdBlock = new G4RotationMatrix;
-	rotateExtraColdBlock->rotateY(M_PI/2.0);
+    // The extra block of structureMat that's in the diagram "Cut C"
+    G4SubtractionSolid* extraColdBlock = ExtraColdBlock();
+    G4RotationMatrix* rotateExtraColdBlock = new G4RotationMatrix;
+    rotateExtraColdBlock->rotateY(M_PI/2.0);
 
-	G4ThreeVector moveExtraColdBlock(fDetectorTotalLength - fCanFaceThickness/2.0
-			- fRearPlateThickness + fShift
-			+ fAppliedBackShift - fExtraBlockDistanceFromBackPlate
-			- fExtraBlockThickness/2.0, 0, 0);
+    G4ThreeVector moveExtraColdBlock(fDetectorTotalLength - fCanFaceThickness/2.0
+            - fRearPlateThickness + fShift
+            + fAppliedBackShift - fExtraBlockDistanceFromBackPlate
+            - fExtraBlockThickness/2.0, 0, 0);
 
-	fExtraColdBlockLog = new G4LogicalVolume(extraColdBlock, structureMat, "extraColdBlockLog", 0, 0, 0);
+    fExtraColdBlockLog = new G4LogicalVolume(extraColdBlock, structureMat, "extraColdBlockLog", 0, 0, 0);
 
-	fAssembly->AddPlacedVolume(fExtraColdBlockLog, moveExtraColdBlock, rotateExtraColdBlock);
+    fAssembly->AddPlacedVolume(fExtraColdBlockLog, moveExtraColdBlock, rotateExtraColdBlock);
 
-	// The structures above the cooling end plate
-	G4Tubs* structureMatColdFinger = StructureMatColdFinger();
-	fStructureMatColdFingerLog = new G4LogicalVolume(structureMatColdFinger, structureMat, "structureMatColdFingerLog", 0, 0, 0);
-	fStructureMatColdFingerLog->SetVisAttributes(structureMatVisAtt);
+    // The structures above the cooling end plate
+    G4Tubs* structureMatColdFinger = StructureMatColdFinger();
+    fStructureMatColdFingerLog = new G4LogicalVolume(structureMatColdFinger, structureMat, "structureMatColdFingerLog", 0, 0, 0);
+    fStructureMatColdFingerLog->SetVisAttributes(structureMatVisAtt);
 
-	G4RotationMatrix* rotateStructureMatColdFinger = new G4RotationMatrix;
-	rotateStructureMatColdFinger->rotateY(M_PI/2.0);
-	G4ThreeVector moveStructureMatColdFinger(fStructureMatColdFingerThickness/2.0
-			+ fColdFingerEndPlateThickness
-			+ fCanFaceThickness/2.0
-			+ fGermaniumDistFromCanFace +fGermaniumLength
-			+ fColdFingerSpace +fShift +fAppliedBackShift, 0, 0);
+    G4RotationMatrix* rotateStructureMatColdFinger = new G4RotationMatrix;
+    rotateStructureMatColdFinger->rotateY(M_PI/2.0);
+    G4ThreeVector moveStructureMatColdFinger(fStructureMatColdFingerThickness/2.0
+            + fColdFingerEndPlateThickness
+            + fCanFaceThickness/2.0
+            + fGermaniumDistFromCanFace +fGermaniumLength
+            + fColdFingerSpace +fShift +fAppliedBackShift, 0, 0);
 
-	fAssembly->AddPlacedVolume(fStructureMatColdFingerLog, moveStructureMatColdFinger, rotateStructureMatColdFinger);
+    fAssembly->AddPlacedVolume(fStructureMatColdFingerLog, moveStructureMatColdFinger, rotateStructureMatColdFinger);
 
-	// Cooling Side Block
-	G4Box* coolingSideBlock = CoolingSideBlock();
-	fCoolingSideBlockLog = new G4LogicalVolume(coolingSideBlock, structureMat, "coolingSideBlockLog", 0, 0, 0);
-	fCoolingSideBlockLog->SetVisAttributes(structureMatVisAtt);
+    // Cooling Side Block
+    G4Box* coolingSideBlock = CoolingSideBlock();
+    fCoolingSideBlockLog = new G4LogicalVolume(coolingSideBlock, structureMat, "coolingSideBlockLog", 0, 0, 0);
+    fCoolingSideBlockLog->SetVisAttributes(structureMatVisAtt);
 
-	G4Box* coolingBar = CoolingBar();
-	fCoolingBarLog = new G4LogicalVolume(coolingBar, structureMat, "coolingBarLog", 0, 0, 0);
-	fCoolingBarLog->SetVisAttributes(structureMatVisAtt);
+    G4Box* coolingBar = CoolingBar();
+    fCoolingBarLog = new G4LogicalVolume(coolingBar, structureMat, "coolingBarLog", 0, 0, 0);
+    fCoolingBarLog->SetVisAttributes(structureMatVisAtt);
 
-	G4RotationMatrix* rotatePiece[8] ;
+    G4RotationMatrix* rotatePiece[8] ;
 
-	x = fCoolingSideBlockThickness/2.0
-		+ fColdFingerEndPlateThickness
-		+ fCanFaceThickness/2.0
-		+ fGermaniumDistFromCanFace +fGermaniumLength
-		+ fColdFingerSpace +fShift +fAppliedBackShift ;
+    x = fCoolingSideBlockThickness/2.0
+        + fColdFingerEndPlateThickness
+        + fCanFaceThickness/2.0
+        + fGermaniumDistFromCanFace +fGermaniumLength
+        + fColdFingerSpace +fShift +fAppliedBackShift ;
 
-	y01 = fGermaniumWidth - fCoolingSideBlockHorizontalDepth/2.0 ;
+    y01 = fGermaniumWidth - fCoolingSideBlockHorizontalDepth/2.0 ;
 
-	y02 = fGermaniumWidth
-		- fCoolingSideBlockHorizontalDepth
-		- (fGermaniumWidth
-				- fCoolingSideBlockHorizontalDepth
-				- fStructureMatColdFingerRadius)/2.0 ;
+    y02 = fGermaniumWidth
+        - fCoolingSideBlockHorizontalDepth
+        - (fGermaniumWidth
+                - fCoolingSideBlockHorizontalDepth
+                - fStructureMatColdFingerRadius)/2.0 ;
 
-	for(i = 0 ; i < 4 ; i++)
-	{
-		// Add cooling side blocks and cooling bars at the same time.
-		rotatePiece[2*i] = new G4RotationMatrix ; // cooling side blocks
-		rotatePiece[2*i]->rotateZ(M_PI/2.0) ;
-		rotatePiece[2*i]->rotateX(M_PI/2.0 - i*M_PI/2.0) ;
+    for(i = 0 ; i < 4 ; i++)
+    {
+        // Add cooling side blocks and cooling bars at the same time.
+        rotatePiece[2*i] = new G4RotationMatrix ; // cooling side blocks
+        rotatePiece[2*i]->rotateZ(M_PI/2.0) ;
+        rotatePiece[2*i]->rotateX(M_PI/2.0 - i*M_PI/2.0) ;
 
-		y = -y01 * cos(i*M_PI/2.0) ;
-		z = -y01 * sin(i*M_PI/2.0) ;
+        y = -y01 * cos(i*M_PI/2.0) ;
+        z = -y01 * sin(i*M_PI/2.0) ;
 
-		movePiece[2*i] = G4ThreeVector(x, y, z) ;
+        movePiece[2*i] = G4ThreeVector(x, y, z) ;
 
-		rotatePiece[2*i+1] = new G4RotationMatrix ; // cooling bars
-		rotatePiece[2*i+1]->rotateZ(M_PI/2.0) ;
-		rotatePiece[2*i+1]->rotateX(M_PI/2.0 - i*M_PI/2.0) ;
+        rotatePiece[2*i+1] = new G4RotationMatrix ; // cooling bars
+        rotatePiece[2*i+1]->rotateZ(M_PI/2.0) ;
+        rotatePiece[2*i+1]->rotateX(M_PI/2.0 - i*M_PI/2.0) ;
 
-		y = -y02 * cos(i*M_PI/2.0) ;
-		z = -y02 * sin(i*M_PI/2.0) ;
+        y = -y02 * cos(i*M_PI/2.0) ;
+        z = -y02 * sin(i*M_PI/2.0) ;
 
-		movePiece[2*i+1] = G4ThreeVector(x, y, z) ;
+        movePiece[2*i+1] = G4ThreeVector(x, y, z) ;
 
-		fAssembly->AddPlacedVolume(fCoolingSideBlockLog, movePiece[2*i], rotatePiece[2*i]);
-		fAssembly->AddPlacedVolume(fCoolingBarLog, movePiece[2*i+1], rotatePiece[2*i+1]);
-	}
+        fAssembly->AddPlacedVolume(fCoolingSideBlockLog, movePiece[2*i], rotatePiece[2*i]);
+        fAssembly->AddPlacedVolume(fCoolingBarLog, movePiece[2*i+1], rotatePiece[2*i+1]);
+    }
 
-	// Triangle posts from "Cut A"
-	// First, find how far from the centre to place the tips of the triangles
+    // Triangle posts from "Cut A"
+    // First, find how far from the centre to place the tips of the triangles
 
-	G4double distanceOfTheTip = fGermaniumSeparation/2.0
-		+ (fGermaniumWidth/2.0 - fGermaniumShift) //centre of the middle hole
-		+ sqrt(pow((fGermaniumOuterRadius
-						+ fTrianglePostsDistanceFromCrystals), 2.0)
-				- pow(fGermaniumWidth/2.0 - fGermaniumShift, 2.0));
+    G4double distanceOfTheTip = fGermaniumSeparation/2.0
+        + (fGermaniumWidth/2.0 - fGermaniumShift) //centre of the middle hole
+        + sqrt(pow((fGermaniumOuterRadius
+                        + fTrianglePostsDistanceFromCrystals), 2.0)
+                - pow(fGermaniumWidth/2.0 - fGermaniumShift, 2.0));
 
-	// The distance of the base from the detector centre
-	G4double distanceOfTheBase = fGermaniumSeparation/2.0 + fGermaniumWidth;
+    // The distance of the base from the detector centre
+    G4double distanceOfTheBase = fGermaniumSeparation/2.0 + fGermaniumWidth;
 
-	G4double trianglePostLength = fGermaniumLength - fTrianglePostStartingDepth
-		+ fColdFingerSpace;
+    G4double trianglePostLength = fGermaniumLength - fTrianglePostStartingDepth
+        + fColdFingerSpace;
 
-	G4Trd* trianglePost = TrianglePost();
-	fTrianglePostLog = new G4LogicalVolume(trianglePost, structureMat, "trianglePostLog", 0, 0, 0);
+    G4Trd* trianglePost = TrianglePost();
+    fTrianglePostLog = new G4LogicalVolume(trianglePost, structureMat, "trianglePostLog", 0, 0, 0);
 
-	x = fCanFaceThickness/2.0
-		+ fGermaniumDistFromCanFace +fGermaniumLength
-		+ fColdFingerSpace +fShift +fAppliedBackShift
-		- trianglePostLength/2.0 ;
+    x = fCanFaceThickness/2.0
+        + fGermaniumDistFromCanFace +fGermaniumLength
+        + fColdFingerSpace +fShift +fAppliedBackShift
+        - trianglePostLength/2.0 ;
 
-	y0 = (distanceOfTheBase + distanceOfTheTip)/2.0 ;
+    y0 = (distanceOfTheBase + distanceOfTheTip)/2.0 ;
 
-	for(i = 0 ; i < 4 ; i++)
-	{
-		rotatePiece[i] = new G4RotationMatrix ;
-		rotatePiece[i]->rotateY(0) ; // Initially included...seems a little redundant.
-		rotatePiece[i]->rotateX(M_PI/2.0 - i*M_PI/2.0) ;  // 4, 1, 2, 3
+    for(i = 0 ; i < 4 ; i++)
+    {
+        rotatePiece[i] = new G4RotationMatrix ;
+        rotatePiece[i]->rotateY(0) ; // Initially included...seems a little redundant.
+        rotatePiece[i]->rotateX(M_PI/2.0 - i*M_PI/2.0) ;  // 4, 1, 2, 3
 
-		y = -y0 * cos(i*M_PI/2.0) ;
-		z =  y0 * sin(i*M_PI/2.0) ;
+        y = -y0 * cos(i*M_PI/2.0) ;
+        z =  y0 * sin(i*M_PI/2.0) ;
 
-		movePiece[i] = G4ThreeVector(x, y, z) ;
+        movePiece[i] = G4ThreeVector(x, y, z) ;
 
-		fAssembly->AddPlacedVolume(fTrianglePostLog, movePiece[i], rotatePiece[i]);
-	}
+        fAssembly->AddPlacedVolume(fTrianglePostLog, movePiece[i], rotatePiece[i]);
+    }
 }//end ::ConstructColdFinger
 
 ///////////////////////////////////////////////////////////////////////
 // methods used in ConstructColdFinger()
 ///////////////////////////////////////////////////////////////////////
 G4Box* DetectionSystemGriffin::EndPlate() {
-	G4double halfThicknessX = fColdFingerEndPlateThickness/2.0;
-	G4double halfLengthY = fGermaniumWidth;  //Since it must cover the back of the detector
-	G4double halfLengthZ = halfLengthY;  //Since it is symmetric
+    G4double halfThicknessX = fColdFingerEndPlateThickness/2.0;
+    G4double halfLengthY = fGermaniumWidth;  //Since it must cover the back of the detector
+    G4double halfLengthZ = halfLengthY;  //Since it is symmetric
 
-	G4Box* endPlate = new G4Box("endPlate", halfThicknessX, halfLengthY, halfLengthZ);
+    G4Box* endPlate = new G4Box("endPlate", halfThicknessX, halfLengthY, halfLengthZ);
 
-	return endPlate;
+    return endPlate;
 }//end ::endPlate
 
 
 G4Tubs* DetectionSystemGriffin::Finger() {
-	G4double innerRadius = 0.0*cm;
-	G4double outerRadius = fColdFingerRadius;
-	G4double halfLengthZ = (fColdFingerLength
-			- fStructureMatColdFingerThickness)/2.0;
-	G4double startAngle = 0.0*M_PI;
-	G4double finalAngle = 2.0*M_PI;
+    G4double innerRadius = 0.0*cm;
+    G4double outerRadius = fColdFingerRadius;
+    G4double halfLengthZ = (fColdFingerLength
+            - fStructureMatColdFingerThickness)/2.0;
+    G4double startAngle = 0.0*M_PI;
+    G4double finalAngle = 2.0*M_PI;
 
-	G4Tubs* fing = new G4Tubs("finger", innerRadius, outerRadius, halfLengthZ, startAngle, finalAngle);
+    G4Tubs* fing = new G4Tubs("finger", innerRadius, outerRadius, halfLengthZ, startAngle, finalAngle);
 
-	return fing;
+    return fing;
 }//end ::finger
 
 
 G4SubtractionSolid* DetectionSystemGriffin::ExtraColdBlock() {
-	G4double halfWidthX = fGermaniumWidth;
-	G4double halfWidthY = halfWidthX;
-	G4double halfThicknessZ = fExtraBlockThickness/2.0;
+    G4double halfWidthX = fGermaniumWidth;
+    G4double halfWidthY = halfWidthX;
+    G4double halfThicknessZ = fExtraBlockThickness/2.0;
 
-	G4Box* plate = new G4Box("plate", halfWidthX, halfWidthY, halfThicknessZ);
+    G4Box* plate = new G4Box("plate", halfWidthX, halfWidthY, halfThicknessZ);
 
-	G4double innerRadius = 0.0;
-	G4double outerRadius = fExtraBlockInnerDiameter/2.0;
+    G4double innerRadius = 0.0;
+    G4double outerRadius = fExtraBlockInnerDiameter/2.0;
 
-	G4double halfHeightZ = halfThicknessZ +1.0*cm;  //+1.0*cm just to make sure the hole goes completely through the plate
-	G4double startAngle = 0.0*M_PI;
-	G4double finalAngle = 2.0*M_PI;
+    G4double halfHeightZ = halfThicknessZ +1.0*cm;  //+1.0*cm just to make sure the hole goes completely through the plate
+    G4double startAngle = 0.0*M_PI;
+    G4double finalAngle = 2.0*M_PI;
 
-	G4Tubs* hole = new G4Tubs("hole", innerRadius, outerRadius, halfHeightZ, startAngle, finalAngle);
+    G4Tubs* hole = new G4Tubs("hole", innerRadius, outerRadius, halfHeightZ, startAngle, finalAngle);
 
-	G4SubtractionSolid* extraColdBlock = new G4SubtractionSolid("extraColdBlock", plate, hole);
+    G4SubtractionSolid* extraColdBlock = new G4SubtractionSolid("extraColdBlock", plate, hole);
 
 
 
-	// Fix overlap
-	G4SubtractionSolid* fixExtraColdBlock[4];
-	G4double cutTubeY0, cutYMov, cutZMov;
-	G4RotationMatrix* cutRotatePiece[4] ;
-	G4ThreeVector cutMovePiece[4] ;
-	G4Tubs* cutTubeLocation[4] ;
+    // Fix overlap
+    G4SubtractionSolid* fixExtraColdBlock[4];
+    G4double cutTubeY0, cutYMov, cutZMov;
+    G4RotationMatrix* cutRotatePiece[4] ;
+    G4ThreeVector cutMovePiece[4] ;
+    G4Tubs* cutTubeLocation[4] ;
 
-	cutTubeY0 = (fDetectorTotalWidth/2.0) - (fBentEndLength * tan(fBentEndAngle)) ;
+    cutTubeY0 = (fDetectorTotalWidth/2.0) - (fBentEndLength * tan(fBentEndAngle)) ;
 
-	for(G4int i = 0 ; i < 4 ; i++) {
-		// Lower Left, Upper Left, Upper Right, Lower Right
-		cutTubeLocation[i] = CornerTube() ;
-		cutRotatePiece[i] = new G4RotationMatrix ;
-		cutRotatePiece[i]->rotateZ(-M_PI/2.0 + (i-1)*M_PI/2.0) ;
+    for(G4int i = 0 ; i < 4 ; i++) {
+        // Lower Left, Upper Left, Upper Right, Lower Right
+        cutTubeLocation[i] = CornerTube() ;
+        cutRotatePiece[i] = new G4RotationMatrix ;
+        cutRotatePiece[i]->rotateZ(-M_PI/2.0 + (i-1)*M_PI/2.0) ;
 
-		cutYMov = cutTubeY0 * (-cos(i*M_PI/2.0) + sin(i*M_PI/2.0)) ;
-		cutZMov = cutTubeY0  * (-cos(i*M_PI/2.0) - sin(i*M_PI/2.0)) ;
+        cutYMov = cutTubeY0 * (-cos(i*M_PI/2.0) + sin(i*M_PI/2.0)) ;
+        cutZMov = cutTubeY0  * (-cos(i*M_PI/2.0) - sin(i*M_PI/2.0)) ;
 
-		cutMovePiece[i] = G4ThreeVector(cutZMov, cutYMov, 0) ;
+        cutMovePiece[i] = G4ThreeVector(cutZMov, cutYMov, 0) ;
 
-		if(i == 0) {
-			fixExtraColdBlock[i] = new G4SubtractionSolid("extraColdBlock", extraColdBlock, cutTubeLocation[i], cutRotatePiece[i], cutMovePiece[i]) ;
-		} else {
-			fixExtraColdBlock[i] = new G4SubtractionSolid("extraColdBlock", fixExtraColdBlock[i-1], cutTubeLocation[i], cutRotatePiece[i], cutMovePiece[i]) ;
-		}
-	}
+        if(i == 0) {
+            fixExtraColdBlock[i] = new G4SubtractionSolid("extraColdBlock", extraColdBlock, cutTubeLocation[i], cutRotatePiece[i], cutMovePiece[i]) ;
+        } else {
+            fixExtraColdBlock[i] = new G4SubtractionSolid("extraColdBlock", fixExtraColdBlock[i-1], cutTubeLocation[i], cutRotatePiece[i], cutMovePiece[i]) ;
+        }
+    }
 
-	return fixExtraColdBlock[3];
+    return fixExtraColdBlock[3];
 }//end ::extraColdBlock
 
 
 G4Trd* DetectionSystemGriffin::TrianglePost() {
-	// Calculations that are also done in ConstructColdFinger for positioning
-	// First, find how far from the centre to place the tips of the triangles
-	G4double distanceOfTheTip	= fGermaniumSeparation/2.0
-		+ (fGermaniumWidth/2.0 - fGermaniumShift) //centre of the middle hole
-		+ sqrt(pow((fGermaniumOuterRadius
-						+ fTrianglePostsDistanceFromCrystals), 2.0)
-				- pow(fGermaniumWidth/2.0 - fGermaniumShift, 2.0));
+    // Calculations that are also done in ConstructColdFinger for positioning
+    // First, find how far from the centre to place the tips of the triangles
+    G4double distanceOfTheTip   = fGermaniumSeparation/2.0
+        + (fGermaniumWidth/2.0 - fGermaniumShift) //centre of the middle hole
+        + sqrt(pow((fGermaniumOuterRadius
+                        + fTrianglePostsDistanceFromCrystals), 2.0)
+                - pow(fGermaniumWidth/2.0 - fGermaniumShift, 2.0));
 
-	// The distance of the base from the detector centre
-	G4double distanceOfTheBase = fGermaniumSeparation/2.0
-		+ fGermaniumWidth;
+    // The distance of the base from the detector centre
+    G4double distanceOfTheBase = fGermaniumSeparation/2.0
+        + fGermaniumWidth;
 
-	// The distance away from the boundary between crystals of the side points
-	G4double distanceOfTheSidePoints 	= sqrt(pow((fGermaniumOuterRadius
-					+ fTrianglePostsDistanceFromCrystals), 2.0)
-			- pow(fGermaniumWidth/2.0 +/*notice*/ fGermaniumShift, 2.0));
+    // The distance away from the boundary between crystals of the side points
+    G4double distanceOfTheSidePoints    = sqrt(pow((fGermaniumOuterRadius
+                    + fTrianglePostsDistanceFromCrystals), 2.0)
+            - pow(fGermaniumWidth/2.0 +/*notice*/ fGermaniumShift, 2.0));
 
-	// Measurements to make the posts with
-	G4double length = fGermaniumLength - fTrianglePostStartingDepth
-		+ fColdFingerSpace;
+    // Measurements to make the posts with
+    G4double length = fGermaniumLength - fTrianglePostStartingDepth
+        + fColdFingerSpace;
 
-	G4double baseToTipHeight = (distanceOfTheBase-distanceOfTheTip);
+    G4double baseToTipHeight = (distanceOfTheBase-distanceOfTheTip);
 
-	G4double halfWidthOfBase = distanceOfTheSidePoints;
+    G4double halfWidthOfBase = distanceOfTheSidePoints;
 
-	G4double halfWidthOfTop = fTrianglePostDim; //the easiest way to make a triangle
-	//G4Trd(const G4String& pName,G4double  dx1, G4double dx2, G4double  dy1, G4double dy2,G4double  dz)
-	G4Trd* trianglePost = new G4Trd(	"trianglePost", length / 2.0, length / 2.0,
-			halfWidthOfTop, halfWidthOfBase, baseToTipHeight / 2.0);
+    G4double halfWidthOfTop = fTrianglePostDim; //the easiest way to make a triangle
+    //G4Trd(const G4String& pName,G4double  dx1, G4double dx2, G4double  dy1, G4double dy2,G4double  dz)
+    G4Trd* trianglePost = new G4Trd(    "trianglePost", length / 2.0, length / 2.0,
+            halfWidthOfTop, halfWidthOfBase, baseToTipHeight / 2.0);
 
-	return trianglePost;
+    return trianglePost;
 }//end ::trianglePost
 
 
 G4Tubs* DetectionSystemGriffin::AirHole() {
-	G4double innerRadius = 0.0*cm;
-	G4double outerRadius = fFetAirHoleRadius;
-	G4double halfLengthZ = fColdFingerEndPlateThickness/2.0;
-	G4double startAngle = 0.0*M_PI;
-	G4double finalAngle = 2.0*M_PI;
+    G4double innerRadius = 0.0*cm;
+    G4double outerRadius = fFetAirHoleRadius;
+    G4double halfLengthZ = fColdFingerEndPlateThickness/2.0;
+    G4double startAngle = 0.0*M_PI;
+    G4double finalAngle = 2.0*M_PI;
 
-	G4Tubs* fetAirHole = new G4Tubs("fetAirHole", innerRadius,
-			outerRadius, halfLengthZ, startAngle, finalAngle);
+    G4Tubs* fetAirHole = new G4Tubs("fetAirHole", innerRadius,
+            outerRadius, halfLengthZ, startAngle, finalAngle);
 
-	return fetAirHole;
+    return fetAirHole;
 }//end ::airHole
 
 G4Tubs* DetectionSystemGriffin::AirHoleCut() {
-	G4double innerRadius = 0.0*cm;
-	G4double outerRadius = fFetAirHoleRadius;
-	G4double halfLengthZ = fColdFingerEndPlateThickness/2.0 + 1.0*cm;
-	G4double startAngle = 0.0*M_PI;
-	G4double finalAngle = 2.0*M_PI;
+    G4double innerRadius = 0.0*cm;
+    G4double outerRadius = fFetAirHoleRadius;
+    G4double halfLengthZ = fColdFingerEndPlateThickness/2.0 + 1.0*cm;
+    G4double startAngle = 0.0*M_PI;
+    G4double finalAngle = 2.0*M_PI;
 
-	G4Tubs* fetAirHole = new G4Tubs("fetAirHole", innerRadius,
-			outerRadius, halfLengthZ, startAngle, finalAngle);
+    G4Tubs* fetAirHole = new G4Tubs("fetAirHole", innerRadius,
+            outerRadius, halfLengthZ, startAngle, finalAngle);
 
-	return fetAirHole;
+    return fetAirHole;
 }//end ::airHoleCut
 
 G4Box* DetectionSystemGriffin::CoolingBar() {
-	G4double halfThicknessX = fCoolingBarThickness/2.0;
-	G4double halfLengthY = fCoolingBarWidth/2.0;
-	G4double halfLengthZ = (fGermaniumWidth
-			- fCoolingSideBlockHorizontalDepth
-			- fStructureMatColdFingerRadius)/2.0;
+    G4double halfThicknessX = fCoolingBarThickness/2.0;
+    G4double halfLengthY = fCoolingBarWidth/2.0;
+    G4double halfLengthZ = (fGermaniumWidth
+            - fCoolingSideBlockHorizontalDepth
+            - fStructureMatColdFingerRadius)/2.0;
 
-	G4Box* coolingBar = new G4Box("coolingBar", halfThicknessX, halfLengthY, halfLengthZ);
+    G4Box* coolingBar = new G4Box("coolingBar", halfThicknessX, halfLengthY, halfLengthZ);
 
-	return coolingBar;
+    return coolingBar;
 }//end ::coolingBar
 
 
 G4Box* DetectionSystemGriffin::CoolingSideBlock() {
-	G4double halfThicknessX = fCoolingSideBlockWidth/2.0;
-	G4double halfLengthY = fCoolingSideBlockThickness/2.0;
-	G4double halfLengthZ = fCoolingSideBlockHorizontalDepth/2.0;
+    G4double halfThicknessX = fCoolingSideBlockWidth/2.0;
+    G4double halfLengthY = fCoolingSideBlockThickness/2.0;
+    G4double halfLengthZ = fCoolingSideBlockHorizontalDepth/2.0;
 
-	G4Box* coolingSideBlock = new G4Box("coolingSideBlock",
-			halfThicknessX, halfLengthY, halfLengthZ);
+    G4Box* coolingSideBlock = new G4Box("coolingSideBlock",
+            halfThicknessX, halfLengthY, halfLengthZ);
 
-	return coolingSideBlock;
+    return coolingSideBlock;
 }//end ::coolingSideBlock
 
 
 G4Tubs* DetectionSystemGriffin::StructureMatColdFinger() {
-	G4double innerRadius = 0.0*cm;
-	G4double outerRadius = fStructureMatColdFingerRadius;
-	G4double halfLengthZ = fStructureMatColdFingerThickness/2.0;
-	G4double startAngle = 0.0*M_PI;
-	G4double finalAngle = 2.0*M_PI;
+    G4double innerRadius = 0.0*cm;
+    G4double outerRadius = fStructureMatColdFingerRadius;
+    G4double halfLengthZ = fStructureMatColdFingerThickness/2.0;
+    G4double startAngle = 0.0*M_PI;
+    G4double finalAngle = 2.0*M_PI;
 
-	G4Tubs* structureMatColdFinger= new G4Tubs("structureMatColdFinger",
-			innerRadius, outerRadius, halfLengthZ, startAngle, finalAngle);
+    G4Tubs* structureMatColdFinger= new G4Tubs("structureMatColdFinger",
+            innerRadius, outerRadius, halfLengthZ, startAngle, finalAngle);
 
-	return structureMatColdFinger;
+    return structureMatColdFinger;
 }//end ::structureMatColdFinger
 
 
@@ -1652,418 +1655,454 @@ G4Tubs* DetectionSystemGriffin::StructureMatColdFinger() {
 // as per the design in the specifications. Also, there is a layer
 // of structureMat that surrounds the physical pieces.
 ///////////////////////////////////////////////////////////////////////
-void DetectionSystemGriffin::ConstructNewSuppressorCasingWithShells() {
-	G4int i;
-	G4double x0, y0, z0, x, y, z;
-
-	G4Material* structureMat = G4Material::GetMaterial(fStructureMaterial);
-	if(!structureMat) {
-		G4cout<<" ----> Structure material "<<fStructureMaterial<<" not found, cannot build the detector shell! "<<G4endl;
-		exit(1);
-	}
-	G4Material* materialBGO = G4Material::GetMaterial(fBGOMaterial);
-	if(!materialBGO) {
-		G4cout<<" ----> BGO material "<<fBGOMaterial<<" not found, cannot build the detector shell! "<<G4endl;
-		exit(1);
-	}
+// begin CRN 
+void DetectionSystemGriffin::ConstructNewSuppressorCasingWithShells(G4int det, G4int cry) {
+    G4String strdet = G4UIcommand::ConvertToString(det);
+    G4String strcry = G4UIcommand::ConvertToString(cry);
+    // end CRN 
+    G4int i;
+    G4double x0, y0, z0, x, y, z;
+
+    G4Material* structureMat = G4Material::GetMaterial(fStructureMaterial);
+    if(!structureMat) {
+        G4cout<<" ----> Structure material "<<fStructureMaterial<<" not found, cannot build the detector shell! "<<G4endl;
+        exit(1);
+    }
+    G4Material* materialBGO = G4Material::GetMaterial(fBGOMaterial);
+    if(!materialBGO) {
+        G4cout<<" ----> BGO material "<<fBGOMaterial<<" not found, cannot build the detector shell! "<<G4endl;
+        exit(1);
+    }
+
+    // Change some values to accomodate the shells
+    // Replacement for sideSuppressorLength
+    G4double shellSideSuppressorLength = fSideSuppressorLength
+        + (fSuppressorShellThickness*2.0);
+
+    // Replacement for suppressorExtensionLength
+    G4double shellSuppressorExtensionLength = fSuppressorExtensionLength
+        + (fSuppressorShellThickness*2.0)*(1.0/tan(fBentEndAngle)
+                - tan(fBentEndAngle));
+
+    // Replacement for suppressorExtensionAngle: must totally recalculate
+    G4double shellSuppressorExtensionAngle = atan(((fSuppressorBackRadius
+                    + fBentEndLength +(fBGOCanSeperation
+                        + fSideBGOThickness + fSuppressorShellThickness*2.0)
+                    / tan(fBentEndAngle)
+                    - (fSuppressorExtensionThickness + fSuppressorShellThickness*2.0)
+                    * sin(fBentEndAngle))
+                * tan(fBentEndAngle) -(fSuppressorForwardRadius +fHevimetTipThickness)
+                * sin(fBentEndAngle))/(shellSuppressorExtensionLength));
+
+    G4VisAttributes* SuppressorVisAtt = new G4VisAttributes(G4Colour(0.75,0.75,0.75));
+    SuppressorVisAtt->SetVisibility(true);
+    G4VisAttributes* innardsVisAtt = new G4VisAttributes(G4Colour(0.75, 0.75, 0.75));
+    innardsVisAtt->SetVisibility(true);
+    G4VisAttributes* backInnardsVisAtt = new G4VisAttributes(G4Colour(0.0, 1.0, 0.0));
+    backInnardsVisAtt->SetVisibility(true);
+
+    // first we add the four pieces of back suppressor, and their shells
+
+    G4SubtractionSolid* backQuarterSuppressor = BackSuppressorQuarter();
+
+    G4SubtractionSolid* backQuarterSuppressorShell = ShellForBackSuppressorQuarter();
+
+    // Insert the structureMat shell first.  The shells must be given numbers, rather than
+    // the suppressor pieces themselves.  As an error checking method, the suppressor
+    // pieces are given a copy number value far out of range of any useful copy number.
+    if(fIncludeBackSuppressors) {
+        // begin CRN 
+        G4String backQuarterSuppressorShellLogName = "backQuarterSuppressorShell_" + strdet + "_" + strcry + "_log";
+        fBackQuarterSuppressorShellLog = new G4LogicalVolume(
+                backQuarterSuppressorShell, structureMat,
+                backQuarterSuppressorShellLogName, 0, 0, 0);
+        // end CRN 
+
+        fBackQuarterSuppressorShellLog->SetVisAttributes(SuppressorVisAtt);
+
+        G4Material* backMaterial = G4Material::GetMaterial(fBackSuppressorMaterial);
+        if(!backMaterial) {
+            G4cout<<" ----> Back suppressor material "<<fBackSuppressorMaterial<<" not found, cannot build the detector shell! "<<G4endl;
+            exit(1);
+        }
+
+        // begin CRN 
+        G4String backQuarterSuppressorLogName = "backQuarterSuppressor_" + strdet + "_" + strcry + "_log";
+        fBackQuarterSuppressorLog = new G4LogicalVolume(backQuarterSuppressor, backMaterial,
+                backQuarterSuppressorLogName, 0, 0, 0);
+        // end CRN
+        fBackQuarterSuppressorLog->SetVisAttributes(backInnardsVisAtt);
+
+        fSuppressorBackAssembly->AddPlacedVolume(fBackQuarterSuppressorLog, fMoveNull, fRotateNull);
+
+        x0 =    (fBackBGOThickness -fCanFaceThickness)/2.0 + fSuppressorShellThickness
+            + fDetectorTotalLength +fBGOCanSeperation
+            + fShift + fAppliedBackShift ;
+
+        y0 = fDetectorTotalWidth/4.0 ;
+
+        z0 = fDetectorTotalWidth/4.0 ;
+
+        G4RotationMatrix* rotateBackSuppressorShells[4] ;
+        G4ThreeVector moveBackQuarterSuppressor[4] ;
+
+        for(i = 0 ; i < 4 ; i++) {
+            rotateBackSuppressorShells[i] = new G4RotationMatrix ;
+            rotateBackSuppressorShells[i]->rotateX(-M_PI / 2.0 + i * M_PI / 2.0) ;
 
-	// Change some values to accomodate the shells
-	// Replacement for sideSuppressorLength
-	G4double shellSideSuppressorLength = fSideSuppressorLength
-		+ (fSuppressorShellThickness*2.0);
+            x = x0 ;
 
-	// Replacement for suppressorExtensionLength
-	G4double shellSuppressorExtensionLength = fSuppressorExtensionLength
-		+ (fSuppressorShellThickness*2.0)*(1.0/tan(fBentEndAngle)
-				- tan(fBentEndAngle));
+            y = y0 * (sin(i * M_PI/2.0) - cos(i * M_PI/2.0)) ;
+            z = -z0 * (sin(i * M_PI/2.0) + cos(i * M_PI/2.0)) ;
 
-	// Replacement for suppressorExtensionAngle: must totally recalculate
-	G4double shellSuppressorExtensionAngle = atan(((fSuppressorBackRadius
-					+ fBentEndLength +(fBGOCanSeperation
-						+ fSideBGOThickness + fSuppressorShellThickness*2.0)
-					/ tan(fBentEndAngle)
-					- (fSuppressorExtensionThickness + fSuppressorShellThickness*2.0)
-					* sin(fBentEndAngle))
-				* tan(fBentEndAngle) -(fSuppressorForwardRadius +fHevimetTipThickness)
-				* sin(fBentEndAngle))/(shellSuppressorExtensionLength));
+            moveBackQuarterSuppressor[i] = G4ThreeVector(x, y, z) ;
 
-	G4VisAttributes* SuppressorVisAtt = new G4VisAttributes(G4Colour(0.75,0.75,0.75));
-	SuppressorVisAtt->SetVisibility(true);
-	G4VisAttributes* innardsVisAtt = new G4VisAttributes(G4Colour(0.75, 0.75, 0.75));
-	innardsVisAtt->SetVisibility(true);
-	G4VisAttributes* backInnardsVisAtt = new G4VisAttributes(G4Colour(0.0, 1.0, 0.0));
-	backInnardsVisAtt->SetVisibility(true);
+            fBackAndSideSuppressorShellAssembly->AddPlacedVolume(fBackQuarterSuppressorShellLog, moveBackQuarterSuppressor[i], rotateBackSuppressorShells[i]) ;
+        }
+    }
 
-	// first we add the four pieces of back suppressor, and their shells
+    ////////////////////////////////////////////////////////////////////////////////////////
+    // now we add the side pieces of suppressor that taper off towards the front of the can
+    ////////////////////////////////////////////////////////////////////////////////////////
+    // begin CRN 
+    G4String rightSuppressorShellLogName = "rightSuppressorShell_" + strdet + "_" + strcry + "_log";
+    G4String leftSuppressorShellLogName = "leftSuppressorShell_" + strdet + "_" + strcry + "_log";
 
-	G4SubtractionSolid* backQuarterSuppressor = BackSuppressorQuarter();
+    G4String rightSuppressorLogName = "rightSuppressor_" + strdet + "_" + strcry + "_log";
+    G4String leftSuppressorLogName = "leftSuppressor_" + strdet + "_" + strcry + "_log";
 
-	G4SubtractionSolid* backQuarterSuppressorShell = ShellForBackSuppressorQuarter();
+    // Define the structureMat shell logical volume
+    G4SubtractionSolid* rightSuppressorShell = ShellForFrontSlantSuppressor("right");
 
-	// Insert the structureMat shell first.  The shells must be given numbers, rather than
-	// the suppressor pieces themselves.  As an error checking method, the suppressor
-	// pieces are given a copy number value far out of range of any useful copy number.
-	if(fIncludeBackSuppressors) {
-		fBackQuarterSuppressorShellLog = new G4LogicalVolume(
-				backQuarterSuppressorShell, structureMat,
-				"backQuarterSuppressorLog", 0, 0, 0);
+    fRightSuppressorShellLog = new G4LogicalVolume(rightSuppressorShell, structureMat,
+            rightSuppressorShellLogName, 0,0,0);
+    fRightSuppressorShellLog->SetVisAttributes(SuppressorVisAtt);
 
-		fBackQuarterSuppressorShellLog->SetVisAttributes(SuppressorVisAtt);
+    G4SubtractionSolid* leftSuppressorShell = ShellForFrontSlantSuppressor("left");
 
-		G4Material* backMaterial = G4Material::GetMaterial(fBackSuppressorMaterial);
-		if(!backMaterial) {
-			G4cout<<" ----> Back suppressor material "<<fBackSuppressorMaterial<<" not found, cannot build the detector shell! "<<G4endl;
-			exit(1);
-		}
+    fLeftSuppressorShellLog = new G4LogicalVolume(leftSuppressorShell, structureMat,
+            leftSuppressorShellLogName, 0,0,0);
+    fLeftSuppressorShellLog->SetVisAttributes(SuppressorVisAtt);
 
-		fBackQuarterSuppressorLog = new G4LogicalVolume(backQuarterSuppressor, backMaterial,
-				"backQuarterSuppressorLog", 0, 0, 0);
-		fBackQuarterSuppressorLog->SetVisAttributes(backInnardsVisAtt);
+    G4SubtractionSolid* rightSuppressor = FrontSlantSuppressor("right", false); // Right, non-chopping.
 
-		fSuppressorBackAssembly->AddPlacedVolume(fBackQuarterSuppressorLog, fMoveNull, fRotateNull);
+    fRightSuppressorLog = new G4LogicalVolume(rightSuppressor, materialBGO, rightSuppressorLogName, 0, 0, 0);
+    fRightSuppressorLog->SetVisAttributes(innardsVisAtt);
 
-		x0 = 	(fBackBGOThickness -fCanFaceThickness)/2.0 + fSuppressorShellThickness
-			+ fDetectorTotalLength +fBGOCanSeperation
-			+ fShift + fAppliedBackShift ;
+    G4SubtractionSolid* leftSuppressor = FrontSlantSuppressor("left", false); // Left, non-chopping.
 
-		y0 = fDetectorTotalWidth/4.0 ;
+    fLeftSuppressorLog = new G4LogicalVolume(leftSuppressor, materialBGO, leftSuppressorLogName 0, 0, 0);
+    fLeftSuppressorLog->SetVisAttributes(innardsVisAtt);
+    // end CRN 
 
-		z0 = fDetectorTotalWidth/4.0 ;
+    fRightSuppressorCasingAssembly->AddPlacedVolume(fRightSuppressorLog, fMoveNull, fRotateNull);
+    fLeftSuppressorCasingAssembly->AddPlacedVolume(fLeftSuppressorLog, fMoveNull, fRotateNull);
 
-		G4RotationMatrix* rotateBackSuppressorShells[4] ;
-		G4ThreeVector moveBackQuarterSuppressor[4] ;
 
-		for(i = 0 ; i < 4 ; i++) {
-			rotateBackSuppressorShells[i] = new G4RotationMatrix ;
-			rotateBackSuppressorShells[i]->rotateX(-M_PI / 2.0 + i * M_PI / 2.0) ;
+    /////////////////////////////////////////////////////////////////////
+    // Note : Left and Right are read from the BACK of the detector
+    // Suppressors 1 and 2 cover germanium 1
+    // Suppressors 3 and 4 cover germanium 2
+    // Suppressors 5 and 6 cover germanium 3
+    // Suppressors 7 and 8 cover germanium 4
+    /////////////////////////////////////////////////////////////////////
 
-			x = x0 ;
+    x0 =    shellSideSuppressorLength/2.0 -fCanFaceThickness/2.0
+        + fBentEndLength + (fBGOCanSeperation
+                + fBGOChoppedTip) / tan(fBentEndAngle)
+        + fShift + fAppliedBackShift ;
 
-			y = y0 * (sin(i * M_PI/2.0) - cos(i * M_PI/2.0)) ;
-			z = -z0 * (sin(i * M_PI/2.0) + cos(i * M_PI/2.0)) ;
+    y0 =    fSideBGOThickness/2.0 + fSuppressorShellThickness
+        + fDetectorTotalWidth/2.0 + fBGOCanSeperation ;
 
-			moveBackQuarterSuppressor[i] = G4ThreeVector(x, y, z) ;
+    z0 =    fSideBGOThickness/2.0 + fSuppressorShellThickness
+        + fDetectorTotalWidth/2.0 + fBGOCanSeperation ;
 
-			fBackAndSideSuppressorShellAssembly->AddPlacedVolume(fBackQuarterSuppressorShellLog, moveBackQuarterSuppressor[i], rotateBackSuppressorShells[i]) ;
-		}
-	}
+    G4RotationMatrix* rotateSuppressorExtensionShell[8] ;
+    G4ThreeVector moveSuppressorExtensionShell[8] ;
 
-	// now we add the side pieces of suppressor that taper off towards the front of the can
+    for(i = 0 ; i < 4 ; i++)
+    {
+        //********************** RIGHT **********************//
+        rotateSuppressorExtensionShell[2*i] = new G4RotationMatrix ;
+        rotateSuppressorExtensionShell[2*i]->rotateZ(M_PI/2.0) ;
+        rotateSuppressorExtensionShell[2*i]->rotateY(M_PI/2.0) ;
+        rotateSuppressorExtensionShell[2*i]->rotateX(M_PI * (1 - i/2.0)) ;
 
-	// Define the structureMat shell logical volume
-	G4SubtractionSolid* rightSuppressorShell = ShellForFrontSlantSuppressor("right");
+        x = x0 ;
 
-	fRightSuppressorShellLog = new G4LogicalVolume(rightSuppressorShell, structureMat,
-			"rightSuppressorShellLog", 0,0,0);
-	fRightSuppressorShellLog->SetVisAttributes(SuppressorVisAtt);
+        y = y0 * (-cos(i * M_PI/2.0) + sin(i * M_PI/2.0)) / (1 + (i + 1) % 2) ; // -y/2, y, y/2, -y
 
-	G4SubtractionSolid* leftSuppressorShell = ShellForFrontSlantSuppressor("left");
+        z = z0 * (cos(i * M_PI/2.0) + sin(i * M_PI/2.0)) / (1 + i % 2) ;  // z, z/2, -z, -z/2
 
-	fLeftSuppressorShellLog = new G4LogicalVolume(leftSuppressorShell, structureMat,
-			"leftSuppressorShellLog", 0,0,0);
-	fLeftSuppressorShellLog->SetVisAttributes(SuppressorVisAtt);
+        moveSuppressorExtensionShell[2*i] = G4ThreeVector(x, y, z) ;
 
-	G4SubtractionSolid* rightSuppressor = FrontSlantSuppressor("right", false); // Right, non-chopping.
+        fBackAndSideSuppressorShellAssembly->AddPlacedVolume(fRightSuppressorShellLog, moveSuppressorExtensionShell[2*i], rotateSuppressorExtensionShell[2*i]) ;
 
-	fRightSuppressorLog = new G4LogicalVolume(rightSuppressor, materialBGO, "rightSuppressorCasingLog", 0, 0, 0);
-	fRightSuppressorLog->SetVisAttributes(innardsVisAtt);
+        //*********************** LEFT ***********************//
+        rotateSuppressorExtensionShell[2*i+1] = new G4RotationMatrix ;
+        rotateSuppressorExtensionShell[2*i+1]->rotateY(-M_PI/2.0) ;
+        rotateSuppressorExtensionShell[2*i+1]->rotateX(M_PI * (1 - i/2.0)) ;
 
-	G4SubtractionSolid* leftSuppressor = FrontSlantSuppressor("left", false); // Left, non-chopping.
+        x = x0 ;
 
-	fLeftSuppressorLog = new G4LogicalVolume(leftSuppressor, materialBGO, "leftSuppressorCasingLog", 0, 0, 0);
-	fLeftSuppressorLog->SetVisAttributes(innardsVisAtt);
+        y = y0 * (cos(i * M_PI/2.0) - sin(i * M_PI/2.0)) / (1 + i % 2) ; // y, -y/2, -y, y/2
 
-	fRightSuppressorCasingAssembly->AddPlacedVolume(fRightSuppressorLog, fMoveNull, fRotateNull);
-	fLeftSuppressorCasingAssembly->AddPlacedVolume(fLeftSuppressorLog, fMoveNull, fRotateNull);
+        z = -z0 * (cos(i * M_PI/2.0) + sin(i * M_PI/2.0)) / (1 + (i + 1) % 2) ; // -z/2, -z, z/2, z
 
+        moveSuppressorExtensionShell[2*i+1] = G4ThreeVector(x, y, z) ;
 
-	/////////////////////////////////////////////////////////////////////
-	// Note : Left and Right are read from the BACK of the detector
-	// Suppressors 1 and 2 cover germanium 1
-	// Suppressors 3 and 4 cover germanium 2
-	// Suppressors 5 and 6 cover germanium 3
-	// Suppressors 7 and 8 cover germanium 4
-	/////////////////////////////////////////////////////////////////////
+        fBackAndSideSuppressorShellAssembly->AddPlacedVolume(fLeftSuppressorShellLog, moveSuppressorExtensionShell[2*i+1], rotateSuppressorExtensionShell[2*i+1]) ;
 
-	x0 =    shellSideSuppressorLength/2.0 -fCanFaceThickness/2.0
-		+ fBentEndLength + (fBGOCanSeperation
-				+ fBGOChoppedTip) / tan(fBentEndAngle)
-		+ fShift + fAppliedBackShift ;
+    }
 
-	y0 =    fSideBGOThickness/2.0 + fSuppressorShellThickness
-		+ fDetectorTotalWidth/2.0 + fBGOCanSeperation ;
 
-	z0 =    fSideBGOThickness/2.0 + fSuppressorShellThickness
-		+ fDetectorTotalWidth/2.0 + fBGOCanSeperation ;
+    ////////////////////////////////////////////////////////////////////////////////////////
+    // now we add the side pieces of suppressor that extend out in front of the can when it's in the back position
+    ////////////////////////////////////////////////////////////////////////////////////////
+    // begin CRN 
+    G4String rightSuppressorExtensionLogName = "rightSuppressorExtension_" + strdet + "_" + strcry + "_log";
+    G4String leftSuppressorExtensionLogName = "leftSuppressorExtension_" + strdet + "_" + strcry + "_log";
 
-	G4RotationMatrix* rotateSuppressorExtensionShell[8] ;
-	G4ThreeVector moveSuppressorExtensionShell[8] ;
+    G4String rightSuppressorShellExtensionLogName = "rightSuppressorShellExtension_" + strdet + "_" + strcry + "_log";
+    G4String leftSuppressorShellExtensionLogName = "leftSuppressorShellExtension_" + strdet + "_" + strcry + "_log";
+    // end CRN
 
-	for(i = 0 ; i < 4 ; i++)
-	{
-		//********************** RIGHT **********************//
-		rotateSuppressorExtensionShell[2*i] = new G4RotationMatrix ;
-		rotateSuppressorExtensionShell[2*i]->rotateZ(M_PI/2.0) ;
-		rotateSuppressorExtensionShell[2*i]->rotateY(M_PI/2.0) ;
-		rotateSuppressorExtensionShell[2*i]->rotateX(M_PI * (1 - i/2.0)) ;
+    // Define the shell right logical volume
+    // G4SubtractionSolid* rightSuppressorShellExtension = ShellForRightSuppressorExtension();
+    G4SubtractionSolid* rightSuppressorShellExtension = ShellForSuppressorExtension("right");
 
-		x = x0 ;
+    // begin CRN
+    fRightSuppressorShellExtensionLog = new G4LogicalVolume(rightSuppressorShellExtension,
+            materialBGO, rightSuppressorShellExtensionLogName, 0, 0, 0);
+    // end CRN
+    fRightSuppressorShellExtensionLog->SetVisAttributes(SuppressorVisAtt);
 
-		y = y0 * (-cos(i * M_PI/2.0) + sin(i * M_PI/2.0)) / (1 + (i + 1) % 2) ; // -y/2, y, y/2, -y
+    G4SubtractionSolid* rightSuppressorExtension = SideSuppressorExtension("right", false); // Right, non-chopping // CALLED
 
-		z = z0 * (cos(i * M_PI/2.0) + sin(i * M_PI/2.0)) / (1 + i % 2) ;  // z, z/2, -z, -z/2
+    // begin CRN
+    fRightSuppressorExtensionLog = new G4LogicalVolume(rightSuppressorExtension, materialBGO,
+            rightSuppressorExtensionLogName, 0, 0, 0);
+    // end CRN
+    fRightSuppressorExtensionLog->SetVisAttributes(innardsVisAtt);
 
-		moveSuppressorExtensionShell[2*i] = G4ThreeVector(x, y, z) ;
+    // Define the left shell logical volume
+    // G4SubtractionSolid* leftSuppressorShellExtension = ShellForLeftSuppressorExtension();
+    G4SubtractionSolid* leftSuppressorShellExtension = ShellForSuppressorExtension("left");
 
-		fBackAndSideSuppressorShellAssembly->AddPlacedVolume(fRightSuppressorShellLog, moveSuppressorExtensionShell[2*i], rotateSuppressorExtensionShell[2*i]) ;
 
-		//*********************** LEFT ***********************//
-		rotateSuppressorExtensionShell[2*i+1] = new G4RotationMatrix ;
-		rotateSuppressorExtensionShell[2*i+1]->rotateY(-M_PI/2.0) ;
-		rotateSuppressorExtensionShell[2*i+1]->rotateX(M_PI * (1 - i/2.0)) ;
+    // begin CRN
+    fLeftSuppressorShellExtensionLog = new G4LogicalVolume(leftSuppressorShellExtension,
+            materialBGO, leftSuppressorShellExtensionLogName, 0, 0, 0);
+    //end CRN 
+    fLeftSuppressorShellExtensionLog->SetVisAttributes(SuppressorVisAtt);
 
-		x = x0 ;
+    G4SubtractionSolid* leftSuppressorExtension = SideSuppressorExtension("left", false); // Left, Non-chopping // CALLED
 
-		y = y0 * (cos(i * M_PI/2.0) - sin(i * M_PI/2.0)) / (1 + i % 2) ; // y, -y/2, -y, y/2
+    // begin CRN
+    fLeftSuppressorExtensionLog = new G4LogicalVolume(leftSuppressorExtension, materialBGO,
+            leftSuppressorExtensionLogName, 0, 0, 0);
+    // end CRN
+    fLeftSuppressorExtensionLog->SetVisAttributes(innardsVisAtt);
 
-		z = -z0 * (cos(i * M_PI/2.0) + sin(i * M_PI/2.0)) / (1 + (i + 1) % 2) ; // -z/2, -z, z/2, z
+    fRightSuppressorExtensionAssembly->AddPlacedVolume(fRightSuppressorExtensionLog, fMoveNull, fRotateNull);
+    fLeftSuppressorExtensionAssembly->AddPlacedVolume(fLeftSuppressorExtensionLog, fMoveNull, fRotateNull);
 
-		moveSuppressorExtensionShell[2*i+1] = G4ThreeVector(x, y, z) ;
+    //geometry objects for the following:
+    G4RotationMatrix* rotateExtension[8];
+    G4ThreeVector moveExtension[8];
 
-		fBackAndSideSuppressorShellAssembly->AddPlacedVolume(fLeftSuppressorShellLog, moveSuppressorExtensionShell[2*i+1], rotateSuppressorExtensionShell[2*i+1]) ;
+    x0 =  - fCanFaceThickness/2.0 -(shellSuppressorExtensionLength/2.0
+            - (fSuppressorExtensionThickness + fSuppressorShellThickness*2.0)
+            * tan(fBentEndAngle)/2.0)
+        * cos(fBentEndAngle) +fBentEndLength +(fBGOCanSeperation
+                + fSideBGOThickness
+                + fSuppressorShellThickness*2.0)/tan(fBentEndAngle)
+        - (fSuppressorExtensionThickness + fSuppressorShellThickness*2.0)
+        * sin(fBentEndAngle) +fSuppShift +fSuppressorBackRadius
+        - fSuppressorForwardRadius ;
 
-	}
+    y0 =  - (shellSuppressorExtensionLength * tan(shellSuppressorExtensionAngle) / 2.0
+            + (fSuppressorForwardRadius + fHevimetTipThickness)
+            * sin(fBentEndAngle))/2.0;
 
+    z0 =  - ((fSuppressorExtensionThickness/2.0 + fSuppressorShellThickness)
+            / cos(fBentEndAngle)
+            + (shellSuppressorExtensionLength/2.0 -(fSuppressorExtensionThickness
+                    + fSuppressorShellThickness*2.0)
+                * tan(fBentEndAngle)/2.0)*sin(fBentEndAngle) -(fSuppressorBackRadius
+                + fBentEndLength +(fBGOCanSeperation
+                    + fSideBGOThickness + fSuppressorShellThickness*2.0)
+                / tan(fBentEndAngle) -(fSuppressorExtensionThickness
+                    + fSuppressorShellThickness*2.0)
+                * sin(fBentEndAngle)) * tan(fBentEndAngle)) ;
 
-	// now we add the side pieces of suppressor that extend out in front of the can when it's in the back position
+    if(fSuppressorPositionSelector == 0 && fIncludeExtensionSuppressors)
+    {
 
-	// Define the shell right logical volume
-	// G4SubtractionSolid* rightSuppressorShellExtension = ShellForRightSuppressorExtension();
-	G4SubtractionSolid* rightSuppressorShellExtension = ShellForSuppressorExtension("right");
+        // these two parameters are for shifting the extensions back and out when in their BACK position
+        G4double extensionBackShift =   fAirBoxFrontLength
+            - (fHevimetTipThickness +shellSuppressorExtensionLength
+                    + (fSuppressorExtensionThickness + fSuppressorShellThickness*2.0)
+                    * tan(fBentEndAngle)) * cos(fBentEndAngle) ;
 
-	fRightSuppressorShellExtensionLog = new G4LogicalVolume(rightSuppressorShellExtension,
-			materialBGO, "rightSuppressorShellExtensionLog", 0, 0, 0);
-	fRightSuppressorShellExtensionLog->SetVisAttributes(SuppressorVisAtt);
+        G4double extensionRadialShift = extensionBackShift * tan(fBentEndAngle) ;
 
-	G4SubtractionSolid* rightSuppressorExtension = SideSuppressorExtension("right", false); // Right, non-chopping // CALLED
+        // The suppressors are put into the back position
 
-	fRightSuppressorExtensionLog = new G4LogicalVolume(rightSuppressorExtension, materialBGO,
-			"rightSuppressorExtensionLog", 0, 0, 0);
-	fRightSuppressorExtensionLog->SetVisAttributes(innardsVisAtt);
+        x0 += extensionBackShift ;
 
-	// Define the left shell logical volume
-	// G4SubtractionSolid* leftSuppressorShellExtension = ShellForLeftSuppressorExtension();
-	G4SubtractionSolid* leftSuppressorShellExtension = ShellForSuppressorExtension("left");
+        z0 += extensionRadialShift ;
 
+        for(i=0; i<4; i++)
+        {
+            rotateExtension[i*2] = new G4RotationMatrix;
+            rotateExtension[i*2]->rotateZ(M_PI/2.0);
+            rotateExtension[i*2]->rotateY(fBentEndAngle);
+            rotateExtension[i*2]->rotateX(M_PI - M_PI/2.0*i);
 
-	fLeftSuppressorShellExtensionLog = new G4LogicalVolume(leftSuppressorShellExtension,
-			materialBGO, "leftSuppressorShellExtensionLog", 0, 0, 0);
-	fLeftSuppressorShellExtensionLog->SetVisAttributes(SuppressorVisAtt);
+            x = x0;
+            y = y0*cos(i*M_PI/2) + z0*sin(i*M_PI/2);
+            z = z0*cos(i*M_PI/2) - y0*sin(i*M_PI/2);
 
-	G4SubtractionSolid* leftSuppressorExtension = SideSuppressorExtension("left", false); // Left, Non-chopping // CALLED
+            moveExtension[i*2] = G4ThreeVector(x, y, z);
 
-	fLeftSuppressorExtensionLog = new G4LogicalVolume(leftSuppressorExtension, materialBGO,
-			"leftSuppressorExtensionLog", 0, 0, 0);
-	fLeftSuppressorExtensionLog->SetVisAttributes(innardsVisAtt);
+            fExtensionSuppressorShellAssembly->AddPlacedVolume(fRightSuppressorShellExtensionLog, moveExtension[i*2], rotateExtension[i*2]);
 
-	fRightSuppressorExtensionAssembly->AddPlacedVolume(fRightSuppressorExtensionLog, fMoveNull, fRotateNull);
-	fLeftSuppressorExtensionAssembly->AddPlacedVolume(fLeftSuppressorExtensionLog, fMoveNull, fRotateNull);
+            rotateExtension[i*2+1] = new G4RotationMatrix;
+            rotateExtension[i*2+1]->rotateY(M_PI/2.0);
+            rotateExtension[i*2+1]->rotateZ(M_PI/2.0 + fBentEndAngle);
+            rotateExtension[i*2+1]->rotateX(M_PI - M_PI/2.0*i);
 
-	//geometry objects for the following:
-	G4RotationMatrix* rotateExtension[8];
-	G4ThreeVector moveExtension[8];
+            x = x0;
+            y = -z0*cos(i*M_PI/2) - y0*sin(i*M_PI/2);
+            z = -y0*cos(i*M_PI/2) + z0*sin(i*M_PI/2);
 
-	x0 =  - fCanFaceThickness/2.0 -(shellSuppressorExtensionLength/2.0
-			- (fSuppressorExtensionThickness + fSuppressorShellThickness*2.0)
-			* tan(fBentEndAngle)/2.0)
-		* cos(fBentEndAngle) +fBentEndLength +(fBGOCanSeperation
-				+ fSideBGOThickness
-				+ fSuppressorShellThickness*2.0)/tan(fBentEndAngle)
-		- (fSuppressorExtensionThickness + fSuppressorShellThickness*2.0)
-		* sin(fBentEndAngle) +fSuppShift +fSuppressorBackRadius
-		- fSuppressorForwardRadius ;
+            moveExtension[i*2+1] = G4ThreeVector(x, y, z);
 
-	y0 =  - (shellSuppressorExtensionLength * tan(shellSuppressorExtensionAngle) / 2.0
-			+ (fSuppressorForwardRadius + fHevimetTipThickness)
-			* sin(fBentEndAngle))/2.0;
+            fExtensionSuppressorShellAssembly->AddPlacedVolume(fLeftSuppressorShellExtensionLog, moveExtension[i*2+1], rotateExtension[i*2+1]);
+        }
 
-	z0 =  - ((fSuppressorExtensionThickness/2.0 + fSuppressorShellThickness)
-			/ cos(fBentEndAngle)
-			+ (shellSuppressorExtensionLength/2.0 -(fSuppressorExtensionThickness
-					+ fSuppressorShellThickness*2.0)
-				* tan(fBentEndAngle)/2.0)*sin(fBentEndAngle) -(fSuppressorBackRadius
-				+ fBentEndLength +(fBGOCanSeperation
-					+ fSideBGOThickness + fSuppressorShellThickness*2.0)
-				/ tan(fBentEndAngle) -(fSuppressorExtensionThickness
-					+ fSuppressorShellThickness*2.0)
-				* sin(fBentEndAngle)) * tan(fBentEndAngle)) ;
 
-	if(fSuppressorPositionSelector == 0 && fIncludeExtensionSuppressors)
-	{
+    }//end if(detectors forward) statement
 
-		// these two parameters are for shifting the extensions back and out when in their BACK position
-		G4double extensionBackShift =   fAirBoxFrontLength
-			- (fHevimetTipThickness +shellSuppressorExtensionLength
-					+ (fSuppressorExtensionThickness + fSuppressorShellThickness*2.0)
-					* tan(fBentEndAngle)) * cos(fBentEndAngle) ;
+    // Otherwise, put them forward
+    else if(fSuppressorPositionSelector == 1 && fIncludeExtensionSuppressors)
+    {
 
-		G4double extensionRadialShift = extensionBackShift * tan(fBentEndAngle) ;
+        for(i = 0 ; i < 4 ; i++){
+            rotateExtension[2*i] = new G4RotationMatrix;
+            rotateExtension[2*i]->rotateZ(M_PI/2.0);
+            rotateExtension[2*i]->rotateY(fBentEndAngle);
+            rotateExtension[2*i]->rotateX(M_PI - i*M_PI/2.0);
 
-		// The suppressors are put into the back position
+            x = x0;
+            y = y0*cos(i*M_PI/2) + z0*sin(i*M_PI/2);
+            z = z0*cos(i*M_PI/2) - y0*sin(i*M_PI/2);
 
-		x0 += extensionBackShift ;
+            moveExtension[i*2] = G4ThreeVector(x, y, z);
 
-		z0 += extensionRadialShift ;
+            fExtensionSuppressorShellAssembly->AddPlacedVolume(fRightSuppressorShellExtensionLog, moveExtension[2*i], rotateExtension[2*i]);
 
-		for(i=0; i<4; i++)
-		{
-			rotateExtension[i*2] = new G4RotationMatrix;
-			rotateExtension[i*2]->rotateZ(M_PI/2.0);
-			rotateExtension[i*2]->rotateY(fBentEndAngle);
-			rotateExtension[i*2]->rotateX(M_PI - M_PI/2.0*i);
+            rotateExtension[2*i+1] = new G4RotationMatrix;
+            rotateExtension[2*i+1]->rotateY(M_PI/2.0);
+            rotateExtension[2*i+1]->rotateZ(M_PI/2.0 + fBentEndAngle);
+            rotateExtension[2*i+1]->rotateX(M_PI - i*M_PI/2);
 
-			x = x0;
-			y = y0*cos(i*M_PI/2) + z0*sin(i*M_PI/2);
-			z = z0*cos(i*M_PI/2) - y0*sin(i*M_PI/2);
+            x =  x0;
+            y =  -z0 * cos(i*M_PI/2) - y0 * sin(i*M_PI/2);
+            z =  -y0 * cos(i*M_PI/2) + z0 * sin(i*M_PI/2);
 
-			moveExtension[i*2] = G4ThreeVector(x, y, z);
+            moveExtension[i*2+1] = G4ThreeVector(x, y, z);
 
-			fExtensionSuppressorShellAssembly->AddPlacedVolume(fRightSuppressorShellExtensionLog, moveExtension[i*2], rotateExtension[i*2]);
+            fExtensionSuppressorShellAssembly->AddPlacedVolume(fLeftSuppressorShellExtensionLog, moveExtension[2*i+1], rotateExtension[2*i+1]);
+        }
 
-			rotateExtension[i*2+1] = new G4RotationMatrix;
-			rotateExtension[i*2+1]->rotateY(M_PI/2.0);
-			rotateExtension[i*2+1]->rotateZ(M_PI/2.0 + fBentEndAngle);
-			rotateExtension[i*2+1]->rotateX(M_PI - M_PI/2.0*i);
-
-			x = x0;
-			y = -z0*cos(i*M_PI/2) - y0*sin(i*M_PI/2);
-			z = -y0*cos(i*M_PI/2) + z0*sin(i*M_PI/2);
-
-			moveExtension[i*2+1] = G4ThreeVector(x, y, z);
-
-			fExtensionSuppressorShellAssembly->AddPlacedVolume(fLeftSuppressorShellExtensionLog, moveExtension[i*2+1], rotateExtension[i*2+1]);
-		}
-
-
-	}//end if(detectors forward) statement
-
-	// Otherwise, put them forward
-	else if(fSuppressorPositionSelector == 1 && fIncludeExtensionSuppressors)
-	{
-
-		for(i = 0 ; i < 4 ; i++){
-			rotateExtension[2*i] = new G4RotationMatrix;
-			rotateExtension[2*i]->rotateZ(M_PI/2.0);
-			rotateExtension[2*i]->rotateY(fBentEndAngle);
-			rotateExtension[2*i]->rotateX(M_PI - i*M_PI/2.0);
-
-			x = x0;
-			y = y0*cos(i*M_PI/2) + z0*sin(i*M_PI/2);
-			z = z0*cos(i*M_PI/2) - y0*sin(i*M_PI/2);
-
-			moveExtension[i*2] = G4ThreeVector(x, y, z);
-
-			fExtensionSuppressorShellAssembly->AddPlacedVolume(fRightSuppressorShellExtensionLog, moveExtension[2*i], rotateExtension[2*i]);
-
-			rotateExtension[2*i+1] = new G4RotationMatrix;
-			rotateExtension[2*i+1]->rotateY(M_PI/2.0);
-			rotateExtension[2*i+1]->rotateZ(M_PI/2.0 + fBentEndAngle);
-			rotateExtension[2*i+1]->rotateX(M_PI - i*M_PI/2);
-
-			x =  x0;
-			y =  -z0 * cos(i*M_PI/2) - y0 * sin(i*M_PI/2);
-			z =  -y0 * cos(i*M_PI/2) + z0 * sin(i*M_PI/2);
-
-			moveExtension[i*2+1] = G4ThreeVector(x, y, z);
-
-			fExtensionSuppressorShellAssembly->AddPlacedVolume(fLeftSuppressorShellExtensionLog, moveExtension[2*i+1], rotateExtension[2*i+1]);
-		}
-
-	}//end if(detectors back) statement
+    }//end if(detectors back) statement
 
 }//end ::ConstructNewSuppressorCasingWithShells
 
 
 void DetectionSystemGriffin::ConstructNewSuppressorCasingDetectorSpecificDeadLayer(G4int det, G4int cry) {
-	G4String strdet = G4UIcommand::ConvertToString(det);
-	G4String strcry = G4UIcommand::ConvertToString(cry);
+    G4String strdet = G4UIcommand::ConvertToString(det);
+    G4String strcry = G4UIcommand::ConvertToString(cry);
 
-	G4Material* materialBGO = G4Material::GetMaterial(fBGOMaterial);
-	if(!materialBGO) {
-		G4cout<<" ----> BGO material "<<fBGOMaterial<<" not found, cannot build the detector shell! "<<G4endl;
-		exit(1);
-	}
+    G4Material* materialBGO = G4Material::GetMaterial(fBGOMaterial);
+    if(!materialBGO) {
+        G4cout<<" ----> BGO material "<<fBGOMaterial<<" not found, cannot build the detector shell! "<<G4endl;
+        exit(1);
+    }
 
-	G4VisAttributes* SuppressorVisAtt = new G4VisAttributes(G4Colour(0.75,0.75,0.75));
-	SuppressorVisAtt->SetVisibility(true);
-	G4VisAttributes* innardsVisAtt = new G4VisAttributes(G4Colour(0.75, 0.75, 0.75));
-	innardsVisAtt->SetVisibility(true);
-	G4VisAttributes* backInnardsVisAtt = new G4VisAttributes(G4Colour(0.0, 1.0, 0.0));
-	backInnardsVisAtt->SetVisibility(true);
+    G4VisAttributes* SuppressorVisAtt = new G4VisAttributes(G4Colour(0.75,0.75,0.75));
+    SuppressorVisAtt->SetVisibility(true);
+    G4VisAttributes* innardsVisAtt = new G4VisAttributes(G4Colour(0.75, 0.75, 0.75));
+    innardsVisAtt->SetVisibility(true);
+    G4VisAttributes* backInnardsVisAtt = new G4VisAttributes(G4Colour(0.0, 1.0, 0.0));
+    backInnardsVisAtt->SetVisibility(true);
 
-	// first we add the four pieces of back suppressor, and their shells
+    // first we add the four pieces of back suppressor, and their shells
 
-	G4SubtractionSolid* backQuarterSuppressor = BackSuppressorQuarter();
+    G4SubtractionSolid* backQuarterSuppressor = BackSuppressorQuarter();
 
-	// Insert the structureMat shell first.  The shells must be given numbers, rather than
-	// the suppressor pieces themselves.  As an error checking method, the suppressor
-	// pieces are given a copy number value far out of range of any useful copy number.
-	if(fIncludeBackSuppressors) {
-		G4Material* backMaterial = G4Material::GetMaterial(fBackSuppressorMaterial);
+    // Insert the structureMat shell first.  The shells must be given numbers, rather than
+    // the suppressor pieces themselves.  As an error checking method, the suppressor
+    // pieces are given a copy number value far out of range of any useful copy number.
+    if(fIncludeBackSuppressors) {
+        G4Material* backMaterial = G4Material::GetMaterial(fBackSuppressorMaterial);
 
-		if(!backMaterial) {
-			G4cout<<" ----> Back suppressor material "<<fBackSuppressorMaterial<<" not found, cannot build the detector shell! "<<G4endl;
-			exit(1);
-		}
+        if(!backMaterial) {
+            G4cout<<" ----> Back suppressor material "<<fBackSuppressorMaterial<<" not found, cannot build the detector shell! "<<G4endl;
+            exit(1);
+        }
 
-		G4String backQuarterSuppressorName = "backDlsQuarterSuppressor_" + strdet + "_" + strcry + "_log" ;
+        G4String backQuarterSuppressorName = "backDlsQuarterSuppressor_" + strdet + "_" + strcry + "_log" ;
 
-		fBackQuarterSuppressorLog = new G4LogicalVolume(backQuarterSuppressor, backMaterial,
-				backQuarterSuppressorName, 0, 0, 0);
+        fBackQuarterSuppressorLog = new G4LogicalVolume(backQuarterSuppressor, backMaterial,
+                backQuarterSuppressorName, 0, 0, 0);
 
-		fBackQuarterSuppressorLog->SetVisAttributes(backInnardsVisAtt);
+        fBackQuarterSuppressorLog->SetVisAttributes(backInnardsVisAtt);
 
-		fSuppressorBackAssemblyCry[cry]->AddPlacedVolume(fBackQuarterSuppressorLog, fMoveNull, fRotateNull);
+        fSuppressorBackAssemblyCry[cry]->AddPlacedVolume(fBackQuarterSuppressorLog, fMoveNull, fRotateNull);
 
-	}
+    }
 
-	// now we add the side pieces of suppressor that taper off towards the front of the can
+    // now we add the side pieces of suppressor that taper off towards the front of the can
 
-	G4String rightSuppressorCasingName = "rightDlsSuppressorCasing_" + strdet + "_" + strcry + "_log" ;
-	G4String leftSuppressorCasingName = "leftDlsSuppressorCasing_" + strdet + "_" + strcry + "_log" ;
+    G4String rightSuppressorCasingName = "rightDlsSuppressorCasing_" + strdet + "_" + strcry + "_log" ;
+    G4String leftSuppressorCasingName = "leftDlsSuppressorCasing_" + strdet + "_" + strcry + "_log" ;
 
-	G4SubtractionSolid* rightSuppressor = FrontSlantSuppressor("right", false); // Right, non-chopping. // CALLED
+    G4SubtractionSolid* rightSuppressor = FrontSlantSuppressor("right", false); // Right, non-chopping. // CALLED
 
-	fRightSuppressorLog = new G4LogicalVolume(rightSuppressor, materialBGO, rightSuppressorCasingName, 0, 0, 0);
-	fRightSuppressorLog->SetVisAttributes(innardsVisAtt);
+    fRightSuppressorLog = new G4LogicalVolume(rightSuppressor, materialBGO, rightSuppressorCasingName, 0, 0, 0);
+    fRightSuppressorLog->SetVisAttributes(innardsVisAtt);
 
-	G4SubtractionSolid* leftSuppressor = FrontSlantSuppressor("left", false); // Left, non-chopping. // CALLED
+    G4SubtractionSolid* leftSuppressor = FrontSlantSuppressor("left", false); // Left, non-chopping. // CALLED
 
-	fLeftSuppressorLog = new G4LogicalVolume(leftSuppressor, materialBGO, leftSuppressorCasingName, 0, 0, 0);
-	fLeftSuppressorLog->SetVisAttributes(innardsVisAtt);
+    fLeftSuppressorLog = new G4LogicalVolume(leftSuppressor, materialBGO, leftSuppressorCasingName, 0, 0, 0);
+    fLeftSuppressorLog->SetVisAttributes(innardsVisAtt);
 
-	fRightSuppressorCasingAssemblyCry[cry]->AddPlacedVolume(fRightSuppressorLog, fMoveNull, fRotateNull);
-	fLeftSuppressorCasingAssemblyCry[cry]->AddPlacedVolume(fLeftSuppressorLog, fMoveNull, fRotateNull);
+    fRightSuppressorCasingAssemblyCry[cry]->AddPlacedVolume(fRightSuppressorLog, fMoveNull, fRotateNull);
+    fLeftSuppressorCasingAssemblyCry[cry]->AddPlacedVolume(fLeftSuppressorLog, fMoveNull, fRotateNull);
 
-	G4String rightSuppressorExtensionName = "rightDlsSuppressorExtension_" + strdet + "_" + strcry + "_log" ;
-	G4String leftSuppressorExtensionName = "leftDlsSuppressorExtension_" + strdet + "_" + strcry + "_log" ;
+    G4String rightSuppressorExtensionName = "rightDlsSuppressorExtension_" + strdet + "_" + strcry + "_log" ;
+    G4String leftSuppressorExtensionName = "leftDlsSuppressorExtension_" + strdet + "_" + strcry + "_log" ;
 
-	// now we add the side pieces of suppressor that extend out in front of the can when it's in the back position
+    // now we add the side pieces of suppressor that extend out in front of the can when it's in the back position
 
-	G4SubtractionSolid* rightSuppressorExtension = SideSuppressorExtension("right", false); // Right, non-chopping // CALLED
+    G4SubtractionSolid* rightSuppressorExtension = SideSuppressorExtension("right", false); // Right, non-chopping // CALLED
 
-	fRightSuppressorExtensionLog = new G4LogicalVolume(rightSuppressorExtension, materialBGO,
-			rightSuppressorExtensionName, 0, 0, 0);
-	fRightSuppressorExtensionLog->SetVisAttributes(innardsVisAtt);
+    fRightSuppressorExtensionLog = new G4LogicalVolume(rightSuppressorExtension, materialBGO,
+            rightSuppressorExtensionName, 0, 0, 0);
+    fRightSuppressorExtensionLog->SetVisAttributes(innardsVisAtt);
 
-	G4SubtractionSolid* leftSuppressorExtension = SideSuppressorExtension("left", false); // Left, Non-chopping // CALLED
+    G4SubtractionSolid* leftSuppressorExtension = SideSuppressorExtension("left", false); // Left, Non-chopping // CALLED
 
-	fLeftSuppressorExtensionLog = new G4LogicalVolume(leftSuppressorExtension, materialBGO,
-			leftSuppressorExtensionName, 0, 0, 0);
-	fLeftSuppressorExtensionLog->SetVisAttributes(innardsVisAtt);
+    fLeftSuppressorExtensionLog = new G4LogicalVolume(leftSuppressorExtension, materialBGO,
+            leftSuppressorExtensionName, 0, 0, 0);
+    fLeftSuppressorExtensionLog->SetVisAttributes(innardsVisAtt);
 
-	fRightSuppressorExtensionAssemblyCry[cry]->AddPlacedVolume(fRightSuppressorExtensionLog, fMoveNull, fRotateNull);
-	fLeftSuppressorExtensionAssemblyCry[cry]->AddPlacedVolume(fLeftSuppressorExtensionLog, fMoveNull, fRotateNull);
+    fRightSuppressorExtensionAssemblyCry[cry]->AddPlacedVolume(fRightSuppressorExtensionLog, fMoveNull, fRotateNull);
+    fLeftSuppressorExtensionAssemblyCry[cry]->AddPlacedVolume(fLeftSuppressorExtensionLog, fMoveNull, fRotateNull);
 
 
 }//end ::ConstructNewSuppressorCasingDetectorSpecificDeadLayer
@@ -2074,69 +2113,69 @@ void DetectionSystemGriffin::ConstructNewSuppressorCasingDetectorSpecificDeadLay
 // the electrodeMat layers between the crystals
 ///////////////////////////////////////////////////////////////////////
 G4UnionSolid* DetectionSystemGriffin::InterCrystalelectrodeMatBack() {
-	G4double distanceOfTheTriangleTips = fGermaniumSeparation/2.0
-		+ (fGermaniumWidth/2.0 - fGermaniumShift) //centre of the middle hole
-		+ sqrt(pow((fGermaniumOuterRadius
-						+ fTrianglePostsDistanceFromCrystals), 2.0)
-				- pow(fGermaniumWidth/2.0 - fGermaniumShift, 2.0));
+    G4double distanceOfTheTriangleTips = fGermaniumSeparation/2.0
+        + (fGermaniumWidth/2.0 - fGermaniumShift) //centre of the middle hole
+        + sqrt(pow((fGermaniumOuterRadius
+                        + fTrianglePostsDistanceFromCrystals), 2.0)
+                - pow(fGermaniumWidth/2.0 - fGermaniumShift, 2.0));
 
-	G4double extentOfTheElectrodeMatPieces = distanceOfTheTriangleTips
-		- fTrianglePostsDistanceFromCrystals;
+    G4double extentOfTheElectrodeMatPieces = distanceOfTheTriangleTips
+        - fTrianglePostsDistanceFromCrystals;
 
-	G4Box* electrodeMatPiece1 = new G4Box("electrodeMatPiece1", extentOfTheElectrodeMatPieces,
-			(fGermaniumLength-fGermaniumBentLength)/2.0,
-			fInterCrystalElectrodeMatThickness/2.0);
+    G4Box* electrodeMatPiece1 = new G4Box("electrodeMatPiece1", extentOfTheElectrodeMatPieces,
+            (fGermaniumLength-fGermaniumBentLength)/2.0,
+            fInterCrystalElectrodeMatThickness/2.0);
 
-	G4Box* electrodeMatPiece2 = new G4Box("electrodeMatPiece2", extentOfTheElectrodeMatPieces,
-			(fGermaniumLength-fGermaniumBentLength)/2.0,
-			fInterCrystalElectrodeMatThickness/2.0);
+    G4Box* electrodeMatPiece2 = new G4Box("electrodeMatPiece2", extentOfTheElectrodeMatPieces,
+            (fGermaniumLength-fGermaniumBentLength)/2.0,
+            fInterCrystalElectrodeMatThickness/2.0);
 
-	G4RotationMatrix* rotatePiece2 = new G4RotationMatrix;
-	rotatePiece2->rotateY(M_PI/2.0);
+    G4RotationMatrix* rotatePiece2 = new G4RotationMatrix;
+    rotatePiece2->rotateY(M_PI/2.0);
 
-	G4ThreeVector moveZero(0,0,0);
+    G4ThreeVector moveZero(0,0,0);
 
-	G4UnionSolid* interCrystalElectrodeMatBack = new G4UnionSolid(
-			"interCrystalElectrodeMatBack", electrodeMatPiece1, electrodeMatPiece2,
-			rotatePiece2, moveZero);
+    G4UnionSolid* interCrystalElectrodeMatBack = new G4UnionSolid(
+            "interCrystalElectrodeMatBack", electrodeMatPiece1, electrodeMatPiece2,
+            rotatePiece2, moveZero);
 
-	return interCrystalElectrodeMatBack;
+    return interCrystalElectrodeMatBack;
 } //end ::interCrystalelectrodeMatBack
 
 G4UnionSolid* DetectionSystemGriffin::InterCrystalelectrodeMatFront() {
 
-	G4double distanceOfTheTriangleTips = fGermaniumSeparation/2.0
-		+ (fGermaniumWidth/2.0 - fGermaniumShift) //centre of the middle hole
-		+ sqrt(pow((fGermaniumOuterRadius
-						+ fTrianglePostsDistanceFromCrystals), 2.0)
-				- pow(fGermaniumWidth/2.0 - fGermaniumShift, 2.0));
+    G4double distanceOfTheTriangleTips = fGermaniumSeparation/2.0
+        + (fGermaniumWidth/2.0 - fGermaniumShift) //centre of the middle hole
+        + sqrt(pow((fGermaniumOuterRadius
+                        + fTrianglePostsDistanceFromCrystals), 2.0)
+                - pow(fGermaniumWidth/2.0 - fGermaniumShift, 2.0));
 
-	G4Trd* electrodeMatPiece1 = new G4Trd("electrodeMatPiece1", distanceOfTheTriangleTips
-			- fTrianglePostsDistanceFromCrystals,
-			fGermaniumWidth - fGermaniumBentLength
-			*tan(fBentEndAngle),
-			fGermaniumSeparation/2.0,
-			fGermaniumSeparation/2.0, (fGermaniumBentLength
-				- fElectrodeMatStartingDepth)/2.0);
+    G4Trd* electrodeMatPiece1 = new G4Trd("electrodeMatPiece1", distanceOfTheTriangleTips
+            - fTrianglePostsDistanceFromCrystals,
+            fGermaniumWidth - fGermaniumBentLength
+            *tan(fBentEndAngle),
+            fGermaniumSeparation/2.0,
+            fGermaniumSeparation/2.0, (fGermaniumBentLength
+                - fElectrodeMatStartingDepth)/2.0);
 
-	G4Trd* electrodeMatPiece2 = new G4Trd("electrodeMatPiece2", distanceOfTheTriangleTips
-			- fTrianglePostsDistanceFromCrystals,
-			fGermaniumWidth - fGermaniumBentLength
-			*tan(fBentEndAngle),
-			fGermaniumSeparation/2.0,
-			fGermaniumSeparation/2.0, (fGermaniumBentLength
-				- fElectrodeMatStartingDepth)/2.0);
+    G4Trd* electrodeMatPiece2 = new G4Trd("electrodeMatPiece2", distanceOfTheTriangleTips
+            - fTrianglePostsDistanceFromCrystals,
+            fGermaniumWidth - fGermaniumBentLength
+            *tan(fBentEndAngle),
+            fGermaniumSeparation/2.0,
+            fGermaniumSeparation/2.0, (fGermaniumBentLength
+                - fElectrodeMatStartingDepth)/2.0);
 
-	G4RotationMatrix* rotatePiece2 = new G4RotationMatrix;
-	rotatePiece2->rotateZ(M_PI/2.0);
+    G4RotationMatrix* rotatePiece2 = new G4RotationMatrix;
+    rotatePiece2->rotateZ(M_PI/2.0);
 
-	G4ThreeVector moveZero(0,0,0);
+    G4ThreeVector moveZero(0,0,0);
 
-	G4UnionSolid* interCrystalElectrodeMatFront = new G4UnionSolid(
-			"interCrystalElectrodeMatFront", electrodeMatPiece1, electrodeMatPiece2,
-			rotatePiece2, moveZero);
+    G4UnionSolid* interCrystalElectrodeMatFront = new G4UnionSolid(
+            "interCrystalElectrodeMatFront", electrodeMatPiece1, electrodeMatPiece2,
+            rotatePiece2, moveZero);
 
-	return interCrystalElectrodeMatFront;
+    return interCrystalElectrodeMatFront;
 } //end ::interCrystalelectrodeMatFront
 
 ///////////////////////////////////////////////////////////////////////
@@ -2145,33 +2184,33 @@ G4UnionSolid* DetectionSystemGriffin::InterCrystalelectrodeMatFront() {
 // forward position   
 ///////////////////////////////////////////////////////////////////////
 void DetectionSystemGriffin::ConstructNewHeavyMet() {
-	G4Material* materialHevimetal = G4Material::GetMaterial("Hevimetal");
-	if(!materialHevimetal) {
-		G4cout<<" ----> Material Hevimetal not found, cannot build the detector shell! "<<G4endl;
-		exit(1);
-	}
+    G4Material* materialHevimetal = G4Material::GetMaterial("Hevimetal");
+    if(!materialHevimetal) {
+        G4cout<<" ----> Material Hevimetal not found, cannot build the detector shell! "<<G4endl;
+        exit(1);
+    }
 
-	G4VisAttributes* heviMetVisAtt = new G4VisAttributes(G4Colour(0.5,0.5,0.5));
-	heviMetVisAtt->SetVisibility(true);
+    G4VisAttributes* heviMetVisAtt = new G4VisAttributes(G4Colour(0.5,0.5,0.5));
+    heviMetVisAtt->SetVisibility(true);
 
-	G4SubtractionSolid* hevimet = NewHeavyMet();
+    G4SubtractionSolid* hevimet = NewHeavyMet();
 
-	G4RotationMatrix* rotateHevimet = new G4RotationMatrix;
-	rotateHevimet->rotateY(-1.0*M_PI/2.0);
+    G4RotationMatrix* rotateHevimet = new G4RotationMatrix;
+    rotateHevimet->rotateY(-1.0*M_PI/2.0);
 
-	G4ThreeVector moveHevimet(((fHevimetTipThickness / cos(fHevimetTipAngle)) * cos(fBentEndAngle -fHevimetTipAngle)
-				+ fSuppressorForwardRadius* tan(fHevimetTipAngle)*sin(fBentEndAngle))/2.0
-			- fAirBoxBackLength/2.0 -fAirBoxFrontLength, 0.0, 0.0);
+    G4ThreeVector moveHevimet(((fHevimetTipThickness / cos(fHevimetTipAngle)) * cos(fBentEndAngle -fHevimetTipAngle)
+                + fSuppressorForwardRadius* tan(fHevimetTipAngle)*sin(fBentEndAngle))/2.0
+            - fAirBoxBackLength/2.0 -fAirBoxFrontLength, 0.0, 0.0);
 
-	// NOTE** The hevimet does not require the "shift" parameter, as the airBox has been designed
-	// so that the hevimet sits right at the front, and has been moved accordingly. Also, the
-	// "appliedBackShift" parameter is missing, as the hevimet only goes on in the "detector back" position
+    // NOTE** The hevimet does not require the "shift" parameter, as the airBox has been designed
+    // so that the hevimet sits right at the front, and has been moved accordingly. Also, the
+    // "appliedBackShift" parameter is missing, as the hevimet only goes on in the "detector back" position
 
-	fHevimetLog = new G4LogicalVolume(hevimet, materialHevimetal, "hevimetLog", 0, 0, 0);
+    fHevimetLog = new G4LogicalVolume(hevimet, materialHevimetal, "hevimetLog", 0, 0, 0);
 
-	fHevimetLog->SetVisAttributes(heviMetVisAtt);
+    fHevimetLog->SetVisAttributes(heviMetVisAtt);
 
-	fHevimetAssembly->AddPlacedVolume(fHevimetLog, moveHevimet, rotateHevimet);
+    fHevimetAssembly->AddPlacedVolume(fHevimetLog, moveHevimet, rotateHevimet);
 
 
 }//end ::ConstructHeavyMet
@@ -2182,30 +2221,30 @@ void DetectionSystemGriffin::ConstructNewHeavyMet() {
 ///////////////////////////////////////////////////////////////////////
 G4Box* DetectionSystemGriffin::SquareFrontFace() {
 
-	G4double fixOverlap = 250*nm;
+    G4double fixOverlap = 250*nm;
 
-	G4double halfThicknessX = fCanFaceThickness/2.0;
+    G4double halfThicknessX = fCanFaceThickness/2.0;
 
-	G4double halfLengthY = ((fDetectorTotalWidth/2.0) -(fBentEndLength
-				*tan(fBentEndAngle)))-fixOverlap;
+    G4double halfLengthY = ((fDetectorTotalWidth/2.0) -(fBentEndLength
+                *tan(fBentEndAngle)))-fixOverlap;
 
-	G4double halfLengthZ = halfLengthY;
+    G4double halfLengthZ = halfLengthY;
 
-	G4Box* frontFace = new G4Box("frontFace", halfThicknessX, halfLengthY, halfLengthZ);
+    G4Box* frontFace = new G4Box("frontFace", halfThicknessX, halfLengthY, halfLengthZ);
 
-	return frontFace;
+    return frontFace;
 
 }//end ::squareFrontFace
 
 
 G4Trap* DetectionSystemGriffin::CornerWedge() {
-	G4double heightY = fCanFaceThickness;
-	G4double lengthZ = fDetectorTotalWidth -2.0*(fBentEndLength *tan(fBentEndAngle));
-	G4double extensionLengthX = heightY *tan(fBentEndAngle);
+    G4double heightY = fCanFaceThickness;
+    G4double lengthZ = fDetectorTotalWidth -2.0*(fBentEndLength *tan(fBentEndAngle));
+    G4double extensionLengthX = heightY *tan(fBentEndAngle);
 
-	G4Trap* wedge = new G4Trap("wedge", lengthZ, heightY, extensionLengthX, fWedgeDim);
+    G4Trap* wedge = new G4Trap("wedge", lengthZ, heightY, extensionLengthX, fWedgeDim);
 
-	return wedge;
+    return wedge;
 }//end ::cornerWedge
 
 
@@ -2216,149 +2255,149 @@ G4Trap* DetectionSystemGriffin::CornerWedge() {
 ///////////////////////////////////////////////////////////////////////
 G4Para* DetectionSystemGriffin::BentSidePiece() {
 
-	G4double halfLengthX = ((fBentEndLength -fCanFaceThickness)
-			/cos(fBentEndAngle))/2.0;
+    G4double halfLengthX = ((fBentEndLength -fCanFaceThickness)
+            /cos(fBentEndAngle))/2.0;
 
-	G4double halfLengthY = (fDetectorTotalWidth/2.0) -(fBentEndLength
-			*tan(fBentEndAngle)) -fCanFaceThickness
-		*(1.0 -tan(fBentEndAngle));
+    G4double halfLengthY = (fDetectorTotalWidth/2.0) -(fBentEndLength
+            *tan(fBentEndAngle)) -fCanFaceThickness
+        *(1.0 -tan(fBentEndAngle));
 
-	// Last two operations in "halfLengthY" are correction
-	// factor to keep the bent pieces from overlapping
-	G4double halfLengthZ = fCanFaceThickness *cos(fBentEndAngle)/2.0;
-	G4double alphaAngle = 0.0*M_PI;
-	G4double polarAngle = fBentEndAngle;
-	G4double azimuthalAngle = 0.0*M_PI;
+    // Last two operations in "halfLengthY" are correction
+    // factor to keep the bent pieces from overlapping
+    G4double halfLengthZ = fCanFaceThickness *cos(fBentEndAngle)/2.0;
+    G4double alphaAngle = 0.0*M_PI;
+    G4double polarAngle = fBentEndAngle;
+    G4double azimuthalAngle = 0.0*M_PI;
 
-	G4Para* bentSidePiece = new G4Para("bentSidePiece", halfLengthX,
-			halfLengthY, halfLengthZ, alphaAngle, polarAngle, azimuthalAngle);
+    G4Para* bentSidePiece = new G4Para("bentSidePiece", halfLengthX,
+            halfLengthY, halfLengthZ, alphaAngle, polarAngle, azimuthalAngle);
 
-	return bentSidePiece;
+    return bentSidePiece;
 
 }//end ::bentSidePiece
 
 
 // this is a conic piece that attaches two bent end pieces
 G4Cons* DetectionSystemGriffin::RoundedEndEdge() {
-	G4double holeEliminator = fCanFaceThickness *(1.0 -tan(fBentEndAngle));
+    G4double holeEliminator = fCanFaceThickness *(1.0 -tan(fBentEndAngle));
 
-	// this is correction factor to avoid holes caused by bent pieces
-	G4double halfLengthZ = (fBentEndLength -fCanFaceThickness)/2.0;
-	G4double insideRadiusAtApex = 0.0;
-	G4double outsideRadiusAtApex = fCanFaceThickness *tan(fBentEndAngle) +holeEliminator;
-	G4double outsideRadiusAtBase = fBentEndLength *tan(fBentEndAngle) +holeEliminator;
-	G4double insideRadiusAtBase = outsideRadiusAtBase -fCanFaceThickness;
-	G4double startAngle = 0.0*M_PI;
-	G4double finalAngle = 0.5*M_PI;
+    // this is correction factor to avoid holes caused by bent pieces
+    G4double halfLengthZ = (fBentEndLength -fCanFaceThickness)/2.0;
+    G4double insideRadiusAtApex = 0.0;
+    G4double outsideRadiusAtApex = fCanFaceThickness *tan(fBentEndAngle) +holeEliminator;
+    G4double outsideRadiusAtBase = fBentEndLength *tan(fBentEndAngle) +holeEliminator;
+    G4double insideRadiusAtBase = outsideRadiusAtBase -fCanFaceThickness;
+    G4double startAngle = 0.0*M_PI;
+    G4double finalAngle = 0.5*M_PI;
 
-	G4Cons* roundedEndEdge = new G4Cons("roundedEndEdge", insideRadiusAtApex,
-			outsideRadiusAtApex, insideRadiusAtBase, outsideRadiusAtBase,
-			halfLengthZ, startAngle, finalAngle);
+    G4Cons* roundedEndEdge = new G4Cons("roundedEndEdge", insideRadiusAtApex,
+            outsideRadiusAtApex, insideRadiusAtBase, outsideRadiusAtBase,
+            halfLengthZ, startAngle, finalAngle);
 
-	return roundedEndEdge;
+    return roundedEndEdge;
 
 }//end ::roundedEndEdge
 
 
 G4Tubs* DetectionSystemGriffin::CornerTube() {
-	G4double outerRadius 	= fBentEndLength *tan(fBentEndAngle);
-	G4double innerRadius 	= outerRadius - fCanSideThickness;
-	G4double halfHeightZ 	= (fDetectorTotalLength -fBentEndLength
-			-fRearPlateThickness)/2.0;
+    G4double outerRadius    = fBentEndLength *tan(fBentEndAngle);
+    G4double innerRadius    = outerRadius - fCanSideThickness;
+    G4double halfHeightZ    = (fDetectorTotalLength -fBentEndLength
+            -fRearPlateThickness)/2.0;
 
-	G4double startAngle = 0.0*M_PI;
-	G4double finalAngle = 0.5*M_PI;
+    G4double startAngle = 0.0*M_PI;
+    G4double finalAngle = 0.5*M_PI;
 
-	G4Tubs* cornerTube = new G4Tubs("cornerTube", innerRadius, outerRadius, halfHeightZ, startAngle, finalAngle);
+    G4Tubs* cornerTube = new G4Tubs("cornerTube", innerRadius, outerRadius, halfHeightZ, startAngle, finalAngle);
 
-	return cornerTube;
+    return cornerTube;
 }//end ::cornerTube
 
 
 G4Box* DetectionSystemGriffin::SidePanel() {
-	G4double halfLengthX = (fDetectorTotalLength -fBentEndLength -fRearPlateThickness)/2.0;
-	G4double halfThicknessY = (fCanSideThickness)/2.0;
-	G4double halfWidthZ = (fDetectorTotalWidth)/2.0 -(fBentEndLength *tan(fBentEndAngle));
+    G4double halfLengthX = (fDetectorTotalLength -fBentEndLength -fRearPlateThickness)/2.0;
+    G4double halfThicknessY = (fCanSideThickness)/2.0;
+    G4double halfWidthZ = (fDetectorTotalWidth)/2.0 -(fBentEndLength *tan(fBentEndAngle));
 
-	G4Box* sidePanel = new G4Box("sidePanel", halfLengthX, halfThicknessY, halfWidthZ);
+    G4Box* sidePanel = new G4Box("sidePanel", halfLengthX, halfThicknessY, halfWidthZ);
 
-	return sidePanel;
+    return sidePanel;
 }//end ::sidePanel
 
 
 G4SubtractionSolid* DetectionSystemGriffin::RearPlate() {
 
-	G4double halfWidthX = fDetectorTotalWidth/2.0;
-	G4double halfWidthY = halfWidthX;
-	G4double halfThicknessZ = fRearPlateThickness/2.0;
+    G4double halfWidthX = fDetectorTotalWidth/2.0;
+    G4double halfWidthY = halfWidthX;
+    G4double halfThicknessZ = fRearPlateThickness/2.0;
 
-	G4Box* plate = new G4Box("plate", halfWidthX, halfWidthY, halfThicknessZ);
+    G4Box* plate = new G4Box("plate", halfWidthX, halfWidthY, halfThicknessZ);
 
-	G4double innerRadius = 0.0;
-	G4double outerRadius = fColdFingerOuterShellRadius;
-	G4double halfHeightZ = halfThicknessZ +1.0*cm;  // +1.0*cm just to make sure the hole goes completely through the plate
-	G4double startAngle = 0.0*M_PI;
-	G4double finalAngle = 2.0*M_PI;
+    G4double innerRadius = 0.0;
+    G4double outerRadius = fColdFingerOuterShellRadius;
+    G4double halfHeightZ = halfThicknessZ +1.0*cm;  // +1.0*cm just to make sure the hole goes completely through the plate
+    G4double startAngle = 0.0*M_PI;
+    G4double finalAngle = 2.0*M_PI;
 
-	G4Tubs* hole = new G4Tubs("hole", innerRadius, outerRadius, halfHeightZ, startAngle, finalAngle);
+    G4Tubs* hole = new G4Tubs("hole", innerRadius, outerRadius, halfHeightZ, startAngle, finalAngle);
 
-	G4SubtractionSolid* rearPlate = new G4SubtractionSolid("rearPlate", plate, hole);
+    G4SubtractionSolid* rearPlate = new G4SubtractionSolid("rearPlate", plate, hole);
 
-	return rearPlate;
+    return rearPlate;
 }//end ::rearPlate
 
 
 G4Tubs* DetectionSystemGriffin::ColdFingerShell() {
-	G4double outerRadius = fColdFingerOuterShellRadius;
-	G4double innerRadius = outerRadius - fColdFingerShellThickness;
-	G4double halfLengthZ = fColdFingerShellLength/2.0;
-	G4double startAngle = 0.0*M_PI;
-	G4double finalAngle = 2.0*M_PI;
+    G4double outerRadius = fColdFingerOuterShellRadius;
+    G4double innerRadius = outerRadius - fColdFingerShellThickness;
+    G4double halfLengthZ = fColdFingerShellLength/2.0;
+    G4double startAngle = 0.0*M_PI;
+    G4double finalAngle = 2.0*M_PI;
 
-	G4Tubs* coldFingerShell = new G4Tubs("coldFingerShell", innerRadius,
-			outerRadius, halfLengthZ, startAngle, finalAngle);
+    G4Tubs* coldFingerShell = new G4Tubs("coldFingerShell", innerRadius,
+            outerRadius, halfLengthZ, startAngle, finalAngle);
 
-	return coldFingerShell;
+    return coldFingerShell;
 
 }//end ::coldFingerShell
 
 
 G4Tubs* DetectionSystemGriffin::LiquidNitrogenTank() {
-	G4double innerRadius = fCoolantRadius - fCoolantThickness;
-	G4double outerRadius = fCoolantRadius;
-	G4double halfLengthZ = (fCoolantLength - 2.0*fCoolantThickness)/2.0;
-	G4double startAngle = 0.0*M_PI;
-	G4double finalAngle = 2.0*M_PI;
+    G4double innerRadius = fCoolantRadius - fCoolantThickness;
+    G4double outerRadius = fCoolantRadius;
+    G4double halfLengthZ = (fCoolantLength - 2.0*fCoolantThickness)/2.0;
+    G4double startAngle = 0.0*M_PI;
+    G4double finalAngle = 2.0*M_PI;
 
-	G4Tubs* tank = new G4Tubs("tank", innerRadius, outerRadius, halfLengthZ, startAngle, finalAngle);
+    G4Tubs* tank = new G4Tubs("tank", innerRadius, outerRadius, halfLengthZ, startAngle, finalAngle);
 
-	return tank;
+    return tank;
 
 }//end ::liquidNitrogenTank
 
 G4Tubs* DetectionSystemGriffin::LiquidNitrogenTankLid() {
-	G4double innerRadius = 0.0*mm;
-	G4double outerRadius = fCoolantRadius;
-	G4double halfLengthZ = (fCoolantThickness)/2.0;
-	G4double startAngle = 0.0*M_PI;
-	G4double finalAngle = 2.0*M_PI;
+    G4double innerRadius = 0.0*mm;
+    G4double outerRadius = fCoolantRadius;
+    G4double halfLengthZ = (fCoolantThickness)/2.0;
+    G4double startAngle = 0.0*M_PI;
+    G4double finalAngle = 2.0*M_PI;
 
-	G4Tubs* tank = new G4Tubs("tank", innerRadius, outerRadius, halfLengthZ, startAngle, finalAngle);
+    G4Tubs* tank = new G4Tubs("tank", innerRadius, outerRadius, halfLengthZ, startAngle, finalAngle);
 
-	return tank;
+    return tank;
 
 }//end ::liquidNitrogenTankLid
 
 G4Tubs* DetectionSystemGriffin::LiquidNitrogen() {
-	G4double innerRadius = 0.0*mm;
-	G4double outerRadius = fCoolantRadius - fCoolantThickness;
-	G4double halfLengthZ = (fCoolantLength - 2.0*fCoolantThickness)/2.0;
-	G4double startAngle = 0.0*M_PI;
-	G4double finalAngle = 2.0*M_PI;
+    G4double innerRadius = 0.0*mm;
+    G4double outerRadius = fCoolantRadius - fCoolantThickness;
+    G4double halfLengthZ = (fCoolantLength - 2.0*fCoolantThickness)/2.0;
+    G4double startAngle = 0.0*M_PI;
+    G4double finalAngle = 2.0*M_PI;
 
-	G4Tubs* tank = new G4Tubs("tank", innerRadius, outerRadius, halfLengthZ, startAngle, finalAngle);
+    G4Tubs* tank = new G4Tubs("tank", innerRadius, outerRadius, halfLengthZ, startAngle, finalAngle);
 
-	return tank;
+    return tank;
 
 }//end ::liquidNitrogen
 
@@ -2368,28 +2407,28 @@ G4Tubs* DetectionSystemGriffin::LiquidNitrogen() {
 // to form a UnionSolid
 ///////////////////////////////////////////////////////////////////////
 G4Box* DetectionSystemGriffin::RectangularSegment() {
-	G4double halfLengthX = fDetectorBlockHeight/2.0;
-	G4double halfLengthY = fDetectorBlockLength/2.0;
-	G4double halfLengthZ = halfLengthY; 	// Since it is symmetric
+    G4double halfLengthX = fDetectorBlockHeight/2.0;
+    G4double halfLengthY = fDetectorBlockLength/2.0;
+    G4double halfLengthZ = halfLengthY;     // Since it is symmetric
 
-	G4Box* rectangularSegment = new G4Box("rectangularSegment", halfLengthX, halfLengthY, halfLengthZ);
+    G4Box* rectangularSegment = new G4Box("rectangularSegment", halfLengthX, halfLengthY, halfLengthZ);
 
-	return rectangularSegment;
+    return rectangularSegment;
 
 }// end ::rectangularSegment
 
 
 G4Trd* DetectionSystemGriffin::TrapezoidalSegment() {
-	G4double halfBaseX 		= fDetectorBlockLength/2.0;
-	G4double halfTopX 		= halfBaseX - (fDetectorBlockTrapezoidalHeight *tan(fBentEndAngle));
-	G4double halfBaseY 		= halfBaseX; 	// Since it is symmetric
-	G4double halfTopY 		= halfTopX;
-	G4double halfHeightZ 	= fDetectorBlockTrapezoidalHeight/2.0;
+    G4double halfBaseX      = fDetectorBlockLength/2.0;
+    G4double halfTopX       = halfBaseX - (fDetectorBlockTrapezoidalHeight *tan(fBentEndAngle));
+    G4double halfBaseY      = halfBaseX;    // Since it is symmetric
+    G4double halfTopY       = halfTopX;
+    G4double halfHeightZ    = fDetectorBlockTrapezoidalHeight/2.0;
 
-	G4Trd* trapezoidalSegment = new G4Trd("trapezoidalSegment",
-			halfBaseX, halfTopX, halfBaseY, halfTopY, halfHeightZ);
+    G4Trd* trapezoidalSegment = new G4Trd("trapezoidalSegment",
+            halfBaseX, halfTopX, halfBaseY, halfTopY, halfHeightZ);
 
-	return trapezoidalSegment;
+    return trapezoidalSegment;
 
 }//end ::trapezoidalSegment
 
@@ -2400,248 +2439,248 @@ G4Trd* DetectionSystemGriffin::TrapezoidalSegment() {
 ///////////////////////////////////////////////////////////////////////
 G4SubtractionSolid* DetectionSystemGriffin::QuarterDetector() {
 
-	G4double halfWidthX 	= fGermaniumWidth/2.0;
-	G4double halfWidthY 	= halfWidthX;
-	G4double halfLengthZ 	= fGermaniumLength/2.0;
+    G4double halfWidthX     = fGermaniumWidth/2.0;
+    G4double halfWidthY     = halfWidthX;
+    G4double halfLengthZ    = fGermaniumLength/2.0;
 
-	G4Box* rectangularGermanium 	= new G4Box("rectangularGermanium", halfWidthX, halfWidthY, halfLengthZ);
+    G4Box* rectangularGermanium     = new G4Box("rectangularGermanium", halfWidthX, halfWidthY, halfLengthZ);
 
-	G4double outerRadius = ((fGermaniumWidth +fGermaniumShift)*1.5)/2.0;
+    G4double outerRadius = ((fGermaniumWidth +fGermaniumShift)*1.5)/2.0;
 
-	// 1.5 is almost root 2, so this makes sure the corners are chopped off
+    // 1.5 is almost root 2, so this makes sure the corners are chopped off
 
-	G4double innerRadius = fGermaniumOuterRadius;
-	G4double startAngle = 0.0*M_PI;
-	G4double finalAngle = 2.0*M_PI;
+    G4double innerRadius = fGermaniumOuterRadius;
+    G4double startAngle = 0.0*M_PI;
+    G4double finalAngle = 2.0*M_PI;
 
-	G4ThreeVector moveChoppingCylinder(fGermaniumShift, -(fGermaniumShift), 0);
-	G4Tubs* choppingCylinder = new G4Tubs("choppingCylinder", innerRadius,
-			outerRadius, halfLengthZ+1.0*cm, startAngle, finalAngle);
+    G4ThreeVector moveChoppingCylinder(fGermaniumShift, -(fGermaniumShift), 0);
+    G4Tubs* choppingCylinder = new G4Tubs("choppingCylinder", innerRadius,
+            outerRadius, halfLengthZ+1.0*cm, startAngle, finalAngle);
 
-	G4SubtractionSolid* germaniumRoundedCorners = new G4SubtractionSolid("germaniumRoundedCorners",
-			rectangularGermanium, choppingCylinder, 0, moveChoppingCylinder);
+    G4SubtractionSolid* germaniumRoundedCorners = new G4SubtractionSolid("germaniumRoundedCorners",
+            rectangularGermanium, choppingCylinder, 0, moveChoppingCylinder);
 
-	G4double baseInnerRadius = fGermaniumOuterRadius;
-	G4double baseOuterRadius = 2.0*baseInnerRadius;
+    G4double baseInnerRadius = fGermaniumOuterRadius;
+    G4double baseOuterRadius = 2.0*baseInnerRadius;
 
-	// G4double tipInnerRadius = baseInnerRadius - fGermaniumBentLength*tan(fBentEndAngle);
-	G4double tipInnerRadius = baseInnerRadius
-		- fGermaniumCornerConeEndLength*tan(fBentEndAngle);
-	G4double tipOuterRadius = baseOuterRadius;
+    // G4double tipInnerRadius = baseInnerRadius - fGermaniumBentLength*tan(fBentEndAngle);
+    G4double tipInnerRadius = baseInnerRadius
+        - fGermaniumCornerConeEndLength*tan(fBentEndAngle);
+    G4double tipOuterRadius = baseOuterRadius;
 
-	// G4double conHalfLengthZ = fGermaniumBentLength/2.0;
-	G4double conHalfLengthZ = fGermaniumCornerConeEndLength/2.0 + fQuarterDetectorCxn;
+    // G4double conHalfLengthZ = fGermaniumBentLength/2.0;
+    G4double conHalfLengthZ = fGermaniumCornerConeEndLength/2.0 + fQuarterDetectorCxn;
 
-	G4double initialAngle = acos((fGermaniumWidth/2.0 +fGermaniumShift)
-			/fGermaniumOuterRadius);
-	G4double totalAngle = M_PI/2.0 -2.0*initialAngle;
+    G4double initialAngle = acos((fGermaniumWidth/2.0 +fGermaniumShift)
+            /fGermaniumOuterRadius);
+    G4double totalAngle = M_PI/2.0 -2.0*initialAngle;
 
-	G4Cons* roundedEdge = new G4Cons("roundedEdge", baseInnerRadius,
-			baseOuterRadius, tipInnerRadius, tipOuterRadius,
-			conHalfLengthZ, initialAngle, totalAngle);
-
-
-	G4RotationMatrix* rotateRoundedEdge = new G4RotationMatrix;
-	rotateRoundedEdge->rotateZ(-M_PI/2.0);
-
-	G4ThreeVector moveRoundedEdge(fGermaniumShift, -fGermaniumShift,
-			fGermaniumLength/2.0 -fGermaniumCornerConeEndLength/2.0
-			+ fQuarterDetectorCxnB);
-
-	G4SubtractionSolid* germaniumRoundedEdge = new G4SubtractionSolid("germaniumRoundedEdge",
-			germaniumRoundedCorners, roundedEdge, rotateRoundedEdge,
-			moveRoundedEdge);
-
-	// now we make the diagonal slices
-	G4double halfChopPieceWidthX 	= fGermaniumWidth/2.0;
-	G4double halfChopPieceWidthY 	= fGermaniumWidth/2.0;
-	G4double halfChopPieceLengthZ 	= (fGermaniumBentLength/cos(fBentEndAngle))/2.0;
-	G4Box* chopPiece = new G4Box("chopPiece", halfChopPieceWidthX,
-			halfChopPieceWidthY, halfChopPieceLengthZ);
-
-	G4RotationMatrix* rotateChopPiece1 = new G4RotationMatrix;
-	rotateChopPiece1->rotateX(-(fBentEndAngle));
-
-	G4ThreeVector moveChopPiece1(0, fGermaniumWidth/2.0 +(fGermaniumBentLength
-				/tan(fBentEndAngle) +fGermaniumWidth
-				*cos(fBentEndAngle))/2.0 -((fGermaniumBentLength
-					/cos(fBentEndAngle))/2.0) /sin(fBentEndAngle),
-			fGermaniumLength/2.0 -fGermaniumBentLength
-			+(fGermaniumBentLength +fGermaniumWidth
-				*sin(fBentEndAngle))/2.0);
-
-	G4SubtractionSolid* choppedGermanium1 = new G4SubtractionSolid("choppedGermanium1",
-			germaniumRoundedEdge, chopPiece, rotateChopPiece1, moveChopPiece1);
+    G4Cons* roundedEdge = new G4Cons("roundedEdge", baseInnerRadius,
+            baseOuterRadius, tipInnerRadius, tipOuterRadius,
+            conHalfLengthZ, initialAngle, totalAngle);
 
 
-	G4RotationMatrix* rotateChopPiece2 = new G4RotationMatrix;
-	rotateChopPiece2->rotateY(-(fBentEndAngle));
+    G4RotationMatrix* rotateRoundedEdge = new G4RotationMatrix;
+    rotateRoundedEdge->rotateZ(-M_PI/2.0);
 
-	G4ThreeVector moveChopPiece2(-(fGermaniumWidth/2.0 +(fGermaniumBentLength
-					/tan(fBentEndAngle) +fGermaniumWidth
-					*cos(fBentEndAngle))/2.0 -((fGermaniumBentLength
-						/cos(fBentEndAngle))/2.0) /sin(fBentEndAngle)), 0,
-			fGermaniumLength/2.0 -fGermaniumBentLength
-			+(fGermaniumBentLength +fGermaniumWidth
-				*sin(fBentEndAngle))/2.0);
+    G4ThreeVector moveRoundedEdge(fGermaniumShift, -fGermaniumShift,
+            fGermaniumLength/2.0 -fGermaniumCornerConeEndLength/2.0
+            + fQuarterDetectorCxnB);
 
-	G4SubtractionSolid* choppedGermanium2 = new G4SubtractionSolid("choppedGermanium2",
-			choppedGermanium1, chopPiece, rotateChopPiece2, moveChopPiece2);
+    G4SubtractionSolid* germaniumRoundedEdge = new G4SubtractionSolid("germaniumRoundedEdge",
+            germaniumRoundedCorners, roundedEdge, rotateRoundedEdge,
+            moveRoundedEdge);
+
+    // now we make the diagonal slices
+    G4double halfChopPieceWidthX    = fGermaniumWidth/2.0;
+    G4double halfChopPieceWidthY    = fGermaniumWidth/2.0;
+    G4double halfChopPieceLengthZ   = (fGermaniumBentLength/cos(fBentEndAngle))/2.0;
+    G4Box* chopPiece = new G4Box("chopPiece", halfChopPieceWidthX,
+            halfChopPieceWidthY, halfChopPieceLengthZ);
+
+    G4RotationMatrix* rotateChopPiece1 = new G4RotationMatrix;
+    rotateChopPiece1->rotateX(-(fBentEndAngle));
+
+    G4ThreeVector moveChopPiece1(0, fGermaniumWidth/2.0 +(fGermaniumBentLength
+                /tan(fBentEndAngle) +fGermaniumWidth
+                *cos(fBentEndAngle))/2.0 -((fGermaniumBentLength
+                    /cos(fBentEndAngle))/2.0) /sin(fBentEndAngle),
+            fGermaniumLength/2.0 -fGermaniumBentLength
+            +(fGermaniumBentLength +fGermaniumWidth
+                *sin(fBentEndAngle))/2.0);
+
+    G4SubtractionSolid* choppedGermanium1 = new G4SubtractionSolid("choppedGermanium1",
+            germaniumRoundedEdge, chopPiece, rotateChopPiece1, moveChopPiece1);
 
 
-	// now we make the hole that will go in the back of each quarter detector, /////////////////////////////////////////////////////////
-	startAngle = 0.0*M_PI;
-	finalAngle = 2.0*M_PI;
-	G4double holeRadius = fGermaniumHoleRadius;
-	G4double holeHalfLengthZ = (fGermaniumLength -fGermaniumHoleDistFromFace)/2.0;
+    G4RotationMatrix* rotateChopPiece2 = new G4RotationMatrix;
+    rotateChopPiece2->rotateY(-(fBentEndAngle));
 
-	G4Tubs* holeTubs = new G4Tubs("holeTubs", 0.0, holeRadius, holeHalfLengthZ, startAngle, finalAngle);
-	G4ThreeVector moveHole(fGermaniumShift, -(fGermaniumShift),-((fGermaniumHoleDistFromFace)));
+    G4ThreeVector moveChopPiece2(-(fGermaniumWidth/2.0 +(fGermaniumBentLength
+                    /tan(fBentEndAngle) +fGermaniumWidth
+                    *cos(fBentEndAngle))/2.0 -((fGermaniumBentLength
+                        /cos(fBentEndAngle))/2.0) /sin(fBentEndAngle)), 0,
+            fGermaniumLength/2.0 -fGermaniumBentLength
+            +(fGermaniumBentLength +fGermaniumWidth
+                *sin(fBentEndAngle))/2.0);
 
-	G4SubtractionSolid* choppedGermanium3 = new G4SubtractionSolid("choppedGermanium3",
-			choppedGermanium2, holeTubs, 0, moveHole);
+    G4SubtractionSolid* choppedGermanium2 = new G4SubtractionSolid("choppedGermanium2",
+            choppedGermanium1, chopPiece, rotateChopPiece2, moveChopPiece2);
 
-	startAngle = 0.0*M_PI;
-	finalAngle = 2.0*M_PI;
-	G4double deadLayerRadius = fGermaniumHoleRadius + fInnerDeadLayerThickness;
-	G4double deadLayerHalfLengthZ = (fGermaniumLength
-			- fGermaniumHoleDistFromFace
-			+ fInnerDeadLayerThickness)/2.0;
 
-	// now dead layer
-	G4Tubs* deadLayerTubs = new G4Tubs("deadLayerTubs", 0.0,
-			deadLayerRadius, deadLayerHalfLengthZ, startAngle,finalAngle);
+    // now we make the hole that will go in the back of each quarter detector, /////////////////////////////////////////////////////////
+    startAngle = 0.0*M_PI;
+    finalAngle = 2.0*M_PI;
+    G4double holeRadius = fGermaniumHoleRadius;
+    G4double holeHalfLengthZ = (fGermaniumLength -fGermaniumHoleDistFromFace)/2.0;
 
-	G4ThreeVector moveDeadLayer(fGermaniumShift, -(fGermaniumShift),
-			-((fGermaniumHoleDistFromFace
-					- fInnerDeadLayerThickness)/2.0));
+    G4Tubs* holeTubs = new G4Tubs("holeTubs", 0.0, holeRadius, holeHalfLengthZ, startAngle, finalAngle);
+    G4ThreeVector moveHole(fGermaniumShift, -(fGermaniumShift),-((fGermaniumHoleDistFromFace)));
 
-	G4SubtractionSolid* choppedGermanium4 = new G4SubtractionSolid("choppedGermanium4",
-			choppedGermanium3, deadLayerTubs, 0, moveDeadLayer);
+    G4SubtractionSolid* choppedGermanium3 = new G4SubtractionSolid("choppedGermanium3",
+            choppedGermanium2, holeTubs, 0, moveHole);
 
-	return choppedGermanium4;
+    startAngle = 0.0*M_PI;
+    finalAngle = 2.0*M_PI;
+    G4double deadLayerRadius = fGermaniumHoleRadius + fInnerDeadLayerThickness;
+    G4double deadLayerHalfLengthZ = (fGermaniumLength
+            - fGermaniumHoleDistFromFace
+            + fInnerDeadLayerThickness)/2.0;
+
+    // now dead layer
+    G4Tubs* deadLayerTubs = new G4Tubs("deadLayerTubs", 0.0,
+            deadLayerRadius, deadLayerHalfLengthZ, startAngle,finalAngle);
+
+    G4ThreeVector moveDeadLayer(fGermaniumShift, -(fGermaniumShift),
+            -((fGermaniumHoleDistFromFace
+                    - fInnerDeadLayerThickness)/2.0));
+
+    G4SubtractionSolid* choppedGermanium4 = new G4SubtractionSolid("choppedGermanium4",
+            choppedGermanium3, deadLayerTubs, 0, moveDeadLayer);
+
+    return choppedGermanium4;
 
 }//end ::quarterDetector
 
 
 G4SubtractionSolid* DetectionSystemGriffin::QuarterSpecificDeadLayerDetector(G4int det, G4int cry) {
 
-	G4double halfWidthX 	= fGermaniumWidth/2.0;
-	G4double halfWidthY 	= halfWidthX;
-	G4double halfLengthZ 	= fGermaniumLength/2.0;
+    G4double halfWidthX     = fGermaniumWidth/2.0;
+    G4double halfWidthY     = halfWidthX;
+    G4double halfLengthZ    = fGermaniumLength/2.0;
 
-	G4Box* rectangularGermanium 	= new G4Box("rectangularGermanium", halfWidthX, halfWidthY, halfLengthZ);
+    G4Box* rectangularGermanium     = new G4Box("rectangularGermanium", halfWidthX, halfWidthY, halfLengthZ);
 
-	G4double outerRadius = ((fGermaniumWidth +fGermaniumShift)*1.5)/2.0;
+    G4double outerRadius = ((fGermaniumWidth +fGermaniumShift)*1.5)/2.0;
 
-	// 1.5 is almost root 2, so this makes sure the corners are chopped off
+    // 1.5 is almost root 2, so this makes sure the corners are chopped off
 
-	G4double innerRadius = fGermaniumOuterRadius;
-	G4double startAngle = 0.0*M_PI;
-	G4double finalAngle = 2.0*M_PI;
+    G4double innerRadius = fGermaniumOuterRadius;
+    G4double startAngle = 0.0*M_PI;
+    G4double finalAngle = 2.0*M_PI;
 
-	G4ThreeVector moveChoppingCylinder(fGermaniumShift, -(fGermaniumShift), 0);
-	G4Tubs* choppingCylinder = new G4Tubs("choppingCylinder", innerRadius,
-			outerRadius, halfLengthZ+1.0*cm, startAngle, finalAngle);
+    G4ThreeVector moveChoppingCylinder(fGermaniumShift, -(fGermaniumShift), 0);
+    G4Tubs* choppingCylinder = new G4Tubs("choppingCylinder", innerRadius,
+            outerRadius, halfLengthZ+1.0*cm, startAngle, finalAngle);
 
-	G4SubtractionSolid* germaniumRoundedCorners = new G4SubtractionSolid("germaniumRoundedCorners",
-			rectangularGermanium, choppingCylinder, 0, moveChoppingCylinder);
+    G4SubtractionSolid* germaniumRoundedCorners = new G4SubtractionSolid("germaniumRoundedCorners",
+            rectangularGermanium, choppingCylinder, 0, moveChoppingCylinder);
 
-	G4double baseInnerRadius = fGermaniumOuterRadius;
-	G4double baseOuterRadius = 2.0*baseInnerRadius;
+    G4double baseInnerRadius = fGermaniumOuterRadius;
+    G4double baseOuterRadius = 2.0*baseInnerRadius;
 
-	G4double tipInnerRadius = baseInnerRadius - fGermaniumCornerConeEndLength*tan(fBentEndAngle);
-	G4double tipOuterRadius = baseOuterRadius;
+    G4double tipInnerRadius = baseInnerRadius - fGermaniumCornerConeEndLength*tan(fBentEndAngle);
+    G4double tipOuterRadius = baseOuterRadius;
 
-	G4double conHalfLengthZ = fGermaniumCornerConeEndLength/2.0 + fQuarterDetectorCxn;
+    G4double conHalfLengthZ = fGermaniumCornerConeEndLength/2.0 + fQuarterDetectorCxn;
 
-	G4double initialAngle = acos((fGermaniumWidth/2.0 +fGermaniumShift)
-			/fGermaniumOuterRadius);
-	G4double totalAngle = M_PI/2.0 -2.0*initialAngle;
+    G4double initialAngle = acos((fGermaniumWidth/2.0 +fGermaniumShift)
+            /fGermaniumOuterRadius);
+    G4double totalAngle = M_PI/2.0 -2.0*initialAngle;
 
-	G4Cons* roundedEdge = new G4Cons("roundedEdge", baseInnerRadius,
-			baseOuterRadius, tipInnerRadius, tipOuterRadius,
-			conHalfLengthZ, initialAngle, totalAngle);
+    G4Cons* roundedEdge = new G4Cons("roundedEdge", baseInnerRadius,
+            baseOuterRadius, tipInnerRadius, tipOuterRadius,
+            conHalfLengthZ, initialAngle, totalAngle);
 
-	G4RotationMatrix* rotateRoundedEdge = new G4RotationMatrix;
-	rotateRoundedEdge->rotateZ(-M_PI/2.0);
+    G4RotationMatrix* rotateRoundedEdge = new G4RotationMatrix;
+    rotateRoundedEdge->rotateZ(-M_PI/2.0);
 
-	G4ThreeVector moveRoundedEdge(fGermaniumShift, -fGermaniumShift,
-			fGermaniumLength/2.0 -fGermaniumCornerConeEndLength/2.0
-			+ fQuarterDetectorCxnB);
+    G4ThreeVector moveRoundedEdge(fGermaniumShift, -fGermaniumShift,
+            fGermaniumLength/2.0 -fGermaniumCornerConeEndLength/2.0
+            + fQuarterDetectorCxnB);
 
-	G4SubtractionSolid* germaniumRoundedEdge = new G4SubtractionSolid("germaniumRoundedEdge",
-			germaniumRoundedCorners, roundedEdge, rotateRoundedEdge,
-			moveRoundedEdge);
+    G4SubtractionSolid* germaniumRoundedEdge = new G4SubtractionSolid("germaniumRoundedEdge",
+            germaniumRoundedCorners, roundedEdge, rotateRoundedEdge,
+            moveRoundedEdge);
 
-	// now we make the diagonal slices
-	G4double halfChopPieceWidthX 	= fGermaniumWidth/2.0;
-	G4double halfChopPieceWidthY 	= fGermaniumWidth/2.0;
-	G4double halfChopPieceLengthZ 	= (fGermaniumBentLength/cos(fBentEndAngle))/2.0;
-	G4Box* chopPiece = new G4Box("chopPiece", halfChopPieceWidthX,
-			halfChopPieceWidthY, halfChopPieceLengthZ);
+    // now we make the diagonal slices
+    G4double halfChopPieceWidthX    = fGermaniumWidth/2.0;
+    G4double halfChopPieceWidthY    = fGermaniumWidth/2.0;
+    G4double halfChopPieceLengthZ   = (fGermaniumBentLength/cos(fBentEndAngle))/2.0;
+    G4Box* chopPiece = new G4Box("chopPiece", halfChopPieceWidthX,
+            halfChopPieceWidthY, halfChopPieceLengthZ);
 
-	G4RotationMatrix* rotateChopPiece1 = new G4RotationMatrix;
-	rotateChopPiece1->rotateX(-(fBentEndAngle));
+    G4RotationMatrix* rotateChopPiece1 = new G4RotationMatrix;
+    rotateChopPiece1->rotateX(-(fBentEndAngle));
 
-	G4ThreeVector moveChopPiece1(0, fGermaniumWidth/2.0 +(fGermaniumBentLength
-				/tan(fBentEndAngle) +fGermaniumWidth
-				*cos(fBentEndAngle))/2.0 -((fGermaniumBentLength
-					/cos(fBentEndAngle))/2.0) /sin(fBentEndAngle),
-			fGermaniumLength/2.0 -fGermaniumBentLength
-			+(fGermaniumBentLength +fGermaniumWidth
-				*sin(fBentEndAngle))/2.0);
+    G4ThreeVector moveChopPiece1(0, fGermaniumWidth/2.0 +(fGermaniumBentLength
+                /tan(fBentEndAngle) +fGermaniumWidth
+                *cos(fBentEndAngle))/2.0 -((fGermaniumBentLength
+                    /cos(fBentEndAngle))/2.0) /sin(fBentEndAngle),
+            fGermaniumLength/2.0 -fGermaniumBentLength
+            +(fGermaniumBentLength +fGermaniumWidth
+                *sin(fBentEndAngle))/2.0);
 
-	G4SubtractionSolid* choppedGermanium1 = new G4SubtractionSolid("choppedGermanium1",
-			germaniumRoundedEdge, chopPiece, rotateChopPiece1, moveChopPiece1);
-
-
-	G4RotationMatrix* rotateChopPiece2 = new G4RotationMatrix;
-	rotateChopPiece2->rotateY(-(fBentEndAngle));
-
-	G4ThreeVector moveChopPiece2(-(fGermaniumWidth/2.0 +(fGermaniumBentLength
-					/tan(fBentEndAngle) +fGermaniumWidth
-					*cos(fBentEndAngle))/2.0 -((fGermaniumBentLength
-						/cos(fBentEndAngle))/2.0) /sin(fBentEndAngle)), 0,
-			fGermaniumLength/2.0 -fGermaniumBentLength
-			+(fGermaniumBentLength +fGermaniumWidth
-				*sin(fBentEndAngle))/2.0);
-
-	G4SubtractionSolid* choppedGermanium2 = new G4SubtractionSolid("choppedGermanium2",
-			choppedGermanium1, chopPiece, rotateChopPiece2, moveChopPiece2);
+    G4SubtractionSolid* choppedGermanium1 = new G4SubtractionSolid("choppedGermanium1",
+            germaniumRoundedEdge, chopPiece, rotateChopPiece1, moveChopPiece1);
 
 
-	// now we make the hole that will go in the back of each quarter detector, /////////////////////////////////////////////////////////
-	startAngle = 0.0*M_PI;
-	finalAngle = 2.0*M_PI;
-	G4double holeRadius = fGermaniumHoleRadius;
-	G4double holeHalfLengthZ = (fGermaniumLength -fGermaniumHoleDistFromFace)/2.0;
+    G4RotationMatrix* rotateChopPiece2 = new G4RotationMatrix;
+    rotateChopPiece2->rotateY(-(fBentEndAngle));
 
-	G4Tubs* holeTubs = new G4Tubs("holeTubs", 0.0, holeRadius, holeHalfLengthZ, startAngle, finalAngle);
-	G4ThreeVector moveHole(fGermaniumShift, -(fGermaniumShift),-((fGermaniumHoleDistFromFace)));
+    G4ThreeVector moveChopPiece2(-(fGermaniumWidth/2.0 +(fGermaniumBentLength
+                    /tan(fBentEndAngle) +fGermaniumWidth
+                    *cos(fBentEndAngle))/2.0 -((fGermaniumBentLength
+                        /cos(fBentEndAngle))/2.0) /sin(fBentEndAngle)), 0,
+            fGermaniumLength/2.0 -fGermaniumBentLength
+            +(fGermaniumBentLength +fGermaniumWidth
+                *sin(fBentEndAngle))/2.0);
 
-	G4SubtractionSolid* choppedGermanium3 = new G4SubtractionSolid("choppedGermanium3",
-			choppedGermanium2, holeTubs, 0, moveHole);
+    G4SubtractionSolid* choppedGermanium2 = new G4SubtractionSolid("choppedGermanium2",
+            choppedGermanium1, chopPiece, rotateChopPiece2, moveChopPiece2);
 
-	startAngle = 0.0*M_PI;
-	finalAngle = 2.0*M_PI;
-	G4double deadLayerRadius = fGermaniumHoleRadius + fGriffinDeadLayers[det][cry];
-	G4double deadLayerHalfLengthZ = (fGermaniumLength
-			- fGermaniumHoleDistFromFace
-			+ fGriffinDeadLayers[det][cry])/2.0;
 
-	// now dead layer
-	G4Tubs* deadLayerTubs = new G4Tubs("deadLayerTubs", 0.0,
-			deadLayerRadius, deadLayerHalfLengthZ, startAngle,finalAngle);
+    // now we make the hole that will go in the back of each quarter detector, /////////////////////////////////////////////////////////
+    startAngle = 0.0*M_PI;
+    finalAngle = 2.0*M_PI;
+    G4double holeRadius = fGermaniumHoleRadius;
+    G4double holeHalfLengthZ = (fGermaniumLength -fGermaniumHoleDistFromFace)/2.0;
 
-	G4ThreeVector moveDeadLayer(fGermaniumShift, -(fGermaniumShift),
-			-((fGermaniumHoleDistFromFace
-					- fGriffinDeadLayers[det][cry])/2.0));
+    G4Tubs* holeTubs = new G4Tubs("holeTubs", 0.0, holeRadius, holeHalfLengthZ, startAngle, finalAngle);
+    G4ThreeVector moveHole(fGermaniumShift, -(fGermaniumShift),-((fGermaniumHoleDistFromFace)));
 
-	G4SubtractionSolid* choppedGermanium4 = new G4SubtractionSolid("choppedGermanium4",
-			choppedGermanium3, deadLayerTubs, 0, moveDeadLayer);
+    G4SubtractionSolid* choppedGermanium3 = new G4SubtractionSolid("choppedGermanium3",
+            choppedGermanium2, holeTubs, 0, moveHole);
 
-	return choppedGermanium4;
+    startAngle = 0.0*M_PI;
+    finalAngle = 2.0*M_PI;
+    G4double deadLayerRadius = fGermaniumHoleRadius + fGriffinDeadLayers[det][cry];
+    G4double deadLayerHalfLengthZ = (fGermaniumLength
+            - fGermaniumHoleDistFromFace
+            + fGriffinDeadLayers[det][cry])/2.0;
+
+    // now dead layer
+    G4Tubs* deadLayerTubs = new G4Tubs("deadLayerTubs", 0.0,
+            deadLayerRadius, deadLayerHalfLengthZ, startAngle,finalAngle);
+
+    G4ThreeVector moveDeadLayer(fGermaniumShift, -(fGermaniumShift),
+            -((fGermaniumHoleDistFromFace
+                    - fGriffinDeadLayers[det][cry])/2.0));
+
+    G4SubtractionSolid* choppedGermanium4 = new G4SubtractionSolid("choppedGermanium4",
+            choppedGermanium3, deadLayerTubs, 0, moveDeadLayer);
+
+    return choppedGermanium4;
 
 }//end ::quarterSpecificDeadLayerDetector
 
@@ -2650,330 +2689,330 @@ G4SubtractionSolid* DetectionSystemGriffin::QuarterSpecificDeadLayerDetector(G4i
 ///////////////////////////////////////////////////////////////////////
 
 G4SubtractionSolid* DetectionSystemGriffin::ShellForBackSuppressorQuarter() {
-	G4double halfThicknessX = fBackBGOThickness/2.0 + fSuppressorShellThickness;
-	G4double halfLengthY = fDetectorTotalWidth/4.0;
-	G4double halfLengthZ = halfLengthY;
-	G4Box* quarterSuppressorShell = new G4Box("quarterSuppressorShell", halfThicknessX, halfLengthY, halfLengthZ);
+    G4double halfThicknessX = fBackBGOThickness/2.0 + fSuppressorShellThickness;
+    G4double halfLengthY = fDetectorTotalWidth/4.0;
+    G4double halfLengthZ = halfLengthY;
+    G4Box* quarterSuppressorShell = new G4Box("quarterSuppressorShell", halfThicknessX, halfLengthY, halfLengthZ);
 
-	G4double shellHoleRadius = fColdFingerOuterShellRadius;
-	G4Tubs* shellHole = new G4Tubs("shellHole", 0, shellHoleRadius, halfThicknessX +1.0*cm, 0.0*M_PI, 2.0*M_PI);
+    G4double shellHoleRadius = fColdFingerOuterShellRadius;
+    G4Tubs* shellHole = new G4Tubs("shellHole", 0, shellHoleRadius, halfThicknessX +1.0*cm, 0.0*M_PI, 2.0*M_PI);
 
-	G4RotationMatrix* rotateShellHole = new G4RotationMatrix;
-	rotateShellHole->rotateY(M_PI/2.0);
-	G4ThreeVector moveShellHole(0, -halfLengthY, halfLengthZ);
+    G4RotationMatrix* rotateShellHole = new G4RotationMatrix;
+    rotateShellHole->rotateY(M_PI/2.0);
+    G4ThreeVector moveShellHole(0, -halfLengthY, halfLengthZ);
 
-	G4SubtractionSolid* quarterSuppressorShellWithHole = new G4SubtractionSolid("quarterSuppressorShellWithHole",
-			quarterSuppressorShell, shellHole, rotateShellHole, moveShellHole);
+    G4SubtractionSolid* quarterSuppressorShellWithHole = new G4SubtractionSolid("quarterSuppressorShellWithHole",
+            quarterSuppressorShell, shellHole, rotateShellHole, moveShellHole);
 
-	//now we need to cut out inner cavity, first we define the cavity
-	halfThicknessX = fBackBGOThickness/2.0;
-	halfLengthY = fDetectorTotalWidth/4.0 - fSuppressorShellThickness;
-	halfLengthZ = halfLengthY;
-	G4Box* quarterSuppressor = new G4Box("quarterSuppressor", halfThicknessX, halfLengthY, halfLengthZ);
+    //now we need to cut out inner cavity, first we define the cavity
+    halfThicknessX = fBackBGOThickness/2.0;
+    halfLengthY = fDetectorTotalWidth/4.0 - fSuppressorShellThickness;
+    halfLengthZ = halfLengthY;
+    G4Box* quarterSuppressor = new G4Box("quarterSuppressor", halfThicknessX, halfLengthY, halfLengthZ);
 
-	G4ThreeVector moveCut(0,0,0);
+    G4ThreeVector moveCut(0,0,0);
 
-	// cut
-	G4SubtractionSolid* quarterSuppressorShellWithHoleAndCavity = new G4SubtractionSolid("quarterSuppressorShellWithHoleAndCavity",
-			quarterSuppressorShellWithHole, quarterSuppressor, 0, moveCut);
+    // cut
+    G4SubtractionSolid* quarterSuppressorShellWithHoleAndCavity = new G4SubtractionSolid("quarterSuppressorShellWithHoleAndCavity",
+            quarterSuppressorShellWithHole, quarterSuppressor, 0, moveCut);
 
-	return quarterSuppressorShellWithHoleAndCavity;
+    return quarterSuppressorShellWithHoleAndCavity;
 
 }//end ::shellForBackSuppressorQuarter
 
 
 G4SubtractionSolid* DetectionSystemGriffin::ShellForFrontSlantSuppressor(G4String sidePosition) {
-	// Change some values to accomodate the shells
-	// Replacement for sideSuppressorLength
-	G4double shellSideSuppressorShellLength = fSideSuppressorLength + (fSuppressorShellThickness*2.0);
+    // Change some values to accomodate the shells
+    // Replacement for sideSuppressorLength
+    G4double shellSideSuppressorShellLength = fSideSuppressorLength + (fSuppressorShellThickness*2.0);
 
-	G4double lengthZ         = shellSideSuppressorShellLength;
-	G4double lengthY         = fSideBGOThickness + fSuppressorShellThickness*2.0;
-	G4double lengthLongerX  = fDetectorTotalWidth/2.0 +fBGOCanSeperation
-		+ fSideBGOThickness + fSuppressorShellThickness*2.0;
-	G4double lengthShorterX = lengthLongerX -fSideBGOThickness
-		- fSuppressorShellThickness*2.0;
+    G4double lengthZ         = shellSideSuppressorShellLength;
+    G4double lengthY         = fSideBGOThickness + fSuppressorShellThickness*2.0;
+    G4double lengthLongerX  = fDetectorTotalWidth/2.0 +fBGOCanSeperation
+        + fSideBGOThickness + fSuppressorShellThickness*2.0;
+    G4double lengthShorterX = lengthLongerX -fSideBGOThickness
+        - fSuppressorShellThickness*2.0;
 
-	G4Trap* suppressorShell = new G4Trap("suppressorShell", lengthZ, lengthY, lengthLongerX, lengthShorterX);
+    G4Trap* suppressorShell = new G4Trap("suppressorShell", lengthZ, lengthY, lengthLongerX, lengthShorterX);
 
-	G4double halfLengthX      = lengthLongerX/2.0 +1.0*cm;
-	G4double halfThicknessY   = fSideBGOThickness/2.0 + fSuppressorShellThickness;
-	G4double halfLengthZ      = ((fSideBGOThickness + fSuppressorShellThickness*2.0
-				- fBGOChoppedTip)/sin(fBentEndAngle))/2.0;
+    G4double halfLengthX      = lengthLongerX/2.0 +1.0*cm;
+    G4double halfThicknessY   = fSideBGOThickness/2.0 + fSuppressorShellThickness;
+    G4double halfLengthZ      = ((fSideBGOThickness + fSuppressorShellThickness*2.0
+                - fBGOChoppedTip)/sin(fBentEndAngle))/2.0;
 
-	G4Box* choppingShellBox = new G4Box("choppingShellBox", halfLengthX, halfThicknessY, halfLengthZ);
+    G4Box* choppingShellBox = new G4Box("choppingShellBox", halfLengthX, halfThicknessY, halfLengthZ);
 
-	G4RotationMatrix* rotateChoppingShellBox = new G4RotationMatrix;
+    G4RotationMatrix* rotateChoppingShellBox = new G4RotationMatrix;
 
-	G4double y0 = fSideBGOThickness/2.0 - fSuppressorShellThickness * sin(fBentEndAngle)
-		- fBGOChoppedTip - 0.5 * sqrt(pow((2.0 * halfLengthZ), 2.0)
-				+ pow((2.0 * halfThicknessY), 2.0)) * cos(M_PI/2.0 - fBentEndAngle - atan(halfThicknessY/halfLengthZ)) ;
+    G4double y0 = fSideBGOThickness/2.0 - fSuppressorShellThickness * sin(fBentEndAngle)
+        - fBGOChoppedTip - 0.5 * sqrt(pow((2.0 * halfLengthZ), 2.0)
+                + pow((2.0 * halfThicknessY), 2.0)) * cos(M_PI/2.0 - fBentEndAngle - atan(halfThicknessY/halfLengthZ)) ;
 
-	G4double z0 = lengthZ/2.0 - 0.5 * sqrt(pow((2.0 * halfLengthZ), 2.0) + pow((2.0 * halfThicknessY), 2.0)) * sin(M_PI/2.0
-			- fBentEndAngle - atan(halfThicknessY/halfLengthZ)) ;
-	G4ThreeVector moveChoppingShellBox ;
+    G4double z0 = lengthZ/2.0 - 0.5 * sqrt(pow((2.0 * halfLengthZ), 2.0) + pow((2.0 * halfThicknessY), 2.0)) * sin(M_PI/2.0
+            - fBentEndAngle - atan(halfThicknessY/halfLengthZ)) ;
+    G4ThreeVector moveChoppingShellBox ;
 
-	if(sidePosition == "left")
-	{
-		rotateChoppingShellBox->rotateX(fBentEndAngle);
-		moveChoppingShellBox = G4ThreeVector(0, y0, z0) ;
-	}
-	else if(sidePosition == "right")
-	{
-		rotateChoppingShellBox->rotateX(-fBentEndAngle);
-		moveChoppingShellBox = G4ThreeVector(0, y0, -z0) ;
-	}
+    if(sidePosition == "left")
+    {
+        rotateChoppingShellBox->rotateX(fBentEndAngle);
+        moveChoppingShellBox = G4ThreeVector(0, y0, z0) ;
+    }
+    else if(sidePosition == "right")
+    {
+        rotateChoppingShellBox->rotateX(-fBentEndAngle);
+        moveChoppingShellBox = G4ThreeVector(0, y0, -z0) ;
+    }
 
-	G4SubtractionSolid* sideSuppressorShell = new G4SubtractionSolid("sideSuppressorShell",
-			suppressorShell, choppingShellBox, rotateChoppingShellBox, moveChoppingShellBox);
+    G4SubtractionSolid* sideSuppressorShell = new G4SubtractionSolid("sideSuppressorShell",
+            suppressorShell, choppingShellBox, rotateChoppingShellBox, moveChoppingShellBox);
 
-	G4SubtractionSolid* sideSuppressorShellWithCavity = nullptr;
+    G4SubtractionSolid* sideSuppressorShellWithCavity = nullptr;
 
-	// cut out cavity
-	if(sidePosition == "left")
-	{
-		G4ThreeVector moveCut(-(fSuppressorShellThickness + (fExtraCutLength/2.0 - fSuppressorShellThickness)/2.0), 0, (fSuppressorShellThickness/2.0));
+    // cut out cavity
+    if(sidePosition == "left")
+    {
+        G4ThreeVector moveCut(-(fSuppressorShellThickness + (fExtraCutLength/2.0 - fSuppressorShellThickness)/2.0), 0, (fSuppressorShellThickness/2.0));
 
-		sideSuppressorShellWithCavity = new G4SubtractionSolid("sideSuppressorShellWithCavity", sideSuppressorShell,
-				FrontSlantSuppressor("left", true), 0, moveCut); // chopping, left from frontSlantSuppressor.
-	}
-	else if(sidePosition == "right")
-	{
-		G4ThreeVector moveCut(-(fSuppressorShellThickness + (fExtraCutLength/2.0 - fSuppressorShellThickness)/2.0), 0, -(fSuppressorShellThickness/2.0));
+        sideSuppressorShellWithCavity = new G4SubtractionSolid("sideSuppressorShellWithCavity", sideSuppressorShell,
+                FrontSlantSuppressor("left", true), 0, moveCut); // chopping, left from frontSlantSuppressor.
+    }
+    else if(sidePosition == "right")
+    {
+        G4ThreeVector moveCut(-(fSuppressorShellThickness + (fExtraCutLength/2.0 - fSuppressorShellThickness)/2.0), 0, -(fSuppressorShellThickness/2.0));
 
-		sideSuppressorShellWithCavity = new G4SubtractionSolid("sideSuppressorShellWithCavity", sideSuppressorShell,
-				FrontSlantSuppressor("right", true), 0, moveCut); // chopping, right from frontSlantSuppressor.
-	}
+        sideSuppressorShellWithCavity = new G4SubtractionSolid("sideSuppressorShellWithCavity", sideSuppressorShell,
+                FrontSlantSuppressor("right", true), 0, moveCut); // chopping, right from frontSlantSuppressor.
+    }
 
-	return sideSuppressorShellWithCavity;
+    return sideSuppressorShellWithCavity;
 } // end ::shellForFrontSlantSuppressor
 
 
 G4SubtractionSolid* DetectionSystemGriffin::ShellForSuppressorExtension(G4String sidePosition) {
 
-	// Replacement for suppressorExtensionLength
-	G4double shellSuppressorShellExtensionLength = fSuppressorExtensionLength
-		+ (fSuppressorShellThickness*2.0)*(1.0/tan(fBentEndAngle)
-				- tan(fBentEndAngle));
+    // Replacement for suppressorExtensionLength
+    G4double shellSuppressorShellExtensionLength = fSuppressorExtensionLength
+        + (fSuppressorShellThickness*2.0)*(1.0/tan(fBentEndAngle)
+                - tan(fBentEndAngle));
 
-	G4double thicknessZ = fSuppressorExtensionThickness + fSuppressorShellThickness*2.0;
-	G4double lengthY = shellSuppressorShellExtensionLength;
+    G4double thicknessZ = fSuppressorExtensionThickness + fSuppressorShellThickness*2.0;
+    G4double lengthY = shellSuppressorShellExtensionLength;
 
-	G4double longerLengthX =  (fSuppressorBackRadius +fBentEndLength +(fBGOCanSeperation
-				+ fSideBGOThickness
-				+ fSuppressorShellThickness*2.0)
-			/ tan(fBentEndAngle)
-			- (fSuppressorExtensionThickness
-				+ fSuppressorShellThickness*2.0)
-			* sin(fBentEndAngle))*tan(fBentEndAngle);
+    G4double longerLengthX =  (fSuppressorBackRadius +fBentEndLength +(fBGOCanSeperation
+                + fSideBGOThickness
+                + fSuppressorShellThickness*2.0)
+            / tan(fBentEndAngle)
+            - (fSuppressorExtensionThickness
+                + fSuppressorShellThickness*2.0)
+            * sin(fBentEndAngle))*tan(fBentEndAngle);
 
-	G4double shorterLengthX = (fSuppressorForwardRadius + fHevimetTipThickness) * sin(fBentEndAngle) ;
+    G4double shorterLengthX = (fSuppressorForwardRadius + fHevimetTipThickness) * sin(fBentEndAngle) ;
 
-	G4Trap* uncutExtensionShell = new G4Trap("uncutExtensionShell", thicknessZ, lengthY, longerLengthX, shorterLengthX);
+    G4Trap* uncutExtensionShell = new G4Trap("uncutExtensionShell", thicknessZ, lengthY, longerLengthX, shorterLengthX);
 
-	// because these pieces are rotated in two planes, there are multiple angles that need to be calculated to make sure
-	// all of the extensions join up
+    // because these pieces are rotated in two planes, there are multiple angles that need to be calculated to make sure
+    // all of the extensions join up
 
-	G4double beta = atan((longerLengthX -shorterLengthX)/(lengthY));
-	G4double phi  = atan(1/cos(fBentEndAngle));
+    G4double beta = atan((longerLengthX -shorterLengthX)/(lengthY));
+    G4double phi  = atan(1/cos(fBentEndAngle));
 
-	G4double choppingHalfLengthX = (thicknessZ / sin(phi)) / 2.0;
-	G4double choppingHalfLengthY = lengthY / (2.0 * cos(beta));
-	G4double choppingHalfLengthZ = choppingHalfLengthX;
-	G4double yAngle = -beta;
-	G4double xAngle = 0.0;
-	G4double zAngle = 0.;
+    G4double choppingHalfLengthX = (thicknessZ / sin(phi)) / 2.0;
+    G4double choppingHalfLengthY = lengthY / (2.0 * cos(beta));
+    G4double choppingHalfLengthZ = choppingHalfLengthX;
+    G4double yAngle = -beta;
+    G4double xAngle = 0.0;
+    G4double zAngle = 0.;
 
-	if(sidePosition == "left")
-		zAngle = M_PI/2.0 - phi ;
-	else if(sidePosition == "right")
-		zAngle = phi - M_PI/2.0 ;
+    if(sidePosition == "left")
+        zAngle = M_PI/2.0 - phi ;
+    else if(sidePosition == "right")
+        zAngle = phi - M_PI/2.0 ;
 
 
-	G4Para* choppingParaShell = new G4Para("choppingParaShell", choppingHalfLengthX,
-			choppingHalfLengthY, choppingHalfLengthZ, yAngle, zAngle, xAngle);
+    G4Para* choppingParaShell = new G4Para("choppingParaShell", choppingHalfLengthX,
+            choppingHalfLengthY, choppingHalfLengthZ, yAngle, zAngle, xAngle);
 
-	G4ThreeVector moveParaShell(((longerLengthX -shorterLengthX)/2.0 +shorterLengthX)/2.0
-			+ choppingHalfLengthX -choppingHalfLengthX*cos(phi), 0.0, 0.0);
+    G4ThreeVector moveParaShell(((longerLengthX -shorterLengthX)/2.0 +shorterLengthX)/2.0
+            + choppingHalfLengthX -choppingHalfLengthX*cos(phi), 0.0, 0.0);
 
-	G4SubtractionSolid* extensionShell = new G4SubtractionSolid("extensionShell",
-			uncutExtensionShell, choppingParaShell, 0, moveParaShell);
+    G4SubtractionSolid* extensionShell = new G4SubtractionSolid("extensionShell",
+            uncutExtensionShell, choppingParaShell, 0, moveParaShell);
 
-	G4ThreeVector moveCut ;
-	G4SubtractionSolid* extensionSuppressorShellWithCavity = nullptr;
-	G4SubtractionSolid* extensionSuppressorShellWithCavityPre = nullptr;
+    G4ThreeVector moveCut ;
+    G4SubtractionSolid* extensionSuppressorShellWithCavity = nullptr;
+    G4SubtractionSolid* extensionSuppressorShellWithCavityPre = nullptr;
 
-	// cut out cavity ----
-	// We make two cuts, one "crude" one from a G4Trap, and a more refined cut using a G4SubtractionSolid. There are two reasons why we make two cuts.
-	// Firstly, the shape of these suppressors are strange. To make the inside cut large enough to have an opening such that the left and right suppressors touch would
-	// require some clever math, and that's a pain. The second (less lazy) reason is Geant4 doesn't like to make a G4SubtractionSolid out of two G4SubtractionSolids.
-	// My experience is that the visulization will fail if two sides of the G4SubtractionSolids are close, that is do not have a LARGE (>~10mm) overlap. To get around this,
-	// I simply make a "crude" first cut using a G4Trap.
-	// The cuts are slightly larger than suppressor to allow for small gaps between the shell and the suppressor.
-	if(sidePosition == "left")
-	{
-		moveCut = G4ThreeVector(-30.0*mm,0.40*mm,0.25*mm);
-		extensionSuppressorShellWithCavityPre = new G4SubtractionSolid("extensionSuppressorShellWithCavityPre", extensionShell, SideSuppressorExtensionUncut(), 0, (moveCut)/2.0); // Left, Chopping sideSuppressorExtension
+    // cut out cavity ----
+    // We make two cuts, one "crude" one from a G4Trap, and a more refined cut using a G4SubtractionSolid. There are two reasons why we make two cuts.
+    // Firstly, the shape of these suppressors are strange. To make the inside cut large enough to have an opening such that the left and right suppressors touch would
+    // require some clever math, and that's a pain. The second (less lazy) reason is Geant4 doesn't like to make a G4SubtractionSolid out of two G4SubtractionSolids.
+    // My experience is that the visulization will fail if two sides of the G4SubtractionSolids are close, that is do not have a LARGE (>~10mm) overlap. To get around this,
+    // I simply make a "crude" first cut using a G4Trap.
+    // The cuts are slightly larger than suppressor to allow for small gaps between the shell and the suppressor.
+    if(sidePosition == "left")
+    {
+        moveCut = G4ThreeVector(-30.0*mm,0.40*mm,0.25*mm);
+        extensionSuppressorShellWithCavityPre = new G4SubtractionSolid("extensionSuppressorShellWithCavityPre", extensionShell, SideSuppressorExtensionUncut(), 0, (moveCut)/2.0); // Left, Chopping sideSuppressorExtension
 
-		moveCut = G4ThreeVector(-1.15*mm,0.40*mm,0.25*mm);
-		extensionSuppressorShellWithCavity = new G4SubtractionSolid("extensionSuppressorShellWithCavity", extensionSuppressorShellWithCavityPre, SideSuppressorExtension("left", true), 0, (moveCut)/2.0);
-	}
-	else if(sidePosition == "right")
-	{
-		moveCut = G4ThreeVector(-30.0*mm,0.40*mm,-0.25*mm);
-		extensionSuppressorShellWithCavityPre = new G4SubtractionSolid("extensionSuppressorShellWithCavityPre", extensionShell, SideSuppressorExtensionUncut(), 0, (moveCut)/2.0); // Left, Chopping sideSuppressorExtension
+        moveCut = G4ThreeVector(-1.15*mm,0.40*mm,0.25*mm);
+        extensionSuppressorShellWithCavity = new G4SubtractionSolid("extensionSuppressorShellWithCavity", extensionSuppressorShellWithCavityPre, SideSuppressorExtension("left", true), 0, (moveCut)/2.0);
+    }
+    else if(sidePosition == "right")
+    {
+        moveCut = G4ThreeVector(-30.0*mm,0.40*mm,-0.25*mm);
+        extensionSuppressorShellWithCavityPre = new G4SubtractionSolid("extensionSuppressorShellWithCavityPre", extensionShell, SideSuppressorExtensionUncut(), 0, (moveCut)/2.0); // Left, Chopping sideSuppressorExtension
 
-		moveCut = G4ThreeVector(-1.15*mm,0.40*mm,-0.25*mm);
-		extensionSuppressorShellWithCavity = new G4SubtractionSolid("extensionSuppressorShellWithCavity", extensionSuppressorShellWithCavityPre, SideSuppressorExtension("right", true), 0, (moveCut)/2.0);
-	}
+        moveCut = G4ThreeVector(-1.15*mm,0.40*mm,-0.25*mm);
+        extensionSuppressorShellWithCavity = new G4SubtractionSolid("extensionSuppressorShellWithCavity", extensionSuppressorShellWithCavityPre, SideSuppressorExtension("right", true), 0, (moveCut)/2.0);
+    }
 
-	return extensionSuppressorShellWithCavity;
+    return extensionSuppressorShellWithCavity;
 } // end ::shellForSuppressorExtension
 
 
 // Back to making the suppressor volumes themselves
 G4SubtractionSolid* DetectionSystemGriffin::BackSuppressorQuarter() {
-	G4double halfThicknessX = fBackBGOThickness/2.0;
-	G4double halfLengthY = fDetectorTotalWidth/4.0 - fSuppressorShellThickness;
-	G4double halfLengthZ = halfLengthY;
-	G4Box* quarterSuppressor = new G4Box("quarterSuppressor", halfThicknessX, halfLengthY, halfLengthZ);
+    G4double halfThicknessX = fBackBGOThickness/2.0;
+    G4double halfLengthY = fDetectorTotalWidth/4.0 - fSuppressorShellThickness;
+    G4double halfLengthZ = halfLengthY;
+    G4Box* quarterSuppressor = new G4Box("quarterSuppressor", halfThicknessX, halfLengthY, halfLengthZ);
 
-	G4double holeRadius = fColdFingerOuterShellRadius;
-	G4Tubs* hole = new G4Tubs("hole", 0, holeRadius, halfThicknessX +1.0*cm, 0.0*M_PI, 2.0*M_PI);
+    G4double holeRadius = fColdFingerOuterShellRadius;
+    G4Tubs* hole = new G4Tubs("hole", 0, holeRadius, halfThicknessX +1.0*cm, 0.0*M_PI, 2.0*M_PI);
 
-	G4RotationMatrix* rotateHole = new G4RotationMatrix;
-	rotateHole->rotateY(M_PI/2.0);
-	G4ThreeVector moveHole(0, -halfLengthY, halfLengthZ);
+    G4RotationMatrix* rotateHole = new G4RotationMatrix;
+    rotateHole->rotateY(M_PI/2.0);
+    G4ThreeVector moveHole(0, -halfLengthY, halfLengthZ);
 
-	G4SubtractionSolid* quarterSuppressorWithHole = new G4SubtractionSolid("quarterSuppressorWithHole",
-			quarterSuppressor, hole, rotateHole, moveHole);
+    G4SubtractionSolid* quarterSuppressorWithHole = new G4SubtractionSolid("quarterSuppressorWithHole",
+            quarterSuppressor, hole, rotateHole, moveHole);
 
-	return quarterSuppressorWithHole;
+    return quarterSuppressorWithHole;
 
 }//end ::backSuppressorQuarter
 
 
 G4SubtractionSolid* DetectionSystemGriffin::FrontSlantSuppressor(G4String sidePosition, G4bool choppingSuppressor) {
-	// If chop is true, it will be a chopping suppressor.
+    // If chop is true, it will be a chopping suppressor.
 
-	G4double lengthZ     = fSideSuppressorLength ;
-	G4double lengthY     = fSideBGOThickness ;
-	G4double lengthLongerX  = 0 ;
+    G4double lengthZ     = fSideSuppressorLength ;
+    G4double lengthY     = fSideBGOThickness ;
+    G4double lengthLongerX  = 0 ;
 
-	if(choppingSuppressor)
-		lengthLongerX  = fDetectorTotalWidth / 2.0 + fBGOCanSeperation + fSideBGOThickness + fExtraCutLength / 2.0 ;
-	else
-		lengthLongerX  = fDetectorTotalWidth / 2.0 + fBGOCanSeperation + fSideBGOThickness;
+    if(choppingSuppressor)
+        lengthLongerX  = fDetectorTotalWidth / 2.0 + fBGOCanSeperation + fSideBGOThickness + fExtraCutLength / 2.0 ;
+    else
+        lengthLongerX  = fDetectorTotalWidth / 2.0 + fBGOCanSeperation + fSideBGOThickness;
 
-	G4double lengthShorterX   = lengthLongerX - fSideBGOThickness;
+    G4double lengthShorterX   = lengthLongerX - fSideBGOThickness;
 
-	G4Trap* suppressor = new G4Trap("suppressor", lengthZ, lengthY, lengthLongerX, lengthShorterX) ;
+    G4Trap* suppressor = new G4Trap("suppressor", lengthZ, lengthY, lengthLongerX, lengthShorterX) ;
 
-	G4double halfLengthX  = lengthLongerX / 2.0 + 1.0*cm ;
-	G4double halfThicknessY   = fSideBGOThickness / 2.0;
-	G4double halfLengthZ  = ((fSideBGOThickness - fBGOChoppedTip) / sin(fBentEndAngle)) / 2.0;
+    G4double halfLengthX  = lengthLongerX / 2.0 + 1.0*cm ;
+    G4double halfThicknessY   = fSideBGOThickness / 2.0;
+    G4double halfLengthZ  = ((fSideBGOThickness - fBGOChoppedTip) / sin(fBentEndAngle)) / 2.0;
 
-	G4Box* choppingBox = new G4Box("choppingBox", halfLengthX, halfThicknessY, halfLengthZ);
+    G4Box* choppingBox = new G4Box("choppingBox", halfLengthX, halfThicknessY, halfLengthZ);
 
-	G4RotationMatrix* rotateChoppingBox = new G4RotationMatrix;
-	G4ThreeVector moveChoppingBox ;
-	G4double y0, z0 ;
+    G4RotationMatrix* rotateChoppingBox = new G4RotationMatrix;
+    G4ThreeVector moveChoppingBox ;
+    G4double y0, z0 ;
 
-	y0 =  fSideBGOThickness / 2.0 - fBGOChoppedTip - 0.5 * sqrt(pow((2.0 * halfLengthZ), 2.0)
-			+ pow((2.0 * halfThicknessY), 2.0)) * cos(M_PI/2.0 - fBentEndAngle - atan(halfThicknessY / halfLengthZ)) ;
+    y0 =  fSideBGOThickness / 2.0 - fBGOChoppedTip - 0.5 * sqrt(pow((2.0 * halfLengthZ), 2.0)
+            + pow((2.0 * halfThicknessY), 2.0)) * cos(M_PI/2.0 - fBentEndAngle - atan(halfThicknessY / halfLengthZ)) ;
 
-	z0 =  lengthZ / 2.0 - 0.5 * sqrt(pow((2.0 * halfLengthZ), 2.0) + pow((2.0 * halfThicknessY), 2.0))
-		* sin(M_PI/2.0 - fBentEndAngle - atan(halfThicknessY / halfLengthZ)) ;
+    z0 =  lengthZ / 2.0 - 0.5 * sqrt(pow((2.0 * halfLengthZ), 2.0) + pow((2.0 * halfThicknessY), 2.0))
+        * sin(M_PI/2.0 - fBentEndAngle - atan(halfThicknessY / halfLengthZ)) ;
 
-	if(sidePosition == "left") {
-		rotateChoppingBox->rotateX(fBentEndAngle) ;
-		moveChoppingBox = G4ThreeVector(0, y0, z0) ;
-	} else if(sidePosition == "right") {
-		rotateChoppingBox->rotateX(-fBentEndAngle) ;
-		moveChoppingBox = G4ThreeVector(0, y0, -z0) ;
-	}
+    if(sidePosition == "left") {
+        rotateChoppingBox->rotateX(fBentEndAngle) ;
+        moveChoppingBox = G4ThreeVector(0, y0, z0) ;
+    } else if(sidePosition == "right") {
+        rotateChoppingBox->rotateX(-fBentEndAngle) ;
+        moveChoppingBox = G4ThreeVector(0, y0, -z0) ;
+    }
 
-	G4SubtractionSolid* sideSuppressor = new G4SubtractionSolid("sideSuppressor",
-			suppressor, choppingBox, rotateChoppingBox, moveChoppingBox);
+    G4SubtractionSolid* sideSuppressor = new G4SubtractionSolid("sideSuppressor",
+            suppressor, choppingBox, rotateChoppingBox, moveChoppingBox);
 
-	return sideSuppressor;
+    return sideSuppressor;
 
 }// end ::frontSlantSuppressor
 
 
 G4SubtractionSolid* DetectionSystemGriffin::SideSuppressorExtension(G4String sidePosition, G4bool choppingSuppressor) {
 
-	G4double thicknessZ      =   fSuppressorExtensionThickness ;
-	G4double lengthY         =   fSuppressorExtensionLength ;
+    G4double thicknessZ      =   fSuppressorExtensionThickness ;
+    G4double lengthY         =   fSuppressorExtensionLength ;
 
-	G4double longerLengthX  =   ((fSuppressorBackRadius + fBentEndLength
-				+ (fBGOCanSeperation
-					+ fSideBGOThickness) / tan(fBentEndAngle)
-				- fSuppressorExtensionThickness
-				* sin(fBentEndAngle)) * tan(fBentEndAngle) - fBGOCanSeperation * 2.0) ;  // - fBGOCanSeperation
+    G4double longerLengthX  =   ((fSuppressorBackRadius + fBentEndLength
+                + (fBGOCanSeperation
+                    + fSideBGOThickness) / tan(fBentEndAngle)
+                - fSuppressorExtensionThickness
+                * sin(fBentEndAngle)) * tan(fBentEndAngle) - fBGOCanSeperation * 2.0) ;  // - fBGOCanSeperation
 
-	G4double shorterLengthX =   ((fSuppressorForwardRadius + fHevimetTipThickness)
-			* sin(fBentEndAngle) - fBGOCanSeperation * 2.0) ; // - fBGOCanSeperation
+    G4double shorterLengthX =   ((fSuppressorForwardRadius + fHevimetTipThickness)
+            * sin(fBentEndAngle) - fBGOCanSeperation * 2.0) ; // - fBGOCanSeperation
 
-	if(choppingSuppressor) {
-		thicknessZ += 0.1*mm;
-		lengthY += 0.1*mm;
-	}
+    if(choppingSuppressor) {
+        thicknessZ += 0.1*mm;
+        lengthY += 0.1*mm;
+    }
 
-	G4Trap* uncutExtension   = new G4Trap("uncutExtension", thicknessZ, lengthY, longerLengthX, shorterLengthX);
+    G4Trap* uncutExtension   = new G4Trap("uncutExtension", thicknessZ, lengthY, longerLengthX, shorterLengthX);
 
-	// because these pieces are rotated in two planes, there are multiple angles that need to be calculated to make sure
-	// all of the extensions join up
-	G4double beta = atan((longerLengthX - shorterLengthX) / (lengthY)) ;
-	G4double phi  = atan(1 / cos(fBentEndAngle)) ;
+    // because these pieces are rotated in two planes, there are multiple angles that need to be calculated to make sure
+    // all of the extensions join up
+    G4double beta = atan((longerLengthX - shorterLengthX) / (lengthY)) ;
+    G4double phi  = atan(1 / cos(fBentEndAngle)) ;
 
-	G4double choppingHalfLengthX = thicknessZ / (2.0 * sin(phi)) ;
-	G4double choppingHalfLengthY = lengthY / (2.0 * cos(beta)) ;
-	G4double choppingHalfLengthZ = choppingHalfLengthX ;
+    G4double choppingHalfLengthX = thicknessZ / (2.0 * sin(phi)) ;
+    G4double choppingHalfLengthY = lengthY / (2.0 * cos(beta)) ;
+    G4double choppingHalfLengthZ = choppingHalfLengthX ;
 
-	G4double xAngle = 0.0 ;
-	G4double yAngle = -beta ;
-	G4double zAngle = phi - M_PI/2.0 ;
+    G4double xAngle = 0.0 ;
+    G4double yAngle = -beta ;
+    G4double zAngle = phi - M_PI/2.0 ;
 
-	if(sidePosition == "left")
-		zAngle *= -1 ;
+    if(sidePosition == "left")
+        zAngle *= -1 ;
 
-	G4Para* choppingPara = new G4Para("choppingPara", choppingHalfLengthX,
-			choppingHalfLengthY, choppingHalfLengthZ,
-			yAngle, zAngle, xAngle);
+    G4Para* choppingPara = new G4Para("choppingPara", choppingHalfLengthX,
+            choppingHalfLengthY, choppingHalfLengthZ,
+            yAngle, zAngle, xAngle);
 
-	G4ThreeVector movePara(((longerLengthX - shorterLengthX) / 2.0
-				+ shorterLengthX) / 2.0 + choppingHalfLengthX
-			- choppingHalfLengthX * cos(phi), 0.0, 0.0);
+    G4ThreeVector movePara(((longerLengthX - shorterLengthX) / 2.0
+                + shorterLengthX) / 2.0 + choppingHalfLengthX
+            - choppingHalfLengthX * cos(phi), 0.0, 0.0);
 
-	G4SubtractionSolid* rightExtension = new G4SubtractionSolid("rightExtension", uncutExtension, choppingPara, 0, movePara);
+    G4SubtractionSolid* rightExtension = new G4SubtractionSolid("rightExtension", uncutExtension, choppingPara, 0, movePara);
 
-	return rightExtension;
+    return rightExtension;
 
 }// end ::sideSuppressorExtension()
 
 
 G4Trap* DetectionSystemGriffin::SideSuppressorExtensionUncut() {
 
-	G4double thicknessZ      =   fSuppressorExtensionThickness ;
-	G4double lengthY         =   fSuppressorExtensionLength ;
+    G4double thicknessZ      =   fSuppressorExtensionThickness ;
+    G4double lengthY         =   fSuppressorExtensionLength ;
 
-	G4double longerLengthX  =   ((fSuppressorBackRadius + fBentEndLength
-				+ (fBGOCanSeperation
-					+ fSideBGOThickness) / tan(fBentEndAngle)
-				- fSuppressorExtensionThickness
-				* sin(fBentEndAngle)) * tan(fBentEndAngle) - fBGOCanSeperation * 2.0) ;  // - fBGOCanSeperation
+    G4double longerLengthX  =   ((fSuppressorBackRadius + fBentEndLength
+                + (fBGOCanSeperation
+                    + fSideBGOThickness) / tan(fBentEndAngle)
+                - fSuppressorExtensionThickness
+                * sin(fBentEndAngle)) * tan(fBentEndAngle) - fBGOCanSeperation * 2.0) ;  // - fBGOCanSeperation
 
-	G4double shorterLengthX =   ((fSuppressorForwardRadius + fHevimetTipThickness)
-			* sin(fBentEndAngle) - fBGOCanSeperation * 2.0) ; // - fBGOCanSeperation
+    G4double shorterLengthX =   ((fSuppressorForwardRadius + fHevimetTipThickness)
+            * sin(fBentEndAngle) - fBGOCanSeperation * 2.0) ; // - fBGOCanSeperation
 
-	// Similar to the "true" choppingSuppressor, add a bit on the z and y lengths to give a bit of a gap.
-	thicknessZ += 0.1*mm;
-	lengthY += 0.1*mm;
+    // Similar to the "true" choppingSuppressor, add a bit on the z and y lengths to give a bit of a gap.
+    thicknessZ += 0.1*mm;
+    lengthY += 0.1*mm;
 
-	G4Trap* uncutExtension   = new G4Trap("uncutExtension", thicknessZ, lengthY, longerLengthX, shorterLengthX);
+    G4Trap* uncutExtension   = new G4Trap("uncutExtension", thicknessZ, lengthY, longerLengthX, shorterLengthX);
 
-	return uncutExtension;
+    return uncutExtension;
 }// end ::sideSuppressorExtensionUncut()
 
 
@@ -2982,62 +3021,62 @@ G4Trap* DetectionSystemGriffin::SideSuppressorExtensionUncut() {
 ///////////////////////////////////////////////////////////////////////
 G4SubtractionSolid* DetectionSystemGriffin::NewHeavyMet() {
 
-	G4double halfThicknessZ = ((fHevimetTipThickness/cos(fHevimetTipAngle))
-			* cos(fBentEndAngle -fHevimetTipAngle)
-			+ fSuppressorForwardRadius * tan(fHevimetTipAngle)
-			* sin(fBentEndAngle))/2.0;
+    G4double halfThicknessZ = ((fHevimetTipThickness/cos(fHevimetTipAngle))
+            * cos(fBentEndAngle -fHevimetTipAngle)
+            + fSuppressorForwardRadius * tan(fHevimetTipAngle)
+            * sin(fBentEndAngle))/2.0;
 
 
-	G4double halfLengthShorterX  = fSuppressorForwardRadius * sin(fBentEndAngle);
-	G4double halfLengthLongerX 	= halfLengthShorterX +2.0*halfThicknessZ*tan(fBentEndAngle);
-	G4double  halfLengthShorterY = halfLengthShorterX;
-	G4double halfLengthLongerY 	= halfLengthLongerX;
+    G4double halfLengthShorterX  = fSuppressorForwardRadius * sin(fBentEndAngle);
+    G4double halfLengthLongerX  = halfLengthShorterX +2.0*halfThicknessZ*tan(fBentEndAngle);
+    G4double  halfLengthShorterY = halfLengthShorterX;
+    G4double halfLengthLongerY  = halfLengthLongerX;
 
-	G4Trd* uncutHevimet = new G4Trd("uncutHevimet", halfLengthLongerX,
-			halfLengthShorterX, halfLengthLongerY, halfLengthShorterY, halfThicknessZ);
+    G4Trd* uncutHevimet = new G4Trd("uncutHevimet", halfLengthLongerX,
+            halfLengthShorterX, halfLengthLongerY, halfLengthShorterY, halfThicknessZ);
 
-	G4double halfShorterLengthX = halfLengthShorterX
-		- fSuppressorForwardRadius * tan(fHevimetTipAngle) * cos(fBentEndAngle);
+    G4double halfShorterLengthX = halfLengthShorterX
+        - fSuppressorForwardRadius * tan(fHevimetTipAngle) * cos(fBentEndAngle);
 
-	G4double halfHeightZ =  (2.0 * halfThicknessZ + (halfLengthLongerX
-				- ((fSuppressorForwardRadius + fHevimetTipThickness)
-					* tan(fHevimetTipAngle)) / cos(fBentEndAngle)
-				- halfShorterLengthX)*tan(fBentEndAngle)) / 2.0;
+    G4double halfHeightZ =  (2.0 * halfThicknessZ + (halfLengthLongerX
+                - ((fSuppressorForwardRadius + fHevimetTipThickness)
+                    * tan(fHevimetTipAngle)) / cos(fBentEndAngle)
+                - halfShorterLengthX)*tan(fBentEndAngle)) / 2.0;
 
-	G4double halfLongerLengthX 	= halfShorterLengthX + 2.0 * halfHeightZ/tan(fBentEndAngle) ;
-	G4double halfShorterLengthY 	= halfShorterLengthX;
-	G4double halfLongerLengthY 	= halfLongerLengthX;
+    G4double halfLongerLengthX  = halfShorterLengthX + 2.0 * halfHeightZ/tan(fBentEndAngle) ;
+    G4double halfShorterLengthY     = halfShorterLengthX;
+    G4double halfLongerLengthY  = halfLongerLengthX;
 
-	G4Trd* intersector = new G4Trd("intersector", halfShorterLengthX,
-			halfLongerLengthX, halfShorterLengthY, halfLongerLengthY, halfHeightZ);
+    G4Trd* intersector = new G4Trd("intersector", halfShorterLengthX,
+            halfLongerLengthX, halfShorterLengthY, halfLongerLengthY, halfHeightZ);
 
-	G4Trd* chopper = new G4Trd("chopper", halfShorterLengthX, halfLongerLengthX,
-			halfShorterLengthY, halfLongerLengthY, halfHeightZ);
+    G4Trd* chopper = new G4Trd("chopper", halfShorterLengthX, halfLongerLengthX,
+            halfShorterLengthY, halfLongerLengthY, halfHeightZ);
 
-	G4ThreeVector moveChopper(0.0, 0.0, halfHeightZ + halfThicknessZ
-			- fSuppressorForwardRadius * tan(fHevimetTipAngle)
-			* sin(fBentEndAngle)) ;
+    G4ThreeVector moveChopper(0.0, 0.0, halfHeightZ + halfThicknessZ
+            - fSuppressorForwardRadius * tan(fHevimetTipAngle)
+            * sin(fBentEndAngle)) ;
 
-	G4SubtractionSolid* choppedHevimet = new G4SubtractionSolid("choppedHevimet",
-			uncutHevimet, chopper, 0, moveChopper);
+    G4SubtractionSolid* choppedHevimet = new G4SubtractionSolid("choppedHevimet",
+            uncutHevimet, chopper, 0, moveChopper);
 
-	G4ThreeVector moveIntersector(0.0, 0.0, -halfHeightZ + halfThicknessZ);
+    G4ThreeVector moveIntersector(0.0, 0.0, -halfHeightZ + halfThicknessZ);
 
-	G4IntersectionSolid* intersectedHevimet = new G4IntersectionSolid("intersectedHevimet",
-			choppedHevimet, intersector, 0, moveIntersector);
+    G4IntersectionSolid* intersectedHevimet = new G4IntersectionSolid("intersectedHevimet",
+            choppedHevimet, intersector, 0, moveIntersector);
 
-	G4double longerHalfLength = halfLengthLongerX -((fSuppressorForwardRadius
-				+ fHevimetTipThickness)*tan(fHevimetTipAngle)) / cos(fBentEndAngle) ;
+    G4double longerHalfLength = halfLengthLongerX -((fSuppressorForwardRadius
+                + fHevimetTipThickness)*tan(fHevimetTipAngle)) / cos(fBentEndAngle) ;
 
-	G4double shorterHalfLength = longerHalfLength -2.0*(halfThicknessZ +0.1*mm)
-		* tan(fBentEndAngle -fHevimetTipAngle);
+    G4double shorterHalfLength = longerHalfLength -2.0*(halfThicknessZ +0.1*mm)
+        * tan(fBentEndAngle -fHevimetTipAngle);
 
-	G4Trd* middleChopper = new G4Trd("middleChopper", longerHalfLength, shorterHalfLength,
-			longerHalfLength, shorterHalfLength, halfThicknessZ +0.1*mm);
+    G4Trd* middleChopper = new G4Trd("middleChopper", longerHalfLength, shorterHalfLength,
+            longerHalfLength, shorterHalfLength, halfThicknessZ +0.1*mm);
 
-	G4SubtractionSolid* hevimet = new G4SubtractionSolid("hevimet", intersectedHevimet, middleChopper);
+    G4SubtractionSolid* hevimet = new G4SubtractionSolid("hevimet", intersectedHevimet, middleChopper);
 
-	return hevimet;
+    return hevimet;
 }//end ::newHeavyMet
 
 

--- a/src/DetectionSystemGriffin.cc
+++ b/src/DetectionSystemGriffin.cc
@@ -123,9 +123,8 @@ void DetectionSystemGriffin::Build() {
     fSurfCheck = true;
     // begin CRN 
     G4int det = 1;
-    G4int cry = 1;
 
-    BuildOneDetector(det, cry);
+    BuildOneDetector(det);
     // end CRN
 
 }//end ::Build
@@ -492,7 +491,7 @@ G4int DetectionSystemGriffin::PlaceDeadLayerSpecificCrystal(G4LogicalVolume* exp
 ///////////////////////////////////////////////////////////////////////
 // BuildOneDetector()
 ///////////////////////////////////////////////////////////////////////
-void DetectionSystemGriffin::BuildOneDetector(G4int det, G4int cry) {
+void DetectionSystemGriffin::BuildOneDetector(G4int det) {
     // Build assembly volumes
     // Holds all pieces that are not a detector (ie. the can, nitrogen tank, cold finger, electrodes, etc.)
     fAssembly                           = new G4AssemblyVolume();
@@ -531,7 +530,7 @@ void DetectionSystemGriffin::BuildOneDetector(G4int det, G4int cry) {
 
     // Include BGOs?
     if(fBGOSelector == 1) {
-        ConstructNewSuppressorCasingWithShells(det, cry) ;
+        ConstructNewSuppressorCasingWithShells(det) ;
     } else if(fBGOSelector == 0) {
         //G4cout<<"Not building BGO "<<G4endl ;
     } else {
@@ -573,8 +572,7 @@ void DetectionSystemGriffin::BuildEverythingButCrystals(G4int det) {
     // Include BGOs?
     if(fBGOSelector == 1) {
         // begin CRN 
-        G4int cry = 0;
-        ConstructNewSuppressorCasingWithShells(det, cry);
+        ConstructNewSuppressorCasingWithShells(det);
         // end CRN 
     } else if(fBGOSelector == 0) {
         //G4cout<<"Not building BGO "<<G4endl;
@@ -1662,9 +1660,8 @@ G4Tubs* DetectionSystemGriffin::StructureMatColdFinger() {
 // of structureMat that surrounds the physical pieces.
 ///////////////////////////////////////////////////////////////////////
 // begin CRN 
-void DetectionSystemGriffin::ConstructNewSuppressorCasingWithShells(G4int det, G4int cry) {
+void DetectionSystemGriffin::ConstructNewSuppressorCasingWithShells(G4int det) {
     G4String strdet = G4UIcommand::ConvertToString(det);
-    G4String strcry = G4UIcommand::ConvertToString(cry);
     // end CRN 
     G4int i;
     G4double x0, y0, z0, x, y, z;
@@ -1717,12 +1714,9 @@ void DetectionSystemGriffin::ConstructNewSuppressorCasingWithShells(G4int det, G
     // the suppressor pieces themselves.  As an error checking method, the suppressor
     // pieces are given a copy number value far out of range of any useful copy number.
     if(fIncludeBackSuppressors) {
-        // begin CRN 
-        G4String backQuarterSuppressorShellLogName = "backQuarterSuppressorShell_" + strdet + "_" + strcry + "_log";
         fBackQuarterSuppressorShellLog = new G4LogicalVolume(
                 backQuarterSuppressorShell, structureMat,
-                backQuarterSuppressorShellLogName, 0, 0, 0);
-        // end CRN 
+                "backQuarterSuppressorShell", 0, 0, 0);
 
         fBackQuarterSuppressorShellLog->SetVisAttributes(SuppressorVisAtt);
 
@@ -1732,11 +1726,8 @@ void DetectionSystemGriffin::ConstructNewSuppressorCasingWithShells(G4int det, G
             exit(1);
         }
 
-        // begin CRN 
-        G4String backQuarterSuppressorLogName = "backQuarterSuppressor_" + strdet + "_" + strcry + "_log";
         fBackQuarterSuppressorLog = new G4LogicalVolume(backQuarterSuppressor, backMaterial,
-                backQuarterSuppressorLogName, 0, 0, 0);
-        // end CRN
+                "backQuarterSuppressor", 0, 0, 0);
         fBackQuarterSuppressorLog->SetVisAttributes(backInnardsVisAtt);
 
         fSuppressorBackAssembly->AddPlacedVolume(fBackQuarterSuppressorLog, fMoveNull, fRotateNull);
@@ -1771,23 +1762,20 @@ void DetectionSystemGriffin::ConstructNewSuppressorCasingWithShells(G4int det, G
     // now we add the side pieces of suppressor that taper off towards the front of the can
     ////////////////////////////////////////////////////////////////////////////////////////
     // begin CRN 
-    G4String rightSuppressorShellLogName = "rightSuppressorShell_" + strdet + "_" + strcry + "_log";
-    G4String leftSuppressorShellLogName = "leftSuppressorShell_" + strdet + "_" + strcry + "_log";
-
-    G4String rightSuppressorLogName = "rightSuppressor_" + strdet + "_" + strcry + "_log";
-    G4String leftSuppressorLogName = "leftSuppressor_" + strdet + "_" + strcry + "_log";
+    G4String rightSuppressorLogName = "rightSuppressor_" + strdet + "_log";
+    G4String leftSuppressorLogName = "leftSuppressor_" + strdet + "_log";
 
     // Define the structureMat shell logical volume
     G4SubtractionSolid* rightSuppressorShell = ShellForFrontSlantSuppressor("right");
 
     fRightSuppressorShellLog = new G4LogicalVolume(rightSuppressorShell, structureMat,
-            rightSuppressorShellLogName, 0,0,0);
+            "rightSuppressorShell", 0,0,0);
     fRightSuppressorShellLog->SetVisAttributes(SuppressorVisAtt);
 
     G4SubtractionSolid* leftSuppressorShell = ShellForFrontSlantSuppressor("left");
 
     fLeftSuppressorShellLog = new G4LogicalVolume(leftSuppressorShell, structureMat,
-            leftSuppressorShellLogName, 0,0,0);
+            "leftSuppressorShell", 0,0,0);
     fLeftSuppressorShellLog->SetVisAttributes(SuppressorVisAtt);
 
     G4SubtractionSolid* rightSuppressor = FrontSlantSuppressor("right", false); // Right, non-chopping.
@@ -1867,11 +1855,11 @@ void DetectionSystemGriffin::ConstructNewSuppressorCasingWithShells(G4int det, G
     // now we add the side pieces of suppressor that extend out in front of the can when it's in the back position
     ////////////////////////////////////////////////////////////////////////////////////////
     // begin CRN 
-    G4String rightSuppressorExtensionLogName = "rightSuppressorExtension_" + strdet + "_" + strcry + "_log";
-    G4String leftSuppressorExtensionLogName = "leftSuppressorExtension_" + strdet + "_" + strcry + "_log";
+    G4String rightSuppressorExtensionLogName = "rightSuppressorExtension_" + strdet + "_log";
+    G4String leftSuppressorExtensionLogName = "leftSuppressorExtension_" + strdet + "_log";
 
-    G4String rightSuppressorShellExtensionLogName = "rightSuppressorShellExtension_" + strdet + "_" + strcry + "_log";
-    G4String leftSuppressorShellExtensionLogName = "leftSuppressorShellExtension_" + strdet + "_" + strcry + "_log";
+    G4String rightSuppressorShellExtensionLogName = "rightSuppressorShellExtension_" + strdet + "_log";
+    G4String leftSuppressorShellExtensionLogName = "leftSuppressorShellExtension_" + strdet + "_log";
     // end CRN
 
     // Define the shell right logical volume

--- a/src/DetectionSystemGriffin.cc
+++ b/src/DetectionSystemGriffin.cc
@@ -37,10 +37,10 @@
 
 
 ///////////////////////////////////////////////////////////////////////
-// The ::DetectionSystemGriffin constructor instatiates all the 
+// The ::DetectionSystemGriffin constructor instatiates all the
 // Logical and Physical Volumes used in the detector geometery (found
 // in our local files as it contains NDA-protected info), and the
-// ::~DetectionSystemGriffin destructor deletes them from the stack 
+// ::~DetectionSystemGriffin destructor deletes them from the stack
 // when they go out of scope
 ///////////////////////////////////////////////////////////////////////
 
@@ -115,10 +115,10 @@ DetectionSystemGriffin::~DetectionSystemGriffin() {
 }// end ::~DetectionSystemGriffin
 
 ///////////////////////////////////////////////////////////////////////
-// ConstructDetectionSystemGriffin builds the DetectionSystemGriffin 
+// ConstructDetectionSystemGriffin builds the DetectionSystemGriffin
 // at the origin
 ///////////////////////////////////////////////////////////////////////
-void DetectionSystemGriffin::Build() { 
+void DetectionSystemGriffin::Build() {
 
     fSurfCheck = true;
     G4int det = 1;
@@ -650,7 +650,7 @@ void DetectionSystemGriffin::ConstructComplexDetectorBlock() {
 }//end ::ConstructComplexDetectorBlock
 
 ///////////////////////////////////////////////////////////////////////
-// ConstructComplexDetectorBlockWithDeadLayer builds four quarters of 
+// ConstructComplexDetectorBlockWithDeadLayer builds four quarters of
 // germanium, with dead layers
 ///////////////////////////////////////////////////////////////////////
 void DetectionSystemGriffin::ConstructComplexDetectorBlockWithDeadLayer() {
@@ -844,7 +844,7 @@ void DetectionSystemGriffin::ConstructComplexDetectorBlockWithDetectorSpecificDe
 
 ///////////////////////////////////////////////////////////////////////
 // Builds a layer of electrodeMat between germanium crystals to
-// approximate electrodes, etc. that Eurisys won't tell us 
+// approximate electrodes, etc. that Eurisys won't tell us
 ///////////////////////////////////////////////////////////////////////
 void DetectionSystemGriffin::BuildelectrodeMatElectrodes() {
 
@@ -893,9 +893,9 @@ void DetectionSystemGriffin::BuildelectrodeMatElectrodes() {
 }//end ::BuildelectrodeMatElectrodes
 
 ///////////////////////////////////////////////////////////////////////
-// ConstructDetector builds the structureMat can, cold finger shell, 
-// and liquid nitrogen tank. Since the can's face is built first, 
-// everything else is placed relative to it  
+// ConstructDetector builds the structureMat can, cold finger shell,
+// and liquid nitrogen tank. Since the can's face is built first,
+// everything else is placed relative to it
 ///////////////////////////////////////////////////////////////////////
 void DetectionSystemGriffin::ConstructDetector()  {
 
@@ -1212,11 +1212,11 @@ void DetectionSystemGriffin::ConstructDetector()  {
 }// end::ConstructDetector
 
 ///////////////////////////////////////////////////////////////////////
-// ConstructColdFinger has changed in this version!  It now 
-// incorporates all the internal details released in Nov 2004 by 
-// Eurisys. ConstructColdFinger builds the cold finger as well as the 
-// cold plate. The finger extends to the Liquid Nitrogen tank, while 
-// the plate is always the same distance from the back of the germanium  
+// ConstructColdFinger has changed in this version!  It now
+// incorporates all the internal details released in Nov 2004 by
+// Eurisys. ConstructColdFinger builds the cold finger as well as the
+// cold plate. The finger extends to the Liquid Nitrogen tank, while
+// the plate is always the same distance from the back of the germanium
 ///////////////////////////////////////////////////////////////////////
 void DetectionSystemGriffin::ConstructColdFinger() {
 
@@ -1647,8 +1647,8 @@ G4Tubs* DetectionSystemGriffin::StructureMatColdFinger() {
 
 
 ///////////////////////////////////////////////////////////////////////
-// ConstructNewSuppressorCasingWithShells builds the suppressor that 
-// surrounds the can. It tapers off at the front, and there is a thick 
+// ConstructNewSuppressorCasingWithShells builds the suppressor that
+// surrounds the can. It tapers off at the front, and there is a thick
 // piece covering the back of the can, which is divided in the middle,
 // as per the design in the specifications. Also, there is a layer
 // of structureMat that surrounds the physical pieces.
@@ -1706,9 +1706,11 @@ void DetectionSystemGriffin::ConstructNewSuppressorCasingWithShells(G4int det) {
     // the suppressor pieces themselves.  As an error checking method, the suppressor
     // pieces are given a copy number value far out of range of any useful copy number.
     if(fIncludeBackSuppressors) {
+        G4String backQuarterSuppressorShellName = "backQuarterSuppressor_" + strdet + "_log";
+
         fBackQuarterSuppressorShellLog = new G4LogicalVolume(
                 backQuarterSuppressorShell, structureMat,
-                "backQuarterSuppressorShell", 0, 0, 0);
+                backQuarterSuppressorShellName, 0, 0, 0);
 
         fBackQuarterSuppressorShellLog->SetVisAttributes(SuppressorVisAtt);
 
@@ -1718,8 +1720,10 @@ void DetectionSystemGriffin::ConstructNewSuppressorCasingWithShells(G4int det) {
             exit(1);
         }
 
+        G4String backQuarterSuppressorName = "backQuarterSuppressor_" + strdet + "_log";
+
         fBackQuarterSuppressorLog = new G4LogicalVolume(backQuarterSuppressor, backMaterial,
-                "backQuarterSuppressor", 0, 0, 0);
+                backQuarterSuppressorName, 0, 0, 0);
         fBackQuarterSuppressorLog->SetVisAttributes(backInnardsVisAtt);
 
         fSuppressorBackAssembly->AddPlacedVolume(fBackQuarterSuppressorLog, fMoveNull, fRotateNull);
@@ -1753,30 +1757,32 @@ void DetectionSystemGriffin::ConstructNewSuppressorCasingWithShells(G4int det) {
     ////////////////////////////////////////////////////////////////////////////////////////
     // now we add the side pieces of suppressor that taper off towards the front of the can
     ////////////////////////////////////////////////////////////////////////////////////////
-    G4String rightSuppressorLogName = "rightSuppressorCasing_" + strdet + "_log";
-    G4String leftSuppressorLogName = "leftSuppressorCasing_" + strdet + "_log";
+    G4String rightSuppressorShellLogName = "rightSuppressorShell_" + strdet + "_log";
+    G4String leftSuppressorShellLogName = "leftSuppressorShell_" + strdet + "_log";
+    G4String rightSuppressorCasingLogName = "rightSuppressorCasing_" + strdet + "_log";
+    G4String leftSuppressorCasingLogName = "leftSuppressorCasing_" + strdet + "_log";
 
     // Define the structureMat shell logical volume
     G4SubtractionSolid* rightSuppressorShell = ShellForFrontSlantSuppressor("right");
 
     fRightSuppressorShellLog = new G4LogicalVolume(rightSuppressorShell, structureMat,
-            "rightSuppressorShell", 0,0,0);
+            rightSuppressorShellLogName, 0,0,0);
     fRightSuppressorShellLog->SetVisAttributes(SuppressorVisAtt);
 
     G4SubtractionSolid* leftSuppressorShell = ShellForFrontSlantSuppressor("left");
 
     fLeftSuppressorShellLog = new G4LogicalVolume(leftSuppressorShell, structureMat,
-            "leftSuppressorShell", 0,0,0);
+            leftSuppressorShellLogName, 0,0,0);
     fLeftSuppressorShellLog->SetVisAttributes(SuppressorVisAtt);
 
     G4SubtractionSolid* rightSuppressor = FrontSlantSuppressor("right", false); // Right, non-chopping.
 
-    fRightSuppressorLog = new G4LogicalVolume(rightSuppressor, materialBGO, rightSuppressorLogName, 0, 0, 0);
+    fRightSuppressorLog = new G4LogicalVolume(rightSuppressor, materialBGO, rightSuppressorCasingLogName, 0, 0, 0);
     fRightSuppressorLog->SetVisAttributes(innardsVisAtt);
 
     G4SubtractionSolid* leftSuppressor = FrontSlantSuppressor("left", false); // Left, non-chopping.
 
-    fLeftSuppressorLog = new G4LogicalVolume(leftSuppressor, materialBGO, leftSuppressorLogName, 0, 0, 0);
+    fLeftSuppressorLog = new G4LogicalVolume(leftSuppressor, materialBGO, leftSuppressorCasingLogName, 0, 0, 0);
     fLeftSuppressorLog->SetVisAttributes(innardsVisAtt);
 
     fRightSuppressorCasingAssembly->AddPlacedVolume(fRightSuppressorLog, fMoveNull, fRotateNull);
@@ -2153,9 +2159,9 @@ G4UnionSolid* DetectionSystemGriffin::InterCrystalelectrodeMatFront() {
 } //end ::interCrystalelectrodeMatFront
 
 ///////////////////////////////////////////////////////////////////////
-// ConstructNewHeavyMet builds the heavy metal that goes on the front 
-// of the Suppressor. It only goes on when the extensions are in their 
-// forward position   
+// ConstructNewHeavyMet builds the heavy metal that goes on the front
+// of the Suppressor. It only goes on when the extensions are in their
+// forward position
 ///////////////////////////////////////////////////////////////////////
 void DetectionSystemGriffin::ConstructNewHeavyMet() {
     G4Material* materialHevimetal = G4Material::GetMaterial("Hevimetal");
@@ -2224,7 +2230,7 @@ G4Trap* DetectionSystemGriffin::CornerWedge() {
 
 ///////////////////////////////////////////////////////////////////////
 // The bent side pieces attach to the front faceface they angle
-// outwards, so the face is smaller than the main part of 
+// outwards, so the face is smaller than the main part of
 // the can four are needed for a square-faced detector
 ///////////////////////////////////////////////////////////////////////
 G4Para* DetectionSystemGriffin::BentSidePiece() {
@@ -3052,5 +3058,3 @@ G4SubtractionSolid* DetectionSystemGriffin::NewHeavyMet() {
 
     return hevimet;
 }//end ::newHeavyMet
-
-

--- a/src/DetectionSystemGriffin.cc
+++ b/src/DetectionSystemGriffin.cc
@@ -121,8 +121,12 @@ DetectionSystemGriffin::~DetectionSystemGriffin() {
 void DetectionSystemGriffin::Build() { 
 
     fSurfCheck = true;
+    // begin CRN 
+    G4int det = 1;
+    G4int cry = 1;
 
-    BuildOneDetector();
+    BuildOneDetector(det, cry);
+    // end CRN
 
 }//end ::Build
 
@@ -488,7 +492,7 @@ G4int DetectionSystemGriffin::PlaceDeadLayerSpecificCrystal(G4LogicalVolume* exp
 ///////////////////////////////////////////////////////////////////////
 // BuildOneDetector()
 ///////////////////////////////////////////////////////////////////////
-void DetectionSystemGriffin::BuildOneDetector() {
+void DetectionSystemGriffin::BuildOneDetector(G4int det, G4int cry) {
     // Build assembly volumes
     // Holds all pieces that are not a detector (ie. the can, nitrogen tank, cold finger, electrodes, etc.)
     fAssembly                           = new G4AssemblyVolume();
@@ -527,7 +531,7 @@ void DetectionSystemGriffin::BuildOneDetector() {
 
     // Include BGOs?
     if(fBGOSelector == 1) {
-        ConstructNewSuppressorCasingWithShells() ;
+        ConstructNewSuppressorCasingWithShells(det, cry) ;
     } else if(fBGOSelector == 0) {
         //G4cout<<"Not building BGO "<<G4endl ;
     } else {
@@ -542,7 +546,9 @@ void DetectionSystemGriffin::BuildOneDetector() {
 
 } // end BuildOneDetector()
 
-void DetectionSystemGriffin::BuildEverythingButCrystals() {
+//begin CRN 
+void DetectionSystemGriffin::BuildEverythingButCrystals(G4int det) {
+// end CRN 
     // Build assembly volumes
     fAssembly                           = new G4AssemblyVolume();
     fLeftSuppressorCasingAssembly       = new G4AssemblyVolume();
@@ -1791,7 +1797,7 @@ void DetectionSystemGriffin::ConstructNewSuppressorCasingWithShells(G4int det, G
 
     G4SubtractionSolid* leftSuppressor = FrontSlantSuppressor("left", false); // Left, non-chopping.
 
-    fLeftSuppressorLog = new G4LogicalVolume(leftSuppressor, materialBGO, leftSuppressorLogName 0, 0, 0);
+    fLeftSuppressorLog = new G4LogicalVolume(leftSuppressor, materialBGO, leftSuppressorLogName, 0, 0, 0);
     fLeftSuppressorLog->SetVisAttributes(innardsVisAtt);
     // end CRN 
 

--- a/src/DetectorConstruction.cc
+++ b/src/DetectorConstruction.cc
@@ -99,181 +99,181 @@
 
 bool operator==(const DetectorProperties& lhs, const DetectorProperties& rhs)
 {
-	return (lhs.systemID == rhs.systemID && lhs.detectorNumber == rhs.detectorNumber && lhs.crystalNumber == rhs.crystalNumber);
+    return (lhs.systemID == rhs.systemID && lhs.detectorNumber == rhs.detectorNumber && lhs.crystalNumber == rhs.crystalNumber);
 }
 
 DetectorConstruction::DetectorConstruction() :
-	fSolidWorld(nullptr),
-	fLogicWorld(nullptr),
-	fPhysiWorld(nullptr)
+    fSolidWorld(nullptr),
+    fLogicWorld(nullptr),
+    fPhysiWorld(nullptr)
 {
-	fWorldSizeX  = fWorldSizeY = fWorldSizeZ = 10.0*m;
+    fWorldSizeX  = fWorldSizeY = fWorldSizeZ = 10.0*m;
 
-	fBoxMat = "G4_WATER";
-	fBoxThickness = 0.0*mm;
-	fBoxInnerDimensions = G4ThreeVector(0.0*mm,0.0*mm,0.0*mm);
-	fBoxColour = G4ThreeVector(0.0,0.0,1.0);
+    fBoxMat = "G4_WATER";
+    fBoxThickness = 0.0*mm;
+    fBoxInnerDimensions = G4ThreeVector(0.0*mm,0.0*mm,0.0*mm);
+    fBoxColour = G4ThreeVector(0.0,0.0,1.0);
 
-	fGridMat = "G4_WATER";
-	fGridSize = 0.0*mm;
-	fGridDimensions = G4ThreeVector(0.0*mm,0.0*mm,0.0*mm);
-	fGridColour = G4ThreeVector(1.0,0.0,0.0);
+    fGridMat = "G4_WATER";
+    fGridSize = 0.0*mm;
+    fGridDimensions = G4ThreeVector(0.0*mm,0.0*mm,0.0*mm);
+    fGridColour = G4ThreeVector(1.0,0.0,0.0);
 
-	// materials
-	DefineMaterials();
+    // materials
+    DefineMaterials();
 
-	//  builtDetectors = false;
+    //  builtDetectors = false;
 
 
-	fMatWorldName = "G4_AIR";
+    fMatWorldName = "G4_AIR";
 
-	// Generic Target Apparatus
-	fSetGenericTargetMaterial   = false;
-	fSetGenericTargetDimensions = false;
-	fSetGenericTargetPosition   = false;
+    // Generic Target Apparatus
+    fSetGenericTargetMaterial   = false;
+    fSetGenericTargetDimensions = false;
+    fSetGenericTargetPosition   = false;
 
-	// Field Box
-	fSetFieldBoxMaterial= false;//think this has been removed 17/8
-	fSetFieldBoxDimensions= false;
-	fSetFieldBoxPosition= false;
-	fSetFieldBoxMagneticField= false;
+    // Field Box
+    fSetFieldBoxMaterial= false;//think this has been removed 17/8
+    fSetFieldBoxDimensions= false;
+    fSetFieldBoxPosition= false;
+    fSetFieldBoxMagneticField= false;
 
-	// parameters to suppress:
+    // parameters to suppress:
 
-	DefineSuppressedParameters();
+    DefineSuppressedParameters();
 
-	// Shield Selection Default
+    // Shield Selection Default
 
-	fUseTigressPositions = false;
+    fUseTigressPositions = false;
 
-	fDetectorShieldSelect = 1 ; // Include suppressors by default.
-	fExtensionSuppressorLocation = 0 ; // Back by default (Detector Forward)
-	fHevimetSelector = 0 ; // Chooses whether or not to include a hevimet
+    fDetectorShieldSelect = 1 ; // Include suppressors by default.
+    fExtensionSuppressorLocation = 0 ; // Back by default (Detector Forward)
+    fHevimetSelector = 0 ; // Chooses whether or not to include a hevimet
 
-	fCustomDetectorNumber 		= 1 ; // detNum
-	fCustomDetectorPosition  = 1 ; // posNum
+    fCustomDetectorNumber       = 1 ; // detNum
+    fCustomDetectorPosition  = 1 ; // posNum
 
-	// create commands for interactive definition
+    // create commands for interactive definition
 
-	fDetectorMessenger = new DetectorMessenger(this);
+    fDetectorMessenger = new DetectorMessenger(this);
 
-	// ensure the global field is initialized
-	//(void)GlobalField::getObject();
+    // ensure the global field is initialized
+    //(void)GlobalField::getObject();
 
-	//expHallMagField = new MagneticField(); // Global field is set to zero
+    //expHallMagField = new MagneticField(); // Global field is set to zero
 
-	fGriffinDetectorsMapIndex = 0;
-	for(G4int i = 0; i < 16; ++i) {
-		fGriffinDetectorsMap[i] = 0;
-		for(G4int j = 0; j < 4; ++j) {
-			fGriffinDeadLayer[i][j] = -1;
-		}
-	}
+    fGriffinDetectorsMapIndex = 0;
+    for(G4int i = 0; i < 16; ++i) {
+        fGriffinDetectorsMap[i] = 0;
+        for(G4int j = 0; j < 4; ++j) {
+            fGriffinDeadLayer[i][j] = -1;
+        }
+    }
 
-	fDescantColor = "white";
-	fDescantRotation.setX(M_PI);
-	fDescantRotation.setY(0.);
-	fDescantRotation.setZ(0.);
+    fDescantColor = "white";
+    fDescantRotation.setX(M_PI);
+    fDescantRotation.setY(0.);
+    fDescantRotation.setZ(0.);
 
-	fApparatusLayeredTarget=0;
+    fApparatusLayeredTarget=0;
 
-	fGridCell = false;
-	fGriffin  = false;
-	fLaBr     = false;
-	fAncBgo   = false;
-	fNaI      = false;
-	fSceptar  = false;
-	fEightPi  = false;
-	fSpice    = false;
-	fPaces    = false;
-	fDescant  = false;
-	fTestcan  = false;
-    
+    fGridCell = false;
+    fGriffin  = false;
+    fLaBr     = false;
+    fAncBgo   = false;
+    fNaI      = false;
+    fSceptar  = false;
+    fEightPi  = false;
+    fSpice    = false;
+    fPaces    = false;
+    fDescant  = false;
+    fTestcan  = false;
+
     fRecordGun = false;
-    
+
     fTrifWindowThickness=6*um;
     fTrifDegraderThickness=0;
-	fTrifDegraderMat="G4_Al";
+    fTrifDegraderMat="G4_Al";
     fTrifAluminised=true;  
     fTrifFlatWindow=false;  
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
-DetectorConstruction::~DetectorConstruction() {	
-	delete fDetectorMessenger;
+DetectorConstruction::~DetectorConstruction() { 
+    delete fDetectorMessenger;
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
 G4VPhysicalVolume* DetectorConstruction::Construct() {
 
-	// Replaced by ConstructDetectionSystems
+    // Replaced by ConstructDetectionSystems
 
-	// Experimental hall (world volume)
-	// search the world material by its name
+    // Experimental hall (world volume)
+    // search the world material by its name
 
-	G4GeometryManager::GetInstance()->OpenGeometry();
-	G4PhysicalVolumeStore::GetInstance()->Clean();
-	G4LogicalVolumeStore::GetInstance()->Clean();
-	G4SolidStore::GetInstance()->Clean();
+    G4GeometryManager::GetInstance()->OpenGeometry();
+    G4PhysicalVolumeStore::GetInstance()->Clean();
+    G4LogicalVolumeStore::GetInstance()->Clean();
+    G4SolidStore::GetInstance()->Clean();
 
-	G4Material* matWorld = G4Material::GetMaterial(fMatWorldName);
+    G4Material* matWorld = G4Material::GetMaterial(fMatWorldName);
 
-	if(!matWorld) {
-		G4cout<<" ----> Material "<<fMatWorldName<<" not found, cannot build world! "<<G4endl;
-		return 0;
-	}
+    if(!matWorld) {
+        G4cout<<" ----> Material "<<fMatWorldName<<" not found, cannot build world! "<<G4endl;
+        return 0;
+    }
 
-	fSolidWorld = new G4Box("World", fWorldSizeX/2,fWorldSizeY/2,fWorldSizeZ/2);
+    fSolidWorld = new G4Box("World", fWorldSizeX/2,fWorldSizeY/2,fWorldSizeZ/2);
 
-	fLogicWorld = new G4LogicalVolume(fSolidWorld,		//its solid
-			matWorld,	//its material
-			"World");		//its name
+    fLogicWorld = new G4LogicalVolume(fSolidWorld,      //its solid
+            matWorld,   //its material
+            "World");       //its name
 
-	fPhysiWorld = new G4PVPlacement(0,                  //no rotation
-			G4ThreeVector(),	//at (0,0,0)
-			fLogicWorld,         //its logical volume
-			"World",            //its name
-			0,                  //its mother  volume
-			false,              //no boolean operation
-			0);                 //copy number
+    fPhysiWorld = new G4PVPlacement(0,                  //no rotation
+            G4ThreeVector(),    //at (0,0,0)
+            fLogicWorld,         //its logical volume
+            "World",            //its name
+            0,                  //its mother  volume
+            false,              //no boolean operation
+            0);                 //copy number
 
-	// Visualization Attributes
+    // Visualization Attributes
 
-	fLogicWorld->SetVisAttributes (G4VisAttributes::Invisible); // The following block of code works too.
+    fLogicWorld->SetVisAttributes (G4VisAttributes::Invisible); // The following block of code works too.
 
-	//  G4VisAttributes* worldVisAtt = new G4VisAttributes(G4Colour(0.0,1.0,1.0));
-	//  worldVisAtt->SetForceWireframe(true);
-	//  worldVisAtt->SetVisibility(worldVis);
-	//  fLogicWorld->SetVisAttributes(worldVisAtt);
-	//  fLogicWorld = fLogicWorld;
+    //  G4VisAttributes* worldVisAtt = new G4VisAttributes(G4Colour(0.0,1.0,1.0));
+    //  worldVisAtt->SetForceWireframe(true);
+    //  worldVisAtt->SetVisibility(worldVis);
+    //  fLogicWorld->SetVisAttributes(worldVisAtt);
+    //  fLogicWorld = fLogicWorld;
 
-	return fPhysiWorld;
+    return fPhysiWorld;
 }
 
 void DetectorConstruction::SetWorldMaterial(G4String name) {
-	fMatWorldName = name;
-	UpdateGeometry(); // auto update
+    fMatWorldName = name;
+    UpdateGeometry(); // auto update
 }
 
 void DetectorConstruction::SetWorldDimensions(G4ThreeVector vec) {
-	fWorldSizeX = vec.x() ;
-	fWorldSizeY = vec.y() ;
-	fWorldSizeZ = vec.z() ;
-	UpdateGeometry(); // auto update
+    fWorldSizeX = vec.x() ;
+    fWorldSizeY = vec.y() ;
+    fWorldSizeZ = vec.z() ;
+    UpdateGeometry(); // auto update
 }
 
 void DetectorConstruction::SetWorldVis(G4bool vis) {
-	fWorldVis = vis;
-	UpdateGeometry(); // auto update
+    fWorldVis = vis;
+    UpdateGeometry(); // auto update
 }
 
 void DetectorConstruction::SetWorldStepLimit(G4double step) {
-	if(fLogicWorld == nullptr) {
-		Construct();
-	}
-	fLogicWorld->SetUserLimits(new G4UserLimits(step));
+    if(fLogicWorld == nullptr) {
+        Construct();
+    }
+    fLogicWorld->SetUserLimits(new G4UserLimits(step));
 }
 
 //void DetectorConstruction::SetWorldMagneticField(G4ThreeVector vec)
@@ -282,975 +282,1005 @@ void DetectorConstruction::SetWorldStepLimit(G4double step) {
 //}
 void DetectorConstruction::LayeredTargetAdd(G4String Material, G4double Areal)
 {
-	if(!fApparatusLayeredTarget)fApparatusLayeredTarget=new ApparatusLayeredTarget(fDetEffPosition.z());
-	if(fApparatusLayeredTarget->BuildTargetLayer(Material,Areal)){
-		if(fLogicWorld == nullptr) {
-			Construct();
-		}  
-		fApparatusLayeredTarget->PlaceTarget(fLogicWorld);
-	}
+    if(!fApparatusLayeredTarget)fApparatusLayeredTarget=new ApparatusLayeredTarget(fDetEffPosition.z());
+    if(fApparatusLayeredTarget->BuildTargetLayer(Material,Areal)){
+        if(fLogicWorld == nullptr) {
+            Construct();
+        }  
+        fApparatusLayeredTarget->PlaceTarget(fLogicWorld);
+    }
 }
 
 
 void DetectorConstruction::SetTabMagneticField(G4String PathAndTableName, G4double z_offset, G4double z_rotation)
 {
-	//const char * c = PathAndTableName.c_str();///conversion attempt using .c_str() (a string member function)
-	new NonUniformMagneticField(PathAndTableName,z_offset,z_rotation);///addition of field for SPICE
+    //const char * c = PathAndTableName.c_str();///conversion attempt using .c_str() (a string member function)
+    new NonUniformMagneticField(PathAndTableName,z_offset,z_rotation);///addition of field for SPICE
 }
 
 void DetectorConstruction::UpdateGeometry() {
-	G4RunManager::GetRunManager()->DefineWorldVolume(Construct());
+    G4RunManager::GetRunManager()->DefineWorldVolume(Construct());
 }
 
 void DetectorConstruction::SetGenericTargetMaterial(G4String name)
 {
-	DetectorConstruction::fSetGenericTargetMaterial = true;
-	DetectorConstruction::fGenericTargetMaterial = name;
-	DetectorConstruction::SetGenericTarget();
+    DetectorConstruction::fSetGenericTargetMaterial = true;
+    DetectorConstruction::fGenericTargetMaterial = name;
+    DetectorConstruction::SetGenericTarget();
 }
 
 void DetectorConstruction::SetGenericTargetDimensions(G4ThreeVector vec)
 {
-	DetectorConstruction::fSetGenericTargetDimensions = true;
-	DetectorConstruction::fGenericTargetDimensions = vec;
-	DetectorConstruction::SetGenericTarget();
+    DetectorConstruction::fSetGenericTargetDimensions = true;
+    DetectorConstruction::fGenericTargetDimensions = vec;
+    DetectorConstruction::SetGenericTarget();
 }
 
 void DetectorConstruction::SetGenericTargetPosition(G4ThreeVector vec)
 {
-	DetectorConstruction::fSetGenericTargetPosition = true;
-	DetectorConstruction::fGenericTargetPosition = vec;
-	DetectorConstruction::SetGenericTarget();
+    DetectorConstruction::fSetGenericTargetPosition = true;
+    DetectorConstruction::fGenericTargetPosition = vec;
+    DetectorConstruction::SetGenericTarget();
 }
 
 void DetectorConstruction::SetGenericTarget()
 {
-	if(fSetGenericTargetMaterial) {
-		if(fSetGenericTargetDimensions) {
-			if(fSetGenericTargetPosition) {
-				G4String name = fGenericTargetMaterial;
-				G4double vecX = fGenericTargetDimensions.x()/mm;
-				G4double vecY = fGenericTargetDimensions.y()/mm;
-				G4double vecZ = fGenericTargetDimensions.z()/mm;
+    if(fSetGenericTargetMaterial) {
+        if(fSetGenericTargetDimensions) {
+            if(fSetGenericTargetPosition) {
+                G4String name = fGenericTargetMaterial;
+                G4double vecX = fGenericTargetDimensions.x()/mm;
+                G4double vecY = fGenericTargetDimensions.y()/mm;
+                G4double vecZ = fGenericTargetDimensions.z()/mm;
 
-				ApparatusGenericTarget* pApparatusGenericTarget = new ApparatusGenericTarget();
-				pApparatusGenericTarget->Build(name, vecX, vecY, vecZ);
-				G4RotationMatrix* rotate = new G4RotationMatrix;
-				pApparatusGenericTarget->PlaceApparatus(fLogicWorld, fGenericTargetPosition, rotate);
-			}
-		}
-	}
+                ApparatusGenericTarget* pApparatusGenericTarget = new ApparatusGenericTarget();
+                pApparatusGenericTarget->Build(name, vecX, vecY, vecZ);
+                G4RotationMatrix* rotate = new G4RotationMatrix;
+                pApparatusGenericTarget->PlaceApparatus(fLogicWorld, fGenericTargetPosition, rotate);
+            }
+        }
+    }
 }
 
 
 G4double DetectorConstruction::LayeredTargetLayerStart(int layer){
-	if(fApparatusLayeredTarget){
-		return fApparatusLayeredTarget->LayerStart(layer);
-	}
-	return fDetEffPosition.z();
+    if(fApparatusLayeredTarget){
+        return fApparatusLayeredTarget->LayerStart(layer);
+    }
+    return fDetEffPosition.z();
 }
 
 
 void DetectorConstruction::AddGrid() {
-	if(fLogicWorld == nullptr) {
-		Construct();
-	}
+    if(fLogicWorld == nullptr) {
+        Construct();
+    }
 
-	if(fGridSize != 0.0*mm)
-	{
-		DetectionSystemGrid* pGrid = new DetectionSystemGrid(	fGridDimensions.x(),
-				fGridDimensions.y(),
-				fGridDimensions.z(),
-				fGridSize,
-				fGridMat,
-				fGridColour,
-				fGridOffset) ;
-		pGrid->Build();
-		pGrid->PlaceDetector(fLogicWorld);
-	}
+    if(fGridSize != 0.0*mm)
+    {
+        DetectionSystemGrid* pGrid = new DetectionSystemGrid(   fGridDimensions.x(),
+                fGridDimensions.y(),
+                fGridDimensions.z(),
+                fGridSize,
+                fGridMat,
+                fGridColour,
+                fGridOffset) ;
+        pGrid->Build();
+        pGrid->PlaceDetector(fLogicWorld);
+    }
 }
 
 void DetectorConstruction::AddApparatusSpiceTargetChamber(G4String Options)//parameter sets lens for SPICE - should be matched with field
 {
-	//Create Target Chamber
-	ApparatusSpiceTargetChamber* fApparatusSpiceTargetChamber = new ApparatusSpiceTargetChamber(Options);
-	fApparatusSpiceTargetChamber->Build(fLogicWorld);
+    //Create Target Chamber
+    ApparatusSpiceTargetChamber* fApparatusSpiceTargetChamber = new ApparatusSpiceTargetChamber(Options);
+    fApparatusSpiceTargetChamber->Build(fLogicWorld);
 }
 
 void DetectorConstruction::AddApparatus8piVacuumChamber() {
-	//Create Vacuum Chamber
-	if(fLogicWorld == nullptr) {
-		Construct();
-	}
+    //Create Vacuum Chamber
+    if(fLogicWorld == nullptr) {
+        Construct();
+    }
 
-	Apparatus8piVacuumChamber* pApparatus8piVacuumChamber = new Apparatus8piVacuumChamber();
-	pApparatus8piVacuumChamber->Build(fLogicWorld);
+    Apparatus8piVacuumChamber* pApparatus8piVacuumChamber = new Apparatus8piVacuumChamber();
+    pApparatus8piVacuumChamber->Build(fLogicWorld);
 }
 
 void DetectorConstruction::AddApparatus8piVacuumChamberAuxMatShell(G4double thickness) {
-	//Create Shell Around Vacuum Chamber
-	if(fLogicWorld == nullptr) {
-		Construct();
-	}
+    //Create Shell Around Vacuum Chamber
+    if(fLogicWorld == nullptr) {
+        Construct();
+    }
 
-	Apparatus8piVacuumChamberAuxMatShell* pApparatus8piVacuumChamberAuxMatShell = new Apparatus8piVacuumChamberAuxMatShell();
-	pApparatus8piVacuumChamberAuxMatShell->Build(fLogicWorld, thickness);
+    Apparatus8piVacuumChamberAuxMatShell* pApparatus8piVacuumChamberAuxMatShell = new Apparatus8piVacuumChamberAuxMatShell();
+    pApparatus8piVacuumChamberAuxMatShell->Build(fLogicWorld, thickness);
 }
 
 void DetectorConstruction::AddApparatusGriffinStructure(G4int selector) {
-	//Create Shell Around Vacuum Chamber
-	if(fLogicWorld == nullptr) {
-		Construct();
-	}
+    //Create Shell Around Vacuum Chamber
+    if(fLogicWorld == nullptr) {
+        Construct();
+    }
 
-	ApparatusGriffinStructure* pApparatusGriffinStructure = new ApparatusGriffinStructure();
-	pApparatusGriffinStructure->Build();
+    ApparatusGriffinStructure* pApparatusGriffinStructure = new ApparatusGriffinStructure();
+    pApparatusGriffinStructure->Build();
 
-	pApparatusGriffinStructure->Place(fLogicWorld, selector);
+    pApparatusGriffinStructure->Place(fLogicWorld, selector);
 }
 
 
 void DetectorConstruction::AddDetectionSystemSodiumIodide(G4int ndet) {
-	if(fLogicWorld == nullptr) {
-		Construct();
-	}
+    if(fLogicWorld == nullptr) {
+        Construct();
+    }
 
-	// Describe Placement
-	G4double detectorAngles[8][2] = {{}};
-	G4double theta,phi,position;
-	G4ThreeVector move,direction;
+    // Describe Placement
+    G4double detectorAngles[8][2] = {{}};
+    G4double theta,phi,position;
+    G4ThreeVector move,direction;
 
-	detectorAngles[0][0] 	= 0.0;
-	detectorAngles[1][0] 	= 45.0;
-	detectorAngles[2][0] 	= 90.0;
-	detectorAngles[3][0] 	= 135.0;
-	detectorAngles[4][0] 	= 180.0;
-	detectorAngles[5][0] 	= 225.0;
-	detectorAngles[6][0] 	= 270.0;
-	detectorAngles[7][0] 	= 315.0;
-	detectorAngles[0][1] 	= 90.0;
-	detectorAngles[1][1] 	= 90.0;
-	detectorAngles[2][1] 	= 90.0;
-	detectorAngles[3][1] 	= 90.0;
-	detectorAngles[4][1] 	= 90.0;
-	detectorAngles[5][1] 	= 90.0;
-	detectorAngles[6][1] 	= 90.0;
-	detectorAngles[7][1] 	= 90.0;
+    detectorAngles[0][0]    = 0.0;
+    detectorAngles[1][0]    = 45.0;
+    detectorAngles[2][0]    = 90.0;
+    detectorAngles[3][0]    = 135.0;
+    detectorAngles[4][0]    = 180.0;
+    detectorAngles[5][0]    = 225.0;
+    detectorAngles[6][0]    = 270.0;
+    detectorAngles[7][0]    = 315.0;
+    detectorAngles[0][1]    = 90.0;
+    detectorAngles[1][1]    = 90.0;
+    detectorAngles[2][1]    = 90.0;
+    detectorAngles[3][1]    = 90.0;
+    detectorAngles[4][1]    = 90.0;
+    detectorAngles[5][1]    = 90.0;
+    detectorAngles[6][1]    = 90.0;
+    detectorAngles[7][1]    = 90.0;
 
-	DetectionSystemSodiumIodide* pSodiumIodide = new DetectionSystemSodiumIodide() ;
-	pSodiumIodide->Build() ;
+    DetectionSystemSodiumIodide* pSodiumIodide = new DetectionSystemSodiumIodide() ;
+    pSodiumIodide->Build() ;
 
-	for(G4int detectorNumber = 0; detectorNumber < ndet; detectorNumber++)
-	{
-		phi = detectorAngles[detectorNumber][0]*deg; // Creates a ring in phi plane
-		theta = detectorAngles[detectorNumber][1]*deg;
+    for(G4int detectorNumber = 0; detectorNumber < ndet; detectorNumber++)
+    {
+        phi = detectorAngles[detectorNumber][0]*deg; // Creates a ring in phi plane
+        theta = detectorAngles[detectorNumber][1]*deg;
 
-		direction = G4ThreeVector(sin(theta)*cos(phi),sin(theta)*sin(phi),cos(theta));
-		position = 25.0*cm + (pSodiumIodide->GetDetectorLengthOfUnitsCM()/2.0);
-		move = position * direction;
+        direction = G4ThreeVector(sin(theta)*cos(phi),sin(theta)*sin(phi),cos(theta));
+        position = 25.0*cm + (pSodiumIodide->GetDetectorLengthOfUnitsCM()/2.0);
+        move = position * direction;
 
-		G4RotationMatrix* rotate = new G4RotationMatrix; 		//rotation matrix corresponding to direction vector
-		rotate->rotateX(theta);
-		rotate->rotateY(0);
-		rotate->rotateZ(phi+0.5*M_PI);
+        G4RotationMatrix* rotate = new G4RotationMatrix;        //rotation matrix corresponding to direction vector
+        rotate->rotateX(theta);
+        rotate->rotateY(0);
+        rotate->rotateZ(phi+0.5*M_PI);
 
-		pSodiumIodide->PlaceDetector(fLogicWorld, move, rotate, detectorNumber) ;
-	}
-	fNaI = true;
+        pSodiumIodide->PlaceDetector(fLogicWorld, move, rotate, detectorNumber) ;
+    }
+    fNaI = true;
 }
 
 void DetectorConstruction::AddDetectionSystemLanthanumBromide(G4ThreeVector input) {
-	if(fLogicWorld == nullptr) {
-		Construct();
-	}
+    if(fLogicWorld == nullptr) {
+        Construct();
+    }
 
-	G4int ndet = G4int(input.x());
-	G4double radialpos = input.y()*cm;
+    G4int ndet = G4int(input.x());
+    G4double radialpos = input.y()*cm;
 
-	DetectionSystemLanthanumBromide* pDetectionSystemLanthanumBromide = new DetectionSystemLanthanumBromide();
-	pDetectionSystemLanthanumBromide->Build();
+    DetectionSystemLanthanumBromide* pDetectionSystemLanthanumBromide = new DetectionSystemLanthanumBromide();
+    pDetectionSystemLanthanumBromide->Build();
 
-	for(G4int detectorNumber = 0; detectorNumber < ndet; detectorNumber++)
-	{
-		pDetectionSystemLanthanumBromide->PlaceDetector(fLogicWorld, detectorNumber, radialpos);
-	}
-	fLaBr = true;
+    for(G4int detectorNumber = 0; detectorNumber < ndet; detectorNumber++)
+    {
+        pDetectionSystemLanthanumBromide->PlaceDetector(fLogicWorld, detectorNumber, radialpos);
+    }
+    fLaBr = true;
 }
 
 void DetectorConstruction::AddDetectionSystemAncillaryBGO(G4ThreeVector input) {
-	if(fLogicWorld == nullptr) {
-		Construct();
-	}
+    if(fLogicWorld == nullptr) {
+        Construct();
+    }
 
-	G4int ndet = G4int(input.x());
-	G4double radialpos = input.y()*cm;
-	G4int hevimetopt = G4int(input.z());
+    G4int ndet = G4int(input.x());
+    G4double radialpos = input.y()*cm;
+    G4int hevimetopt = G4int(input.z());
 
-	DetectionSystemAncillaryBGO* pDetectionSystemAncillaryBGO = new DetectionSystemAncillaryBGO();
-	pDetectionSystemAncillaryBGO->Build();
+    DetectionSystemAncillaryBGO* pDetectionSystemAncillaryBGO = new DetectionSystemAncillaryBGO();
+    pDetectionSystemAncillaryBGO->Build();
 
-	for(G4int detectorNumber = 0; detectorNumber < ndet; detectorNumber++) {
-		pDetectionSystemAncillaryBGO->PlaceDetector(fLogicWorld, detectorNumber, radialpos, hevimetopt);
-	}
-	fAncBgo = true;
+    for(G4int detectorNumber = 0; detectorNumber < ndet; detectorNumber++) {
+        pDetectionSystemAncillaryBGO->PlaceDetector(fLogicWorld, detectorNumber, radialpos, hevimetopt);
+    }
+    fAncBgo = true;
 }
 
 
 
 G4double DetectorConstruction::GetLanthanumBromideCrystalRadius() {
-	DetectionSystemLanthanumBromide* pDetectionSystemLanthanumBromide = new DetectionSystemLanthanumBromide();
-	G4double out = pDetectionSystemLanthanumBromide->GetCrystalRadius();
-	return out;
+    DetectionSystemLanthanumBromide* pDetectionSystemLanthanumBromide = new DetectionSystemLanthanumBromide();
+    G4double out = pDetectionSystemLanthanumBromide->GetCrystalRadius();
+    return out;
 }
 
 G4double DetectorConstruction::GetLanthanumBromideCrystalLength() {
-	DetectionSystemLanthanumBromide* pDetectionSystemLanthanumBromide = new DetectionSystemLanthanumBromide();
-	G4double out = pDetectionSystemLanthanumBromide->GetCrystalLength();
-	return out;
+    DetectionSystemLanthanumBromide* pDetectionSystemLanthanumBromide = new DetectionSystemLanthanumBromide();
+    G4double out = pDetectionSystemLanthanumBromide->GetCrystalLength();
+    return out;
 }
 
 G4double DetectorConstruction::GetLanthanumBromideR() {
-	DetectionSystemLanthanumBromide* pDetectionSystemLanthanumBromide = new DetectionSystemLanthanumBromide();
-	G4double out = pDetectionSystemLanthanumBromide->GetR();
-	return out;
+    DetectionSystemLanthanumBromide* pDetectionSystemLanthanumBromide = new DetectionSystemLanthanumBromide();
+    G4double out = pDetectionSystemLanthanumBromide->GetR();
+    return out;
 }
 
 G4double DetectorConstruction::GetLanthanumBromideTheta(G4int i) {
-	DetectionSystemLanthanumBromide* pDetectionSystemLanthanumBromide = new DetectionSystemLanthanumBromide();
-	G4double out = pDetectionSystemLanthanumBromide->GetTheta(i);
-	return out;
+    DetectionSystemLanthanumBromide* pDetectionSystemLanthanumBromide = new DetectionSystemLanthanumBromide();
+    G4double out = pDetectionSystemLanthanumBromide->GetTheta(i);
+    return out;
 }
 
 G4double DetectorConstruction::GetLanthanumBromidePhi(G4int i) {
-	DetectionSystemLanthanumBromide* pDetectionSystemLanthanumBromide = new DetectionSystemLanthanumBromide();
-	G4double out = pDetectionSystemLanthanumBromide->GetPhi(i);
-	return out;
+    DetectionSystemLanthanumBromide* pDetectionSystemLanthanumBromide = new DetectionSystemLanthanumBromide();
+    G4double out = pDetectionSystemLanthanumBromide->GetPhi(i);
+    return out;
 }
 G4double DetectorConstruction::GetLanthanumBromideYaw(G4int i) {
-	DetectionSystemLanthanumBromide* pDetectionSystemLanthanumBromide = new DetectionSystemLanthanumBromide();
-	G4double out = pDetectionSystemLanthanumBromide->GetYaw(i);
-	return out;
+    DetectionSystemLanthanumBromide* pDetectionSystemLanthanumBromide = new DetectionSystemLanthanumBromide();
+    G4double out = pDetectionSystemLanthanumBromide->GetYaw(i);
+    return out;
 }
 
 G4double DetectorConstruction::GetLanthanumBromidePitch(G4int i) {
-	DetectionSystemLanthanumBromide* pDetectionSystemLanthanumBromide = new DetectionSystemLanthanumBromide();
-	G4double out = pDetectionSystemLanthanumBromide->GetPitch(i);
-	return out;
+    DetectionSystemLanthanumBromide* pDetectionSystemLanthanumBromide = new DetectionSystemLanthanumBromide();
+    G4double out = pDetectionSystemLanthanumBromide->GetPitch(i);
+    return out;
 }
 
 G4double DetectorConstruction::GetLanthanumBromideRoll(G4int i) {
-	DetectionSystemLanthanumBromide* pDetectionSystemLanthanumBromide = new DetectionSystemLanthanumBromide();
-	G4double out = pDetectionSystemLanthanumBromide->GetRoll(i);
-	return out;
+    DetectionSystemLanthanumBromide* pDetectionSystemLanthanumBromide = new DetectionSystemLanthanumBromide();
+    G4double out = pDetectionSystemLanthanumBromide->GetRoll(i);
+    return out;
 }
 
 G4double DetectorConstruction::GetLanthanumBromideCrystalRadialPosition() {
-	DetectionSystemLanthanumBromide* pDetectionSystemLanthanumBromide = new DetectionSystemLanthanumBromide();
-	G4double out = pDetectionSystemLanthanumBromide->GetCrystalRadialPosition();
-	return out;
+    DetectionSystemLanthanumBromide* pDetectionSystemLanthanumBromide = new DetectionSystemLanthanumBromide();
+    G4double out = pDetectionSystemLanthanumBromide->GetCrystalRadialPosition();
+    return out;
 }
 
 
 // Temporary Function for testing purposes
 void DetectorConstruction::AddDetectionSystemGriffinCustomDetector(G4int) {
-	if(fLogicWorld == nullptr) {
-		Construct();
-	}
+    if(fLogicWorld == nullptr) {
+        Construct();
+    }
 
-	fGriffinDetectorsMap[fGriffinDetectorsMapIndex] = fCustomDetectorNumber ;
-	fGriffinDetectorsMapIndex++;
+    fGriffinDetectorsMap[fGriffinDetectorsMapIndex] = fCustomDetectorNumber ;
+    fGriffinDetectorsMapIndex++;
 
-	// NOTE: ndet served no purpose in this case but I left it in just in case this needs to be modified later. The position of a detector placed using this function must be set using
-	// SetDeadLayer.
+    // NOTE: ndet served no purpose in this case but I left it in just in case this needs to be modified later. The position of a detector placed using this function must be set using
+    // SetDeadLayer.
 
-	DetectionSystemGriffin* pGriffinCustom = new DetectionSystemGriffin(fExtensionSuppressorLocation, fDetectorShieldSelect, fDetectorRadialDistance, fHevimetSelector); // Select Forward (0) or Back (1)
+    DetectionSystemGriffin* pGriffinCustom = new DetectionSystemGriffin(fExtensionSuppressorLocation, fDetectorShieldSelect, fDetectorRadialDistance, fHevimetSelector); // Select Forward (0) or Back (1)
 
-	// check for each crystal if a custom dead layer has been specified
-	for(G4int crystal = 0; crystal < 4; ++crystal) {
-		if(fGriffinDeadLayer[fCustomDetectorNumber-1][crystal] >= 0.) {
-			pGriffinCustom->SetDeadLayer(fCustomDetectorNumber-1, crystal, fGriffinDeadLayer[fCustomDetectorNumber-1][crystal]);
-		}
-	}
+    // check for each crystal if a custom dead layer has been specified
+    for(G4int crystal = 0; crystal < 4; ++crystal) {
+        if(fGriffinDeadLayer[fCustomDetectorNumber-1][crystal] >= 0.) {
+            pGriffinCustom->SetDeadLayer(fCustomDetectorNumber-1, crystal, fGriffinDeadLayer[fCustomDetectorNumber-1][crystal]);
+        }
+    }
 
-	pGriffinCustom->BuildDeadLayerSpecificCrystal(fCustomDetectorNumber-1);
+    pGriffinCustom->BuildDeadLayerSpecificCrystal(fCustomDetectorNumber-1);
 
-	pGriffinCustom->PlaceDeadLayerSpecificCrystal(fLogicWorld, fCustomDetectorNumber-1, fCustomDetectorPosition-1, fUseTigressPositions);
+    pGriffinCustom->PlaceDeadLayerSpecificCrystal(fLogicWorld, fCustomDetectorNumber-1, fCustomDetectorPosition-1, fUseTigressPositions);
 
     // begin CRN 
-	pGriffinCustom->BuildEverythingButCrystals(fCustomDetectorNumber-1);
+    pGriffinCustom->BuildEverythingButCrystals(fCustomDetectorNumber-1);
     // end CRN
 
-	pGriffinCustom->PlaceEverythingButCrystals(fLogicWorld, fCustomDetectorNumber-1, fCustomDetectorPosition-1, fUseTigressPositions);
+    pGriffinCustom->PlaceEverythingButCrystals(fLogicWorld, fCustomDetectorNumber-1, fCustomDetectorPosition-1, fUseTigressPositions);
 
-	fGriffin = true;
+    fGriffin = true;
 }
 
 void DetectorConstruction::AddDetectionSystemGriffinCustom(G4int ndet) {
-	if(fLogicWorld == nullptr) {
-		Construct();
-	}
+    if(fLogicWorld == nullptr) {
+        Construct();
+    }
 
-	G4int detNum;
-	G4int posNum;
+    G4int detNum;
+    G4int posNum;
 
-	for(detNum = 1; detNum <= ndet; detNum++) {
-		posNum = detNum;
+    for(detNum = 1; detNum <= ndet; detNum++) {
+        posNum = detNum;
 
-		fGriffinDetectorsMap[fGriffinDetectorsMapIndex] = detNum;
-		fGriffinDetectorsMapIndex++;
+        fGriffinDetectorsMap[fGriffinDetectorsMapIndex] = detNum;
+        fGriffinDetectorsMapIndex++;
 
-		DetectionSystemGriffin* pGriffinCustom = new DetectionSystemGriffin(fExtensionSuppressorLocation, fDetectorShieldSelect, fDetectorRadialDistance, fHevimetSelector) ; // Select Forward (0) or Back (1)
+        DetectionSystemGriffin* pGriffinCustom = new DetectionSystemGriffin(fExtensionSuppressorLocation, fDetectorShieldSelect, fDetectorRadialDistance, fHevimetSelector) ; // Select Forward (0) or Back (1)
 
-		pGriffinCustom->BuildDeadLayerSpecificCrystal(detNum-1);
-		pGriffinCustom->PlaceDeadLayerSpecificCrystal(fLogicWorld, detNum-1, posNum-1, fUseTigressPositions) ;
+        pGriffinCustom->BuildDeadLayerSpecificCrystal(detNum-1);
+        pGriffinCustom->PlaceDeadLayerSpecificCrystal(fLogicWorld, detNum-1, posNum-1, fUseTigressPositions) ;
         //begin CRN 
-		pGriffinCustom->BuildEverythingButCrystals(detNum-1);
+        pGriffinCustom->BuildEverythingButCrystals(detNum-1);
         // end CRN
-		pGriffinCustom->PlaceEverythingButCrystals(fLogicWorld, detNum-1, posNum-1, fUseTigressPositions) ;
+        pGriffinCustom->PlaceEverythingButCrystals(fLogicWorld, detNum-1, posNum-1, fUseTigressPositions) ;
 
-	}
+    }
 
-	fGriffin = true;
+    fGriffin = true;
 }
 
 void DetectorConstruction::AddDetectionSystemGriffinShieldSelect(G4int ShieldSelect){
-	fDetectorShieldSelect = ShieldSelect ;
+    fDetectorShieldSelect = ShieldSelect ;
 }
 
 void DetectorConstruction::AddDetectionSystemGriffinSetRadialDistance(G4double detectorDist){
-	fDetectorRadialDistance = detectorDist ;
+    fDetectorRadialDistance = detectorDist ;
 }
 
 void DetectorConstruction::AddDetectionSystemGriffinSetExtensionSuppLocation(G4int detectorPos){
-	fExtensionSuppressorLocation = detectorPos ;
+    fExtensionSuppressorLocation = detectorPos ;
 }
 
 void DetectorConstruction::AddDetectionSystemGriffinSetPosition(G4ThreeVector params) {
-	G4int detNum = static_cast<G4int>(params.x());
-	G4int detPos = static_cast<G4int>(params.y());
-	if(detNum < 1 || detNum > 16 || detPos < 1 || detPos > 16) {
-		G4cout<<"Warning, can't set detector "<<detNum<<" to position "<<detPos<<", indices out of range!"<<G4endl;
-		return;
-	}
-	fCustomDetectorNumber    = detNum;
-	fCustomDetectorPosition  = detPos;
+    G4int detNum = static_cast<G4int>(params.x());
+    G4int detPos = static_cast<G4int>(params.y());
+    if(detNum < 1 || detNum > 16 || detPos < 1 || detPos > 16) {
+        G4cout<<"Warning, can't set detector "<<detNum<<" to position "<<detPos<<", indices out of range!"<<G4endl;
+        return;
+    }
+    fCustomDetectorNumber    = detNum;
+    fCustomDetectorPosition  = detPos;
 }
 
 void DetectorConstruction::AddDetectionSystemGriffinSetDeadLayer(G4ThreeVector params) {
-	/// x = detector number, y = crystal number, z = dead layer thickness
-	G4int detNum = static_cast<G4int>(params.x());
-	G4int cryNum = static_cast<G4int>(params.y());
-	if(detNum < 0 || detNum > 15 || cryNum < 0 || cryNum > 3) {
-		G4cout<<"Warning, can't set dead layer for detector "<<detNum<<", crystal "<<cryNum<<", indices out of range!"<<G4endl;
-		return;
-	}
-	fGriffinDeadLayer[detNum][cryNum] = params.z();
+    /// x = detector number, y = crystal number, z = dead layer thickness
+    G4int detNum = static_cast<G4int>(params.x());
+    G4int cryNum = static_cast<G4int>(params.y());
+    if(detNum < 0 || detNum > 15 || cryNum < 0 || cryNum > 3) {
+        G4cout<<"Warning, can't set dead layer for detector "<<detNum<<", crystal "<<cryNum<<", indices out of range!"<<G4endl;
+        return;
+    }
+    fGriffinDeadLayer[detNum][cryNum] = params.z();
 }
 
 void DetectorConstruction::AddDetectionSystemGriffinForward(G4int ndet) {
-	if(fLogicWorld == nullptr) {
-		Construct();
-	}
+    if(fLogicWorld == nullptr) {
+        Construct();
+    }
 
-	G4int detNum;
-	G4int posNum;
-	G4int config  = 0;
-	for(detNum = 1; detNum <= ndet; detNum++) {
-		posNum = detNum;
+    G4int detNum;
+    G4int posNum;
+    G4int config  = 0;
+    for(detNum = 1; detNum <= ndet; detNum++) {
+        posNum = detNum;
 
-		fGriffinDetectorsMap[fGriffinDetectorsMapIndex] = detNum;
-		fGriffinDetectorsMapIndex++;
+        fGriffinDetectorsMap[fGriffinDetectorsMapIndex] = detNum;
+        fGriffinDetectorsMapIndex++;
 
-		DetectionSystemGriffin* pGriffinDLS = new DetectionSystemGriffin(config, 1, fGriffinFwdBackPosition, fHevimetSelector); // Select Forward (0) or Back (1)
+        DetectionSystemGriffin* pGriffinDLS = new DetectionSystemGriffin(config, 1, fGriffinFwdBackPosition, fHevimetSelector); // Select Forward (0) or Back (1)
 
-		pGriffinDLS->BuildDeadLayerSpecificCrystal(detNum-1);
-		pGriffinDLS->PlaceDeadLayerSpecificCrystal(fLogicWorld, detNum-1, posNum-1, fUseTigressPositions) ;
+        pGriffinDLS->BuildDeadLayerSpecificCrystal(detNum-1);
+        pGriffinDLS->PlaceDeadLayerSpecificCrystal(fLogicWorld, detNum-1, posNum-1, fUseTigressPositions) ;
         //begin CRN
-		pGriffinDLS->BuildEverythingButCrystals(detNum-1);
+        pGriffinDLS->BuildEverythingButCrystals(detNum-1);
         // end CRN 
-		pGriffinDLS->PlaceEverythingButCrystals(fLogicWorld, detNum-1, posNum-1, fUseTigressPositions) ;
-	}
+        pGriffinDLS->PlaceEverythingButCrystals(fLogicWorld, detNum-1, posNum-1, fUseTigressPositions) ;
+    }
 
-	fGriffin = true;
+    fGriffin = true;
 }
 
 void DetectorConstruction::AddDetectionSystemGriffinForwardDetector(G4int ndet) {
-	if(fLogicWorld == nullptr) {
-		Construct();
-	}
+    if(fLogicWorld == nullptr) {
+        Construct();
+    }
 
-	G4int detNum = ndet;
-	G4int posNum = ndet;
-	G4int config  = 0;
-	fGriffinDetectorsMap[fGriffinDetectorsMapIndex] = detNum;
-	fGriffinDetectorsMapIndex++;
+    G4int detNum = ndet;
+    G4int posNum = ndet;
+    G4int config  = 0;
+    fGriffinDetectorsMap[fGriffinDetectorsMapIndex] = detNum;
+    fGriffinDetectorsMapIndex++;
 
-	DetectionSystemGriffin* pGriffinDLS = new DetectionSystemGriffin(config, 1, fGriffinFwdBackPosition, fHevimetSelector); // Select Forward (0) or Back (1)
+    DetectionSystemGriffin* pGriffinDLS = new DetectionSystemGriffin(config, 1, fGriffinFwdBackPosition, fHevimetSelector); // Select Forward (0) or Back (1)
 
-	pGriffinDLS->BuildDeadLayerSpecificCrystal(detNum-1);
+    pGriffinDLS->BuildDeadLayerSpecificCrystal(detNum-1);
 
-	pGriffinDLS->PlaceDeadLayerSpecificCrystal(fLogicWorld, detNum-1, posNum-1, fUseTigressPositions) ;
+    pGriffinDLS->PlaceDeadLayerSpecificCrystal(fLogicWorld, detNum-1, posNum-1, fUseTigressPositions) ;
 
     // begin CRN 
-	pGriffinDLS->BuildEverythingButCrystals(detNum-1);
+    pGriffinDLS->BuildEverythingButCrystals(detNum-1);
     // end CRN
 
-	pGriffinDLS->PlaceEverythingButCrystals(fLogicWorld, detNum-1, posNum-1, fUseTigressPositions) ;
+    pGriffinDLS->PlaceEverythingButCrystals(fLogicWorld, detNum-1, posNum-1, fUseTigressPositions) ;
 
-	fGriffin = true;
+    fGriffin = true;
 }
 
 void DetectorConstruction::AddDetectionSystemGriffinBack(G4int ndet) {
-	if(fLogicWorld == nullptr) {
-		Construct();
-	}
+    if(fLogicWorld == nullptr) {
+        Construct();
+    }
 
-	G4int detNum;
-	G4int posNum;
-	G4int config  = 1;
+    G4int detNum;
+    G4int posNum;
+    G4int config  = 1;
 
-	for(detNum = 1; detNum <= ndet; detNum++) {
-		posNum = detNum;
+    for(detNum = 1; detNum <= ndet; detNum++) {
+        posNum = detNum;
 
-		fGriffinDetectorsMap[fGriffinDetectorsMapIndex] = detNum;
-		fGriffinDetectorsMapIndex++;
+        fGriffinDetectorsMap[fGriffinDetectorsMapIndex] = detNum;
+        fGriffinDetectorsMapIndex++;
 
-		DetectionSystemGriffin* pGriffinDLS = new DetectionSystemGriffin(config, 1, fGriffinFwdBackPosition, fHevimetSelector); // Select Forward (0) or Back (1)
+        DetectionSystemGriffin* pGriffinDLS = new DetectionSystemGriffin(config, 1, fGriffinFwdBackPosition, fHevimetSelector); // Select Forward (0) or Back (1)
 
-		pGriffinDLS->BuildDeadLayerSpecificCrystal(detNum-1);
-		pGriffinDLS->PlaceDeadLayerSpecificCrystal(fLogicWorld, detNum-1, posNum-1, fUseTigressPositions) ;
+        pGriffinDLS->BuildDeadLayerSpecificCrystal(detNum-1);
+        pGriffinDLS->PlaceDeadLayerSpecificCrystal(fLogicWorld, detNum-1, posNum-1, fUseTigressPositions) ;
         //begin CRN
-		pGriffinDLS->BuildEverythingButCrystals(detNum-1);
+        pGriffinDLS->BuildEverythingButCrystals(detNum-1);
         // end CRN
-		pGriffinDLS->PlaceEverythingButCrystals(fLogicWorld, detNum-1, posNum-1, fUseTigressPositions) ;
-	}
+        pGriffinDLS->PlaceEverythingButCrystals(fLogicWorld, detNum-1, posNum-1, fUseTigressPositions) ;
+    }
 
-	fGriffin = true;
+    fGriffin = true;
 }
 
 void DetectorConstruction::AddDetectionSystemGriffinBackDetector(G4int ndet) {
-	if(fLogicWorld == nullptr) {
-		Construct();
-	}
+    if(fLogicWorld == nullptr) {
+        Construct();
+    }
 
-	G4int detNum = ndet;
-	G4int posNum = ndet;
-	G4int config  = 1;
+    G4int detNum = ndet;
+    G4int posNum = ndet;
+    G4int config  = 1;
 
-	fGriffinDetectorsMap[fGriffinDetectorsMapIndex] = detNum;
-	fGriffinDetectorsMapIndex++;
+    fGriffinDetectorsMap[fGriffinDetectorsMapIndex] = detNum;
+    fGriffinDetectorsMapIndex++;
 
-	DetectionSystemGriffin* pGriffinDLS = new DetectionSystemGriffin(config, 1, fGriffinFwdBackPosition, fHevimetSelector); // Select Forward (0) or Back (1)
+    DetectionSystemGriffin* pGriffinDLS = new DetectionSystemGriffin(config, 1, fGriffinFwdBackPosition, fHevimetSelector); // Select Forward (0) or Back (1)
 
-	pGriffinDLS->BuildDeadLayerSpecificCrystal(detNum-1);
-	pGriffinDLS->PlaceDeadLayerSpecificCrystal(fLogicWorld, detNum-1, posNum-1, fUseTigressPositions) ;
+    pGriffinDLS->BuildDeadLayerSpecificCrystal(detNum-1);
+    pGriffinDLS->PlaceDeadLayerSpecificCrystal(fLogicWorld, detNum-1, posNum-1, fUseTigressPositions) ;
     // begin CRN 
-	pGriffinDLS->BuildEverythingButCrystals(detNum-1);
+    pGriffinDLS->BuildEverythingButCrystals(detNum-1);
     // end CRN
-	pGriffinDLS->PlaceEverythingButCrystals(fLogicWorld, detNum-1, posNum-1, fUseTigressPositions) ;
+    pGriffinDLS->PlaceEverythingButCrystals(fLogicWorld, detNum-1, posNum-1, fUseTigressPositions) ;
 
-	fGriffin = true;
+    fGriffin = true;
 }
 
 void DetectorConstruction::AddDetectionSystemGriffinHevimet(G4int input) {
-	// Includes hevimet.
-	fHevimetSelector = input ;
+    // Includes hevimet.
+    fHevimetSelector = input ;
 
 }
 
 void DetectorConstruction::AddDetectionSystemSceptar(G4int ndet) {
-	if(fLogicWorld == nullptr) {
-		Construct();
-	}
+    if(fLogicWorld == nullptr) {
+        Construct();
+    }
 
-	DetectionSystemSceptar* pSceptar = new DetectionSystemSceptar() ;
-	pSceptar->Build() ;
-	pSceptar->PlaceDetector(fLogicWorld, ndet) ;
+    DetectionSystemSceptar* pSceptar = new DetectionSystemSceptar() ;
+    pSceptar->Build() ;
+    pSceptar->PlaceDetector(fLogicWorld, ndet) ;
 
-	fSceptar = true;
+    fSceptar = true;
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 void DetectorConstruction::AddDetectionSystemDescant(G4int ndet) {
-	if(fLogicWorld == nullptr) {
-		Construct();
-	}
+    if(fLogicWorld == nullptr) {
+        Construct();
+    }
 
-	DetectionSystemDescant* pDetectionSystemDescant = new DetectionSystemDescant(true) ;
-	pDetectionSystemDescant->Build() ;
-	pDetectionSystemDescant->PlaceDetector(fLogicWorld, ndet) ;
+    DetectionSystemDescant* pDetectionSystemDescant = new DetectionSystemDescant(true) ;
+    pDetectionSystemDescant->Build() ;
+    pDetectionSystemDescant->PlaceDetector(fLogicWorld, ndet) ;
 
-	fDescant = true;
+    fDescant = true;
 }
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 void DetectorConstruction::AddDetectionSystemDescantAuxPorts(G4ThreeVector input) {
-	if(fLogicWorld == nullptr) {
-		Construct();
-	}
+    if(fLogicWorld == nullptr) {
+        Construct();
+    }
 
-	G4int ndet = G4int(input.x());
-	G4double radialpos = input.y()*cm;
-	G4int leadShield = G4bool(input.z());
+    G4int ndet = G4int(input.x());
+    G4double radialpos = input.y()*cm;
+    G4int leadShield = G4bool(input.z());
 
-	if(leadShield) G4cout<<"Building DESCANT detectors WITH lead shielding"<<G4endl;
-	if(!leadShield)G4cout<<"Building DESCANT detectors WITHOUT lead shielding"<<G4endl;
+    if(leadShield) G4cout<<"Building DESCANT detectors WITH lead shielding"<<G4endl;
+    if(!leadShield)G4cout<<"Building DESCANT detectors WITHOUT lead shielding"<<G4endl;
 
-	DetectionSystemDescant *  pDetectionSystemDescant = new DetectionSystemDescant(leadShield) ;
-	pDetectionSystemDescant->Build() ;
+    DetectionSystemDescant *  pDetectionSystemDescant = new DetectionSystemDescant(leadShield) ;
+    pDetectionSystemDescant->Build() ;
 
-	for(G4int detectorNumber = 0; detectorNumber < ndet; detectorNumber++)
-	{
-		pDetectionSystemDescant->PlaceDetectorAuxPorts(fLogicWorld, detectorNumber, radialpos);
-	}
+    for(G4int detectorNumber = 0; detectorNumber < ndet; detectorNumber++)
+    {
+        pDetectionSystemDescant->PlaceDetectorAuxPorts(fLogicWorld, detectorNumber, radialpos);
+    }
 
-	fDescant = true;
+    fDescant = true;
 }
 
 void DetectorConstruction::SetDetectionSystemDescantRotation(G4ThreeVector input) {
-	//convert from degree to rad
-	fDescantRotation.setX(input.x()/180.*M_PI);
-	fDescantRotation.setY(input.y()/180.*M_PI);
-	fDescantRotation.setZ(input.z()/180.*M_PI);
+    //convert from degree to rad
+    fDescantRotation.setX(input.x()/180.*M_PI);
+    fDescantRotation.setY(input.y()/180.*M_PI);
+    fDescantRotation.setZ(input.z()/180.*M_PI);
 }
 
 void DetectorConstruction::SetDetectionSystemDescantColor(G4String input) {
-	fDescantColor = input;
+    fDescantColor = input;
 }
 
 void DetectorConstruction::AddDetectionSystemDescantCart(G4ThreeVector input) {
-	if(fLogicWorld == nullptr) {
-		Construct();
-	}
+    if(fLogicWorld == nullptr) {
+        Construct();
+    }
 
-	DetectionSystemDescant* pDetectionSystemDescant = new DetectionSystemDescant(true) ;
-	pDetectionSystemDescant->Build() ;
-	pDetectionSystemDescant->PlaceDetector(fLogicWorld, fDescantColor, input, fDescantRotation) ;
+    DetectionSystemDescant* pDetectionSystemDescant = new DetectionSystemDescant(true) ;
+    pDetectionSystemDescant->Build() ;
+    pDetectionSystemDescant->PlaceDetector(fLogicWorld, fDescantColor, input, fDescantRotation) ;
 
-	fDescant = true;
+    fDescant = true;
 }
 
 void DetectorConstruction::AddDetectionSystemDescantSpher(G4ThreeVector input, G4double unit) {
-	G4ThreeVector sphericalVector;
-	//convert from degree to rad
-	sphericalVector.setRThetaPhi(input.x()*unit, input.y()/180.*M_PI, input.z()/180.*M_PI);
-	AddDetectionSystemDescantCart(sphericalVector);
+    G4ThreeVector sphericalVector;
+    //convert from degree to rad
+    sphericalVector.setRThetaPhi(input.x()*unit, input.y()/180.*M_PI, input.z()/180.*M_PI);
+    AddDetectionSystemDescantCart(sphericalVector);
 
-	fDescant = true;
+    fDescant = true;
 }
 
 void DetectorConstruction::AddApparatusDescantStructure() {
-	if(fLogicWorld == nullptr) {
-		Construct();
-	}
+    if(fLogicWorld == nullptr) {
+        Construct();
+    }
 
-	ApparatusDescantStructure* pApparatusDescantStructure = new ApparatusDescantStructure() ;
-	pApparatusDescantStructure->Build() ;
-	pApparatusDescantStructure->PlaceDescantStructure(fLogicWorld);
+    ApparatusDescantStructure* pApparatusDescantStructure = new ApparatusDescantStructure() ;
+    pApparatusDescantStructure->Build() ;
+    pApparatusDescantStructure->PlaceDescantStructure(fLogicWorld);
 
-	//pApparatusDescantStructure->PlaceDetector(fLogicWorld, ndet) ;
+    //pApparatusDescantStructure->PlaceDetector(fLogicWorld, ndet) ;
 }
 
 void DetectorConstruction::AddDetectionSystemTestcan(G4ThreeVector input) {
-	if(fLogicWorld == nullptr) {
-		Construct();
-	}
+    if(fLogicWorld == nullptr) {
+        Construct();
+    }
 
-	G4double length = G4double(input.x())*cm;
-	G4double radius = G4double(input.y())*cm;
+    G4double length = G4double(input.x())*cm;
+    G4double radius = G4double(input.y())*cm;
 
-	DetectionSystemTestcan* pDetectionSystemTestcan = new DetectionSystemTestcan(length, radius);
-	pDetectionSystemTestcan->Build();
-	pDetectionSystemTestcan->PlaceDetector(fLogicWorld);
+    DetectionSystemTestcan* pDetectionSystemTestcan = new DetectionSystemTestcan(length, radius);
+    pDetectionSystemTestcan->Build();
+    pDetectionSystemTestcan->PlaceDetector(fLogicWorld);
 
-	fTestcan = true;
+    fTestcan = true;
 }
 
 void DetectorConstruction::AddDetectionSystemSpice() {
-	if(fLogicWorld == nullptr) {
-		Construct();
-	}
-	DetectionSystemSpice* pSpice = new DetectionSystemSpice() ;
-	pSpice->BuildPlace(fLogicWorld); 
+    if(fLogicWorld == nullptr) {
+        Construct();
+    }
+    DetectionSystemSpice* pSpice = new DetectionSystemSpice() ;
+    pSpice->BuildPlace(fLogicWorld); 
 
-	fSpice = true;
-	//HistoManager::Instance().Spice(true);//boolean needed to make SPICE histograms
+    fSpice = true;
+    //HistoManager::Instance().Spice(true);//boolean needed to make SPICE histograms
 }
 
 void DetectorConstruction::AddDetectionSystemTrific(G4double Torr) {
-	if(fLogicWorld == nullptr) {
-		Construct();
-	}
-	
-	DetectionSystemTrific* pTrific = new DetectionSystemTrific(Torr,fTrifWindowThickness,fTrifAluminised,fTrifFlatWindow,fTrifDegraderThickness,fTrifDegraderMat);
-	pTrific->BuildPlace(fLogicWorld); 
+    if(fLogicWorld == nullptr) {
+        Construct();
+    }
+
+    DetectionSystemTrific* pTrific = new DetectionSystemTrific(Torr,fTrifWindowThickness,fTrifAluminised,fTrifFlatWindow,fTrifDegraderThickness,fTrifDegraderMat);
+    pTrific->BuildPlace(fLogicWorld); 
 
 }
 
 void DetectorConstruction::AddDetectionSystemPaces(G4int ndet) {
-	if(fLogicWorld == nullptr) {
-		Construct();
-	}
+    if(fLogicWorld == nullptr) {
+        Construct();
+    }
 
-	DetectionSystemPaces* pPaces = new DetectionSystemPaces() ;
-	pPaces->Build() ;
+    DetectionSystemPaces* pPaces = new DetectionSystemPaces() ;
+    pPaces->Build() ;
 
-	pPaces->PlaceDetector(fLogicWorld, ndet) ;
+    pPaces->PlaceDetector(fLogicWorld, ndet) ;
 
-	fPaces = true;
+    fPaces = true;
 }
 
 void DetectorConstruction::SetProperties() {
-	// loop over all existing daughters of the world volume
-	// check if their properties are set and if not, set them
-	if(fLogicWorld == nullptr) return;
-	// thread id is -1 for master, -2 in sequential mode
-	// so this only outputs the number of volumes once
-	if(G4Threading::G4GetThreadId() < 0) {
-		G4cout<<fLogicWorld->GetNoDaughters()<<" daughter volumes"<<std::endl;
-	}
+    // loop over all existing daughters of the world volume
+    // check if their properties are set and if not, set them
+    if(fLogicWorld == nullptr) return;
+    // thread id is -1 for master, -2 in sequential mode
+    // so this only outputs the number of volumes once
+    if(G4Threading::G4GetThreadId() < 0) {
+        G4cout<<fLogicWorld->GetNoDaughters()<<" daughter volumes"<<std::endl;
+    }
     SetPropertiesRecursive(fLogicWorld);
 }
 
 
 void DetectorConstruction::SetPropertiesRecursive(G4LogicalVolume* vol) {
     for(int i = 0; i < vol->GetNoDaughters(); ++i) {
-		if(!HasProperties(vol->GetDaughter(i)) && CheckVolumeName(vol->GetDaughter(i)->GetName())) {
-			fPropertiesMap[vol->GetDaughter(i)] = ParseVolumeName(vol->GetDaughter(i)->GetName());
-		}
-		SetPropertiesRecursive(vol->GetDaughter(i)->GetLogicalVolume());
-	}
-    
+        if(!HasProperties(vol->GetDaughter(i)) && CheckVolumeName(vol->GetDaughter(i)->GetName())) {
+            fPropertiesMap[vol->GetDaughter(i)] = ParseVolumeName(vol->GetDaughter(i)->GetName());
+        }
+        SetPropertiesRecursive(vol->GetDaughter(i)->GetLogicalVolume());
+    }
+
 }
 
 void DetectorConstruction::Print() {
-	if(fLogicWorld == nullptr) {
-		std::cout<<"World volume does not exist yet!"<<std::endl;
-		return;
-	}
+    if(fLogicWorld == nullptr) {
+        std::cout<<"World volume does not exist yet!"<<std::endl;
+        return;
+    }
 
-	SetProperties();
+    SetProperties();
 
     PrintRecursive(fLogicWorld);
 }
 
 void DetectorConstruction::PrintRecursive(G4LogicalVolume* vol){
-    
+
     for(int i = 0; i < vol->GetNoDaughters(); ++i) {
-		std::cout<<i<<": "<<vol->GetDaughter(i)<<" - "<<vol->GetDaughter(i)->GetName();
-		if(HasProperties(vol->GetDaughter(i))) {
-			auto prop = GetProperties(vol->GetDaughter(i));
-			std::cout<<" - "<<prop.detectorNumber<<", "<<prop.crystalNumber<<", "<<prop.systemID;
-		}
-		std::cout<<std::endl;
+        std::cout<<i<<": "<<vol->GetDaughter(i)<<" - "<<vol->GetDaughter(i)->GetName();
+        if(HasProperties(vol->GetDaughter(i))) {
+            auto prop = GetProperties(vol->GetDaughter(i));
+            std::cout<<" - "<<prop.detectorNumber<<", "<<prop.crystalNumber<<", "<<prop.systemID;
+        }
+        std::cout<<std::endl;
         PrintRecursive(vol->GetDaughter(i)->GetLogicalVolume());
-	}
+    }
 }
 
 bool DetectorConstruction::CheckVolumeName(G4String volumeName) {
-	if(volumeName.find("germaniumBlock1") != G4String::npos) return true;
-	if(volumeName.find("backQuarterSuppressor") != G4String::npos) return true;
-	if(volumeName.find("leftSuppressorExtension") != G4String::npos) return true;
-	if(volumeName.find("rightSuppressorExtension") != G4String::npos) return true;
-	if(volumeName.find("leftSuppressorCasing") != G4String::npos) return true;
-	if(volumeName.find("rightSuppressorCasing") != G4String::npos) return true;
-	if(volumeName.find("germaniumDlsBlock1") != G4String::npos) return true;
-	if(volumeName.find("lanthanumBromideCrystalBlock") != G4String::npos) return true;
-	if(volumeName.find("ancillaryBgoBlock") != G4String::npos) return true;
-	if(volumeName.find("sodiumIodideCrystalBlock") != G4String::npos) return true;
-	if(volumeName.find("SiSegmentPhys") != G4String::npos) return true;
-	if(volumeName.find("TrificGasCell") != G4String::npos) return true;
-	if(volumeName.find("pacesSiliconBlockLog") != G4String::npos) return true;
-	if(volumeName.find("sceptarSquareScintillatorLog") != G4String::npos) return true;
-	if(volumeName.find("sceptarAngledScintillatorLog") != G4String::npos) return true;
-	if(volumeName.find("8piGermaniumBlockLog") != G4String::npos) return true;
-	if(volumeName.find("8piInnerBGOAnnulus") != G4String::npos) return true;
-	if(volumeName.find("8piOuterLowerBGOAnnulus") != G4String::npos) return true;
-	if(volumeName.find("8piOuterUpperBGOAnnulus") != G4String::npos) return true;
-	if(volumeName.find("gridcellLog") != G4String::npos) return true;
-	if(volumeName.find("blueScintillatorVolumeLog") != G4String::npos) return true;
-	if(volumeName.find("greenScintillatorVolumeLog") != G4String::npos) return true;
-	if(volumeName.find("redScintillatorVolumeLog") != G4String::npos) return true;
-	if(volumeName.find("whiteScintillatorVolumeLog") != G4String::npos) return true;
-	if(volumeName.find("yellowScintillatorVolumeLog") != G4String::npos) return true;
-	if(volumeName.find("testcanScintillatorLog") != G4String::npos) return true;
-	return false;
+    if(volumeName.find("germaniumBlock1") != G4String::npos) return true;
+    if(volumeName.find("backQuarterSuppressor") != G4String::npos) return true;
+    if(volumeName.find("leftSuppressorExtension") != G4String::npos) return true;
+    if(volumeName.find("rightSuppressorExtension") != G4String::npos) return true;
+    if(volumeName.find("leftSuppressorCasing") != G4String::npos) return true;
+    if(volumeName.find("rightSuppressorCasing") != G4String::npos) return true;
+    if(volumeName.find("germaniumDlsBlock1") != G4String::npos) return true;
+    if(volumeName.find("lanthanumBromideCrystalBlock") != G4String::npos) return true;
+    if(volumeName.find("ancillaryBgoBlock") != G4String::npos) return true;
+    if(volumeName.find("sodiumIodideCrystalBlock") != G4String::npos) return true;
+    if(volumeName.find("SiSegmentPhys") != G4String::npos) return true;
+    if(volumeName.find("TrificGasCell") != G4String::npos) return true;
+    if(volumeName.find("pacesSiliconBlockLog") != G4String::npos) return true;
+    if(volumeName.find("sceptarSquareScintillatorLog") != G4String::npos) return true;
+    if(volumeName.find("sceptarAngledScintillatorLog") != G4String::npos) return true;
+    if(volumeName.find("8piGermaniumBlockLog") != G4String::npos) return true;
+    if(volumeName.find("8piInnerBGOAnnulus") != G4String::npos) return true;
+    if(volumeName.find("8piOuterLowerBGOAnnulus") != G4String::npos) return true;
+    if(volumeName.find("8piOuterUpperBGOAnnulus") != G4String::npos) return true;
+    if(volumeName.find("gridcellLog") != G4String::npos) return true;
+    if(volumeName.find("blueScintillatorVolumeLog") != G4String::npos) return true;
+    if(volumeName.find("greenScintillatorVolumeLog") != G4String::npos) return true;
+    if(volumeName.find("redScintillatorVolumeLog") != G4String::npos) return true;
+    if(volumeName.find("whiteScintillatorVolumeLog") != G4String::npos) return true;
+    if(volumeName.find("yellowScintillatorVolumeLog") != G4String::npos) return true;
+    if(volumeName.find("testcanScintillatorLog") != G4String::npos) return true;
+    return false;
 }
 
 DetectorProperties DetectorConstruction::ParseVolumeName(G4String volumeName) {
-	DetectorProperties result;
+    DetectorProperties result;
 
     // begin CRN 
     G4cout << "* ----- " << G4endl;
     G4cout << "DetectorConstruction::volumeName " << volumeName << G4endl;
     // end CRN 
 
-	// GRIFFIN detectors have the detector and crystal number in their names
-	if(volumeName.find("germaniumBlock1") != G4String::npos) {
-		// strip "germaniumBlock1_" (16 characters) and everything before from the string
-		std::string tmpString = volumeName.substr(volumeName.find("germaniumBlock1")+16);
-		// replace all '_' with spaces so we can just use istringstream::operator>>
-		std::replace(tmpString.begin(), tmpString.end(), '_', ' ');
-		// create istringstream from the stripped and converted stream, and read detector and crystal number
-		std::istringstream is(tmpString);
-		is>>result.detectorNumber>>result.crystalNumber;
-		// converting this number to a "true" detector number isn't necessary anymore since we use the real number and not the assembly/imprint number
-		result.systemID = 1000;
-		return result;
-	}
+    // GRIFFIN detectors have the detector and crystal number in their names
+    if(volumeName.find("germaniumBlock1") != G4String::npos) {
+        // strip "germaniumBlock1_" (16 characters) and everything before from the string
+        std::string tmpString = volumeName.substr(volumeName.find("germaniumBlock1")+16);
+        // replace all '_' with spaces so we can just use istringstream::operator>>
+        std::replace(tmpString.begin(), tmpString.end(), '_', ' ');
+        // create istringstream from the stripped and converted stream, and read detector and crystal number
+        std::istringstream is(tmpString);
+        is>>result.detectorNumber>>result.crystalNumber;
+        // converting this number to a "true" detector number isn't necessary anymore since we use the real number and not the assembly/imprint number
+        result.systemID = 1000;
+        return result;
+    }
 
-	if(volumeName.find("germaniumDlsBlock1") != G4String::npos) {
-		// strip "germaniumDlsBlock1_" (16 characters) and everything before from the string
-		std::string tmpString = volumeName.substr(volumeName.find("germaniumDlsBlock1")+19);
-		// replace all '_' with spaces so we can just use istringstream::operator>>
-		std::replace(tmpString.begin(), tmpString.end(), '_', ' ');
-		// create istringstream from the stripped and converted stream, and read detector and crystal number
-		std::istringstream is(tmpString);
-		is>>result.detectorNumber>>result.crystalNumber;
-		// converting this number to a "true" detector number isn't necessary anymore since we use the real number and not the assembly/imprint number
-		result.systemID = 1000;
-		return result;
-	}
+    if(volumeName.find("germaniumDlsBlock1") != G4String::npos) {
+        // strip "germaniumDlsBlock1_" (16 characters) and everything before from the string
+        std::string tmpString = volumeName.substr(volumeName.find("germaniumDlsBlock1")+19);
+        // replace all '_' with spaces so we can just use istringstream::operator>>
+        std::replace(tmpString.begin(), tmpString.end(), '_', ' ');
+        // create istringstream from the stripped and converted stream, and read detector and crystal number
+        std::istringstream is(tmpString);
+        is>>result.detectorNumber>>result.crystalNumber;
+        // converting this number to a "true" detector number isn't necessary anymore since we use the real number and not the assembly/imprint number
+        result.systemID = 1000;
+        return result;
+    }
 
-	// Spice detectors also have the number in their name
-	if(volumeName.find("SiSegmentPhys") != G4String::npos) {
-		// strip "SiSegmentPhys_" (13 characters) and everything before from the string
-		std::string tmpString = volumeName.substr(volumeName.find("SiSegmentPhys")+13);
-		// replace all '_' with spaces so we can just use istringstream::operator>>
-		std::replace(tmpString.begin(), tmpString.end(), '_', ' ');
-		// create istringstream from the stripped and converted stream, and read detector and crystal number
-		std::istringstream is(tmpString);
-		is>>result.detectorNumber>>result.crystalNumber;
-		result.systemID = 10;
-		return result;
-	}
+    // Spice detectors also have the number in their name
+    if(volumeName.find("SiSegmentPhys") != G4String::npos) {
+        // strip "SiSegmentPhys_" (13 characters) and everything before from the string
+        std::string tmpString = volumeName.substr(volumeName.find("SiSegmentPhys")+13);
+        // replace all '_' with spaces so we can just use istringstream::operator>>
+        std::replace(tmpString.begin(), tmpString.end(), '_', ' ');
+        // create istringstream from the stripped and converted stream, and read detector and crystal number
+        std::istringstream is(tmpString);
+        is>>result.detectorNumber>>result.crystalNumber;
+        result.systemID = 10;
+        return result;
+    }
 
-	// Trific detectors have the number in their name too
-	if(volumeName.find("TrificGasCell") != G4String::npos) {
-		// strip "TrificGasCell_" (13 characters) and everything before from the string
-		std::string tmpString = volumeName.substr(volumeName.find("TrificGasCell")+13);
-		// replace all '_' with spaces so we can just use istringstream::operator>>
-		std::replace(tmpString.begin(), tmpString.end(), '_', ' ');
-		// create istringstream from the stripped and converted stream, and read detector and crystal number
-		std::istringstream is(tmpString);
-		is>>result.detectorNumber>>result.crystalNumber;
-		result.systemID = 20;
-		return result;
-	}
+    // Trific detectors have the number in their name too
+    if(volumeName.find("TrificGasCell") != G4String::npos) {
+        // strip "TrificGasCell_" (13 characters) and everything before from the string
+        std::string tmpString = volumeName.substr(volumeName.find("TrificGasCell")+13);
+        // replace all '_' with spaces so we can just use istringstream::operator>>
+        std::replace(tmpString.begin(), tmpString.end(), '_', ' ');
+        // create istringstream from the stripped and converted stream, and read detector and crystal number
+        std::istringstream is(tmpString);
+        is>>result.detectorNumber>>result.crystalNumber;
+        result.systemID = 20;
+        return result;
+    }
 
-	// for all other detectors we need to get the assembly and imprint number
-	// the name has the form av_<assembly volume number>_impr_<imprint number>_<volume name>_pv_<??? number>
-	if(volumeName.find("av_") != 0 || volumeName.find("_impr_") == G4String::npos) {
-		std::cerr<<"wrongly formed volume name '"<<volumeName<<"', should start with 'av_' and have '_impr_' in it?"<<std::endl;
-		throw std::invalid_argument("unexpected volume name");
-	}
-	// create new string that starts with the assembly number and use stringstream to read it
-	std::string tmpString = volumeName.substr(3);
-	// replace all '_' with spaces so we can just use istringstream::operator>>
-	std::replace(tmpString.begin(), tmpString.end(), '_', ' ');
-	std::istringstream is(tmpString);
-	G4int assemblyNumber;
-	is>>assemblyNumber;
+    // for all other detectors we need to get the assembly and imprint number
+    // the name has the form av_<assembly volume number>_impr_<imprint number>_<volume name>_pv_<??? number>
+    if(volumeName.find("av_") != 0 || volumeName.find("_impr_") == G4String::npos) {
+        std::cerr<<"wrongly formed volume name '"<<volumeName<<"', should start with 'av_' and have '_impr_' in it?"<<std::endl;
+        throw std::invalid_argument("unexpected volume name");
+    }
+    // create new string that starts with the assembly number and use stringstream to read it
+    std::string tmpString = volumeName.substr(3);
+    // replace all '_' with spaces so we can just use istringstream::operator>>
+    std::replace(tmpString.begin(), tmpString.end(), '_', ' ');
+    std::istringstream is(tmpString);
+    G4int assemblyNumber;
+    is>>assemblyNumber;
 
-	// create new string that starts with the imprint number ('_' have been replace by ' ') and use stringstream to read it
-	tmpString = tmpString.substr(tmpString.find(" impr ")+6);
-	is.str(tmpString);
-	G4int imprintNumber;
-	is>>imprintNumber;
+    // create new string that starts with the imprint number ('_' have been replace by ' ') and use stringstream to read it
+    tmpString = tmpString.substr(tmpString.find(" impr ")+6);
+    is.str(tmpString);
+    G4int imprintNumber;
+    is>>imprintNumber;
 
-	// for griffin "components" (aka suppressors) we get the detector number from the assembly volume number (av-5)/fNumberOfAssemblyVols
-	// and the crystal number is the imprint number (fNumberOfAssemblyVols was hard-coded to be 13 in the constructor)
-	result.detectorNumber = static_cast<G4int>(ceil((assemblyNumber-5.)/13.));
-	result.crystalNumber = imprintNumber;
-	if(volumeName.find("backQuarterSuppressor") != G4String::npos) {
-		result.systemID = 1050;
-		return result;
-	}
+    // for griffin "components" (aka suppressors) we get the detector number from the name
+    // and the crystal number is the imprint number (fNumberOfAssemblyVols was hard-coded to be 13 in the constructor)
+    result.crystalNumber = imprintNumber;
+    if(volumeName.find("backQuarterSuppressor") != G4String::npos) {
+        return result;
+    }
 
-	if(volumeName.find("leftSuppressorExtension") != G4String::npos) {
-		result.systemID = 1010;
-		return result;
-	}
+    if(volumeName.find("leftSuppressorExtension") != G4String::npos) {
+        std::string tmpString = volumeName.substr(volumeName.find("leftSuppressorExtension")+23);
+        std::replace(tmpString.begin(), tmpString.end(), '_', ' ');
+        std::istringstream is(tmpString);
+        is>>result.detectorNumber;
+        // converting this number to a "true" detector number isn't necessary anymore since we use the real number and not the assembly/imprint number
+        result.systemID = 1010;
+        // CRNTest
+        G4cout << "det: " << result.detectorNumber << " cry: " << result.crystalNumber << " type: " << result.systemID << G4endl;
+        // CRNTest
+        return result;
+    }
 
-	if(volumeName.find("rightSuppressorExtension") != G4String::npos) {
-		result.systemID = 1020;
-		return result;
-	}
+    if(volumeName.find("rightSuppressorExtension") != G4String::npos) {
+        std::string tmpString = volumeName.substr(volumeName.find("rightSuppressorExtension")+24);
+        std::replace(tmpString.begin(), tmpString.end(), '_', ' ');
+        std::istringstream is(tmpString);
+        is>>result.detectorNumber;
+        // converting this number to a "true" detector number isn't necessary anymore since we use the real number and not the assembly/imprint number
+        result.systemID = 1020;
+        // CRNTest
+        G4cout << "det: " << result.detectorNumber << " cry: " << result.crystalNumber << " type: " << result.systemID << G4endl;
+        // CRNTest
+        return result;
+    }
 
-	if(volumeName.find("leftSuppressorCasing") != G4String::npos) {
-		result.systemID = 1030;
-		return result;
-	}
+    if(volumeName.find("leftSuppressorCasing") != G4String::npos) {
+        std::string tmpString = volumeName.substr(volumeName.find("leftSuppressorCasing")+20);
+        std::replace(tmpString.begin(), tmpString.end(), '_', ' ');
+        std::istringstream is(tmpString);
+        is>>result.detectorNumber;
+        // converting this number to a "true" detector number isn't necessary anymore since we use the real number and not the assembly/imprint number
+        result.systemID = 1030;
+        // CRNTest
+        G4cout << "det: " << result.detectorNumber << " cry: " << result.crystalNumber << " type: " << result.systemID << G4endl;
+        // CRNTest
+        return result;
+    }
 
-	if(volumeName.find("rightSuppressorCasing") != G4String::npos) {
-		result.systemID = 1040;
-		return result;
-	}
+    if(volumeName.find("rightSuppressorCasing") != G4String::npos) {
+        std::string tmpString = volumeName.substr(volumeName.find("rightSuppressorCasing")+21);
+        std::replace(tmpString.begin(), tmpString.end(), '_', ' ');
+        std::istringstream is(tmpString);
+        is>>result.detectorNumber;
+        // converting this number to a "true" detector number isn't necessary anymore since we use the real number and not the assembly/imprint number
+        result.systemID = 1040;
+        // CRNTest
+        G4cout << "det: " << result.detectorNumber << " cry: " << result.crystalNumber << " type: " << result.systemID << G4endl;
+        // CRNTest
+        return result;
+    }
 
-	// for ancillary BGOs the detector number is the (ceiling of the) imprint number divided by 3
-	// and the crystal number is the imprint number minus 3 times the detector number minus one
-	result.detectorNumber = static_cast<G4int>(ceil(imprintNumber/3.0));
-	result.crystalNumber = imprintNumber - (result.detectorNumber-1)*3;
-	if(volumeName.find("ancillaryBgoBlock") != G4String::npos) {
-		result.systemID = 3000;
-		return result;
-	}
+    // for ancillary BGOs the detector number is the (ceiling of the) imprint number divided by 3
+    // and the crystal number is the imprint number minus 3 times the detector number minus one
+    result.detectorNumber = static_cast<G4int>(ceil(imprintNumber/3.0));
+    result.crystalNumber = imprintNumber - (result.detectorNumber-1)*3;
+    if(volumeName.find("ancillaryBgoBlock") != G4String::npos) {
+        result.systemID = 3000;
+        return result;
+    }
 
-	// for "generic" detectors the detector number is the imprint number
-	result.detectorNumber = imprintNumber;
-	result.crystalNumber = 0;
-	if(volumeName.find("lanthanumBromideCrystalBlock") != G4String::npos) {
-		result.systemID = 2000;
-		return result;
-	}
+    // for "generic" detectors the detector number is the imprint number
+    result.detectorNumber = imprintNumber;
+    result.crystalNumber = 0;
+    if(volumeName.find("lanthanumBromideCrystalBlock") != G4String::npos) {
+        result.systemID = 2000;
+        return result;
+    }
 
-	if(volumeName.find("sodiumIodideCrystalBlock") != G4String::npos) {
-		result.systemID = 4000;
-		return result;
-	}
+    if(volumeName.find("sodiumIodideCrystalBlock") != G4String::npos) {
+        result.systemID = 4000;
+        return result;
+    }
 
-	if(volumeName.find("pacesSiliconBlockLog") != G4String::npos) {
-		result.systemID = 50;
-		return result;
-	}
+    if(volumeName.find("pacesSiliconBlockLog") != G4String::npos) {
+        result.systemID = 50;
+        return result;
+    }
 
-	if(volumeName.find("sceptarSquareScintillatorLog") != G4String::npos) {
-		// to number SCEPTAR paddles correctly:
-		switch(result.detectorNumber) {
-			case 0:
-				result.detectorNumber = 5;
-				break;
-			case 1:
-				result.detectorNumber = 9;
-				break;
-			case 2:
-				result.detectorNumber = 8;
-				break;
-			case 3:
-				result.detectorNumber = 7;
-				break;
-			case 4:
-				result.detectorNumber = 6;
-				break;
-			case 5:
-				result.detectorNumber = 13;
-				break;
-			case 6:
-				result.detectorNumber = 12;
-				break;
-			case 7:
-				result.detectorNumber = 11;
-				break;
-			case 8:
-				result.detectorNumber = 10;
-				break;
-			case 9:
-				result.detectorNumber = 14;
-				break;
-			default:
-				std::cerr<<"Unknown detector number "<<result.detectorNumber<<" for square SCEPTAR!"<<std::endl;
-				break;
-		}
-		result.systemID = 5000;
-		return result;
-	}
+    if(volumeName.find("sceptarSquareScintillatorLog") != G4String::npos) {
+        // to number SCEPTAR paddles correctly:
+        switch(result.detectorNumber) {
+            case 0:
+                result.detectorNumber = 5;
+                break;
+            case 1:
+                result.detectorNumber = 9;
+                break;
+            case 2:
+                result.detectorNumber = 8;
+                break;
+            case 3:
+                result.detectorNumber = 7;
+                break;
+            case 4:
+                result.detectorNumber = 6;
+                break;
+            case 5:
+                result.detectorNumber = 13;
+                break;
+            case 6:
+                result.detectorNumber = 12;
+                break;
+            case 7:
+                result.detectorNumber = 11;
+                break;
+            case 8:
+                result.detectorNumber = 10;
+                break;
+            case 9:
+                result.detectorNumber = 14;
+                break;
+            default:
+                std::cerr<<"Unknown detector number "<<result.detectorNumber<<" for square SCEPTAR!"<<std::endl;
+                break;
+        }
+        result.systemID = 5000;
+        return result;
+    }
 
-	if(volumeName.find("sceptarAngledScintillatorLog") != G4String::npos) {
-		// to number SCEPTAR paddles correctly (1 stays 1):
-		switch(result.detectorNumber) {
-			case 0:
-				result.detectorNumber = 0;
-				break;
-			case 1:
-				result.detectorNumber = 4;
-				break;
-			case 2:
-				result.detectorNumber = 3;
-				break;
-			case 3:
-				result.detectorNumber = 2;
-				break;
-			case 4:
-				result.detectorNumber = 1;
-				break;
-			case 5:
-				result.detectorNumber = 18;
-				break;
-			case 6:
-				result.detectorNumber = 17;
-				break;
-			case 7:
-				result.detectorNumber = 16;
-				break;
-			case 8:
-				result.detectorNumber = 15;
-				break;
-			case 9:
-				result.detectorNumber = 19;
-				break;
-			default:
-				std::cerr<<"Unknown detector number "<<result.detectorNumber<<" for angled SCEPTAR!"<<std::endl;
-				break;
-		}
-		result.systemID = 5000;
-		return result;
-	}
+    if(volumeName.find("sceptarAngledScintillatorLog") != G4String::npos) {
+        // to number SCEPTAR paddles correctly (1 stays 1):
+        switch(result.detectorNumber) {
+            case 0:
+                result.detectorNumber = 0;
+                break;
+            case 1:
+                result.detectorNumber = 4;
+                break;
+            case 2:
+                result.detectorNumber = 3;
+                break;
+            case 3:
+                result.detectorNumber = 2;
+                break;
+            case 4:
+                result.detectorNumber = 1;
+                break;
+            case 5:
+                result.detectorNumber = 18;
+                break;
+            case 6:
+                result.detectorNumber = 17;
+                break;
+            case 7:
+                result.detectorNumber = 16;
+                break;
+            case 8:
+                result.detectorNumber = 15;
+                break;
+            case 9:
+                result.detectorNumber = 19;
+                break;
+            default:
+                std::cerr<<"Unknown detector number "<<result.detectorNumber<<" for angled SCEPTAR!"<<std::endl;
+                break;
+        }
+        result.systemID = 5000;
+        return result;
+    }
 
-	if(volumeName.find("8piGermaniumBlockLog") != G4String::npos) {
-		result.systemID = 6000;
-		return result;
-	}
+    if(volumeName.find("8piGermaniumBlockLog") != G4String::npos) {
+        result.systemID = 6000;
+        return result;
+    }
 
-	if(volumeName.find("8piInnerBGOAnnulus") != G4String::npos) {
-		result.systemID = 6010;
-		return result;
-	}
+    if(volumeName.find("8piInnerBGOAnnulus") != G4String::npos) {
+        result.systemID = 6010;
+        return result;
+    }
 
-	if(volumeName.find("8piOuterLowerBGOAnnulus") != G4String::npos) {
-		result.systemID = 6020;
-		return result;
-	}
+    if(volumeName.find("8piOuterLowerBGOAnnulus") != G4String::npos) {
+        result.systemID = 6020;
+        return result;
+    }
 
-	if(volumeName.find("8piOuterUpperBGOAnnulus") != G4String::npos) {
-		result.systemID = 6030;
-		return result;
-	}
+    if(volumeName.find("8piOuterUpperBGOAnnulus") != G4String::npos) {
+        result.systemID = 6030;
+        return result;
+    }
 
-	if(volumeName.find("gridcellLog") != G4String::npos) {
-		result.systemID = 7000;
-		return result;
-	}
+    if(volumeName.find("gridcellLog") != G4String::npos) {
+        result.systemID = 7000;
+        return result;
+    }
 
-	if(volumeName.find("blueScintillatorVolumeLog") != G4String::npos) {
-		result.systemID = 8010;
-		return result;
-	}
+    if(volumeName.find("blueScintillatorVolumeLog") != G4String::npos) {
+        result.systemID = 8010;
+        return result;
+    }
 
-	if(volumeName.find("greenScintillatorVolumeLog") != G4String::npos) {
-		result.systemID = 8020;
-		return result;
-	}
+    if(volumeName.find("greenScintillatorVolumeLog") != G4String::npos) {
+        result.systemID = 8020;
+        return result;
+    }
 
-	if(volumeName.find("redScintillatorVolumeLog") != G4String::npos) {
-		result.systemID = 8030;
-		return result;
-	}
+    if(volumeName.find("redScintillatorVolumeLog") != G4String::npos) {
+        result.systemID = 8030;
+        return result;
+    }
 
-	if(volumeName.find("whiteScintillatorVolumeLog") != G4String::npos) {
-		result.systemID = 8040;
-		return result;
-	}
+    if(volumeName.find("whiteScintillatorVolumeLog") != G4String::npos) {
+        result.systemID = 8040;
+        return result;
+    }
 
-	if(volumeName.find("yellowScintillatorVolumeLog") != G4String::npos) {
-		result.systemID = 8050;
-		return result;
-	}
+    if(volumeName.find("yellowScintillatorVolumeLog") != G4String::npos) {
+        result.systemID = 8050;
+        return result;
+    }
 
-	if(volumeName.find("testcanScintillatorLog") != G4String::npos) {
-		result.systemID = 8500;
-		return result;
-	}
+    if(volumeName.find("testcanScintillatorLog") != G4String::npos) {
+        result.systemID = 8500;
+        return result;
+    }
 
-	return result;
+    return result;
 }
 

--- a/src/DetectorConstruction.cc
+++ b/src/DetectorConstruction.cc
@@ -1043,7 +1043,7 @@ DetectorProperties DetectorConstruction::ParseVolumeName(G4String volumeName) {
 
     // for griffin "components" (aka suppressors) we get the detector number from the name
     // and the crystal number is the imprint number (fNumberOfAssemblyVols was hard-coded to be 13 in the constructor)
-    result.crystalNumber = imprintNumber;
+    result.crystalNumber = imprintNumber - 1;
     if(volumeName.find("leftSuppressorExtension") != G4String::npos) {
         std::string temp_string = volumeName.substr(volumeName.find("leftSuppressorExtension")+23);
         std::replace(temp_string.begin(), temp_string.end(), '_', ' ');

--- a/src/DetectorConstruction.cc
+++ b/src/DetectorConstruction.cc
@@ -603,7 +603,9 @@ void DetectorConstruction::AddDetectionSystemGriffinCustom(G4int ndet) {
 
 		pGriffinCustom->BuildDeadLayerSpecificCrystal(detNum-1);
 		pGriffinCustom->PlaceDeadLayerSpecificCrystal(fLogicWorld, detNum-1, posNum-1, fUseTigressPositions) ;
-		pGriffinCustom->BuildEverythingButCrystals();
+        //begin CRN 
+		pGriffinCustom->BuildEverythingButCrystals(detNum-1);
+        // end CRN
 		pGriffinCustom->PlaceEverythingButCrystals(fLogicWorld, detNum-1, posNum-1, fUseTigressPositions) ;
 
 	}
@@ -663,7 +665,9 @@ void DetectorConstruction::AddDetectionSystemGriffinForward(G4int ndet) {
 
 		pGriffinDLS->BuildDeadLayerSpecificCrystal(detNum-1);
 		pGriffinDLS->PlaceDeadLayerSpecificCrystal(fLogicWorld, detNum-1, posNum-1, fUseTigressPositions) ;
-		pGriffinDLS->BuildEverythingButCrystals();
+        //begin CRN
+		pGriffinDLS->BuildEverythingButCrystals(detNum-1);
+        // end CRN 
 		pGriffinDLS->PlaceEverythingButCrystals(fLogicWorld, detNum-1, posNum-1, fUseTigressPositions) ;
 	}
 
@@ -687,7 +691,9 @@ void DetectorConstruction::AddDetectionSystemGriffinForwardDetector(G4int ndet) 
 
 	pGriffinDLS->PlaceDeadLayerSpecificCrystal(fLogicWorld, detNum-1, posNum-1, fUseTigressPositions) ;
 
-	pGriffinDLS->BuildEverythingButCrystals();
+    // begin CRN 
+	pGriffinDLS->BuildEverythingButCrystals(detNum-1);
+    // end CRN
 
 	pGriffinDLS->PlaceEverythingButCrystals(fLogicWorld, detNum-1, posNum-1, fUseTigressPositions) ;
 
@@ -713,7 +719,9 @@ void DetectorConstruction::AddDetectionSystemGriffinBack(G4int ndet) {
 
 		pGriffinDLS->BuildDeadLayerSpecificCrystal(detNum-1);
 		pGriffinDLS->PlaceDeadLayerSpecificCrystal(fLogicWorld, detNum-1, posNum-1, fUseTigressPositions) ;
-		pGriffinDLS->BuildEverythingButCrystals();
+        //begin CRN
+		pGriffinDLS->BuildEverythingButCrystals(detNum-1);
+        // end CRN
 		pGriffinDLS->PlaceEverythingButCrystals(fLogicWorld, detNum-1, posNum-1, fUseTigressPositions) ;
 	}
 
@@ -736,7 +744,9 @@ void DetectorConstruction::AddDetectionSystemGriffinBackDetector(G4int ndet) {
 
 	pGriffinDLS->BuildDeadLayerSpecificCrystal(detNum-1);
 	pGriffinDLS->PlaceDeadLayerSpecificCrystal(fLogicWorld, detNum-1, posNum-1, fUseTigressPositions) ;
-	pGriffinDLS->BuildEverythingButCrystals();
+    // begin CRN 
+	pGriffinDLS->BuildEverythingButCrystals(detNum-1);
+    // end CRN
 	pGriffinDLS->PlaceEverythingButCrystals(fLogicWorld, detNum-1, posNum-1, fUseTigressPositions) ;
 
 	fGriffin = true;

--- a/src/DetectorConstruction.cc
+++ b/src/DetectorConstruction.cc
@@ -576,9 +576,7 @@ void DetectorConstruction::AddDetectionSystemGriffinCustomDetector(G4int) {
 
     pGriffinCustom->PlaceDeadLayerSpecificCrystal(fLogicWorld, fCustomDetectorNumber-1, fCustomDetectorPosition-1, fUseTigressPositions);
 
-    // begin CRN 
     pGriffinCustom->BuildEverythingButCrystals(fCustomDetectorNumber-1);
-    // end CRN
 
     pGriffinCustom->PlaceEverythingButCrystals(fLogicWorld, fCustomDetectorNumber-1, fCustomDetectorPosition-1, fUseTigressPositions);
 
@@ -603,9 +601,7 @@ void DetectorConstruction::AddDetectionSystemGriffinCustom(G4int ndet) {
 
         pGriffinCustom->BuildDeadLayerSpecificCrystal(detNum-1);
         pGriffinCustom->PlaceDeadLayerSpecificCrystal(fLogicWorld, detNum-1, posNum-1, fUseTigressPositions) ;
-        //begin CRN 
         pGriffinCustom->BuildEverythingButCrystals(detNum-1);
-        // end CRN
         pGriffinCustom->PlaceEverythingButCrystals(fLogicWorld, detNum-1, posNum-1, fUseTigressPositions) ;
 
     }
@@ -665,9 +661,7 @@ void DetectorConstruction::AddDetectionSystemGriffinForward(G4int ndet) {
 
         pGriffinDLS->BuildDeadLayerSpecificCrystal(detNum-1);
         pGriffinDLS->PlaceDeadLayerSpecificCrystal(fLogicWorld, detNum-1, posNum-1, fUseTigressPositions) ;
-        //begin CRN
         pGriffinDLS->BuildEverythingButCrystals(detNum-1);
-        // end CRN 
         pGriffinDLS->PlaceEverythingButCrystals(fLogicWorld, detNum-1, posNum-1, fUseTigressPositions) ;
     }
 
@@ -691,9 +685,7 @@ void DetectorConstruction::AddDetectionSystemGriffinForwardDetector(G4int ndet) 
 
     pGriffinDLS->PlaceDeadLayerSpecificCrystal(fLogicWorld, detNum-1, posNum-1, fUseTigressPositions) ;
 
-    // begin CRN 
     pGriffinDLS->BuildEverythingButCrystals(detNum-1);
-    // end CRN
 
     pGriffinDLS->PlaceEverythingButCrystals(fLogicWorld, detNum-1, posNum-1, fUseTigressPositions) ;
 
@@ -719,9 +711,7 @@ void DetectorConstruction::AddDetectionSystemGriffinBack(G4int ndet) {
 
         pGriffinDLS->BuildDeadLayerSpecificCrystal(detNum-1);
         pGriffinDLS->PlaceDeadLayerSpecificCrystal(fLogicWorld, detNum-1, posNum-1, fUseTigressPositions) ;
-        //begin CRN
         pGriffinDLS->BuildEverythingButCrystals(detNum-1);
-        // end CRN
         pGriffinDLS->PlaceEverythingButCrystals(fLogicWorld, detNum-1, posNum-1, fUseTigressPositions) ;
     }
 
@@ -744,9 +734,7 @@ void DetectorConstruction::AddDetectionSystemGriffinBackDetector(G4int ndet) {
 
     pGriffinDLS->BuildDeadLayerSpecificCrystal(detNum-1);
     pGriffinDLS->PlaceDeadLayerSpecificCrystal(fLogicWorld, detNum-1, posNum-1, fUseTigressPositions) ;
-    // begin CRN 
     pGriffinDLS->BuildEverythingButCrystals(detNum-1);
-    // end CRN
     pGriffinDLS->PlaceEverythingButCrystals(fLogicWorld, detNum-1, posNum-1, fUseTigressPositions) ;
 
     fGriffin = true;
@@ -980,11 +968,6 @@ bool DetectorConstruction::CheckVolumeName(G4String volumeName) {
 DetectorProperties DetectorConstruction::ParseVolumeName(G4String volumeName) {
     DetectorProperties result;
 
-    // begin CRN 
-    G4cout << "* ----- " << G4endl;
-    G4cout << "DetectorConstruction::volumeName " << volumeName << G4endl;
-    // end CRN 
-
     // GRIFFIN detectors have the detector and crystal number in their names
     if(volumeName.find("germaniumBlock1") != G4String::npos) {
         // strip "germaniumBlock1_" (16 characters) and everything before from the string
@@ -1066,54 +1049,42 @@ DetectorProperties DetectorConstruction::ParseVolumeName(G4String volumeName) {
     }
 
     if(volumeName.find("leftSuppressorExtension") != G4String::npos) {
-        std::string tmpString = volumeName.substr(volumeName.find("leftSuppressorExtension")+23);
-        std::replace(tmpString.begin(), tmpString.end(), '_', ' ');
-        std::istringstream is(tmpString);
-        is>>result.detectorNumber;
+        std::string temp_string = volumeName.substr(volumeName.find("leftSuppressorExtension")+23);
+        std::replace(temp_string.begin(), temp_string.end(), '_', ' ');
+        std::istringstream temp_stream(temp_string);
+        temp_stream>>result.detectorNumber;
         // converting this number to a "true" detector number isn't necessary anymore since we use the real number and not the assembly/imprint number
         result.systemID = 1010;
-        // CRNTest
-        G4cout << "det: " << result.detectorNumber << " cry: " << result.crystalNumber << " type: " << result.systemID << G4endl;
-        // CRNTest
         return result;
     }
 
     if(volumeName.find("rightSuppressorExtension") != G4String::npos) {
-        std::string tmpString = volumeName.substr(volumeName.find("rightSuppressorExtension")+24);
-        std::replace(tmpString.begin(), tmpString.end(), '_', ' ');
-        std::istringstream is(tmpString);
-        is>>result.detectorNumber;
+        std::string temp_string = volumeName.substr(volumeName.find("rightSuppressorExtension")+24);
+        std::replace(temp_string.begin(), temp_string.end(), '_', ' ');
+        std::istringstream temp_stream(temp_string);
+        temp_stream>>result.detectorNumber;
         // converting this number to a "true" detector number isn't necessary anymore since we use the real number and not the assembly/imprint number
         result.systemID = 1020;
-        // CRNTest
-        G4cout << "det: " << result.detectorNumber << " cry: " << result.crystalNumber << " type: " << result.systemID << G4endl;
-        // CRNTest
         return result;
     }
 
     if(volumeName.find("leftSuppressorCasing") != G4String::npos) {
-        std::string tmpString = volumeName.substr(volumeName.find("leftSuppressorCasing")+20);
-        std::replace(tmpString.begin(), tmpString.end(), '_', ' ');
-        std::istringstream is(tmpString);
-        is>>result.detectorNumber;
+        std::string temp_string = volumeName.substr(volumeName.find("leftSuppressorCasing")+20);
+        std::replace(temp_string.begin(), temp_string.end(), '_', ' ');
+        std::istringstream temp_stream(temp_string);
+        temp_stream>>result.detectorNumber;
         // converting this number to a "true" detector number isn't necessary anymore since we use the real number and not the assembly/imprint number
         result.systemID = 1030;
-        // CRNTest
-        G4cout << "det: " << result.detectorNumber << " cry: " << result.crystalNumber << " type: " << result.systemID << G4endl;
-        // CRNTest
         return result;
     }
 
     if(volumeName.find("rightSuppressorCasing") != G4String::npos) {
-        std::string tmpString = volumeName.substr(volumeName.find("rightSuppressorCasing")+21);
-        std::replace(tmpString.begin(), tmpString.end(), '_', ' ');
-        std::istringstream is(tmpString);
-        is>>result.detectorNumber;
+        std::string temp_string = volumeName.substr(volumeName.find("rightSuppressorCasing")+21);
+        std::replace(temp_string.begin(), temp_string.end(), '_', ' ');
+        std::istringstream temp_stream(temp_string);
+        temp_stream>>result.detectorNumber;
         // converting this number to a "true" detector number isn't necessary anymore since we use the real number and not the assembly/imprint number
         result.systemID = 1040;
-        // CRNTest
-        G4cout << "det: " << result.detectorNumber << " cry: " << result.crystalNumber << " type: " << result.systemID << G4endl;
-        // CRNTest
         return result;
     }
 

--- a/src/DetectorConstruction.cc
+++ b/src/DetectorConstruction.cc
@@ -576,7 +576,9 @@ void DetectorConstruction::AddDetectionSystemGriffinCustomDetector(G4int) {
 
 	pGriffinCustom->PlaceDeadLayerSpecificCrystal(fLogicWorld, fCustomDetectorNumber-1, fCustomDetectorPosition-1, fUseTigressPositions);
 
-	pGriffinCustom->BuildEverythingButCrystals();
+    // begin CRN 
+	pGriffinCustom->BuildEverythingButCrystals(fCustomDetectorNumber-1);
+    // end CRN
 
 	pGriffinCustom->PlaceEverythingButCrystals(fLogicWorld, fCustomDetectorNumber-1, fCustomDetectorPosition-1, fUseTigressPositions);
 
@@ -967,6 +969,12 @@ bool DetectorConstruction::CheckVolumeName(G4String volumeName) {
 
 DetectorProperties DetectorConstruction::ParseVolumeName(G4String volumeName) {
 	DetectorProperties result;
+
+    // begin CRN 
+    G4cout << "* ----- " << G4endl;
+    G4cout << "DetectorConstruction::volumeName " << volumeName << G4endl;
+    // end CRN 
+
 	// GRIFFIN detectors have the detector and crystal number in their names
 	if(volumeName.find("germaniumBlock1") != G4String::npos) {
 		// strip "germaniumBlock1_" (16 characters) and everything before from the string

--- a/src/DetectorConstruction.cc
+++ b/src/DetectorConstruction.cc
@@ -968,10 +968,6 @@ bool DetectorConstruction::CheckVolumeName(G4String volumeName) {
 DetectorProperties DetectorConstruction::ParseVolumeName(G4String volumeName) {
     DetectorProperties result;
 
-    // begin CRN
-    std::cout << "Vol name: " << volumeName << std::endl;
-    // end CRN
-
     // GRIFFIN detectors have the detector and crystal number in their names
     if(volumeName.find("germaniumBlock1") != G4String::npos) {
         // strip "germaniumBlock1_" (16 characters) and everything before from the string
@@ -1055,9 +1051,6 @@ DetectorProperties DetectorConstruction::ParseVolumeName(G4String volumeName) {
         temp_stream>>result.detectorNumber;
         // converting this number to a "true" detector number isn't necessary anymore since we use the real number and not the assembly/imprint number
         result.systemID = 1010;
-        // begin CRN
-        std::cout << "Det: " << result.detectorNumber << " Cry: " << result.crystalNumber << std::endl;
-        // end CRN
         return result;
     }
 
@@ -1068,9 +1061,6 @@ DetectorProperties DetectorConstruction::ParseVolumeName(G4String volumeName) {
         temp_stream>>result.detectorNumber;
         // converting this number to a "true" detector number isn't necessary anymore since we use the real number and not the assembly/imprint number
         result.systemID = 1020;
-        // begin CRN
-        std::cout << "Det: " << result.detectorNumber << " Cry: " << result.crystalNumber << std::endl;
-        // end CRN
         return result;
     }
 
@@ -1081,9 +1071,6 @@ DetectorProperties DetectorConstruction::ParseVolumeName(G4String volumeName) {
         temp_stream>>result.detectorNumber;
         // converting this number to a "true" detector number isn't necessary anymore since we use the real number and not the assembly/imprint number
         result.systemID = 1030;
-        // begin CRN
-        std::cout << "Det: " << result.detectorNumber << " ID: " << result.crystalNumber << std::endl;
-        // end CRN
         return result;
     }
 
@@ -1094,9 +1081,6 @@ DetectorProperties DetectorConstruction::ParseVolumeName(G4String volumeName) {
         temp_stream>>result.detectorNumber;
         // converting this number to a "true" detector number isn't necessary anymore since we use the real number and not the assembly/imprint number
         result.systemID = 1040;
-        // begin CRN
-        std::cout << "Det: " << result.detectorNumber << " ID: " << result.crystalNumber << std::endl;
-        // end CRN
         return result;
     }
 
@@ -1107,9 +1091,6 @@ DetectorProperties DetectorConstruction::ParseVolumeName(G4String volumeName) {
         temp_stream>>result.detectorNumber;
         // converting this number to a "true" detector number isn't necessary anymore since we use the real number and not the assembly/imprint number
         result.systemID = 1050;
-        // begin CRN
-        std::cout << "Det: " << result.detectorNumber << " ID: " << result.crystalNumber << std::endl;
-        // end CRN
         return result;
     }
 

--- a/src/DetectorConstruction.cc
+++ b/src/DetectorConstruction.cc
@@ -194,13 +194,13 @@ DetectorConstruction::DetectorConstruction() :
     fTrifWindowThickness=6*um;
     fTrifDegraderThickness=0;
     fTrifDegraderMat="G4_Al";
-    fTrifAluminised=true;  
-    fTrifFlatWindow=false;  
+    fTrifAluminised=true;
+    fTrifFlatWindow=false;
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
-DetectorConstruction::~DetectorConstruction() { 
+DetectorConstruction::~DetectorConstruction() {
     delete fDetectorMessenger;
 }
 
@@ -286,7 +286,7 @@ void DetectorConstruction::LayeredTargetAdd(G4String Material, G4double Areal)
     if(fApparatusLayeredTarget->BuildTargetLayer(Material,Areal)){
         if(fLogicWorld == nullptr) {
             Construct();
-        }  
+        }
         fApparatusLayeredTarget->PlaceTarget(fLogicWorld);
     }
 }
@@ -859,7 +859,7 @@ void DetectorConstruction::AddDetectionSystemSpice() {
         Construct();
     }
     DetectionSystemSpice* pSpice = new DetectionSystemSpice() ;
-    pSpice->BuildPlace(fLogicWorld); 
+    pSpice->BuildPlace(fLogicWorld);
 
     fSpice = true;
     //HistoManager::Instance().Spice(true);//boolean needed to make SPICE histograms
@@ -871,7 +871,7 @@ void DetectorConstruction::AddDetectionSystemTrific(G4double Torr) {
     }
 
     DetectionSystemTrific* pTrific = new DetectionSystemTrific(Torr,fTrifWindowThickness,fTrifAluminised,fTrifFlatWindow,fTrifDegraderThickness,fTrifDegraderMat);
-    pTrific->BuildPlace(fLogicWorld); 
+    pTrific->BuildPlace(fLogicWorld);
 
 }
 
@@ -968,6 +968,10 @@ bool DetectorConstruction::CheckVolumeName(G4String volumeName) {
 DetectorProperties DetectorConstruction::ParseVolumeName(G4String volumeName) {
     DetectorProperties result;
 
+    // begin CRN
+    std::cout << "Vol name: " << volumeName << std::endl;
+    // end CRN
+
     // GRIFFIN detectors have the detector and crystal number in their names
     if(volumeName.find("germaniumBlock1") != G4String::npos) {
         // strip "germaniumBlock1_" (16 characters) and everything before from the string
@@ -1044,10 +1048,6 @@ DetectorProperties DetectorConstruction::ParseVolumeName(G4String volumeName) {
     // for griffin "components" (aka suppressors) we get the detector number from the name
     // and the crystal number is the imprint number (fNumberOfAssemblyVols was hard-coded to be 13 in the constructor)
     result.crystalNumber = imprintNumber;
-    if(volumeName.find("backQuarterSuppressor") != G4String::npos) {
-        return result;
-    }
-
     if(volumeName.find("leftSuppressorExtension") != G4String::npos) {
         std::string temp_string = volumeName.substr(volumeName.find("leftSuppressorExtension")+23);
         std::replace(temp_string.begin(), temp_string.end(), '_', ' ');
@@ -1055,6 +1055,9 @@ DetectorProperties DetectorConstruction::ParseVolumeName(G4String volumeName) {
         temp_stream>>result.detectorNumber;
         // converting this number to a "true" detector number isn't necessary anymore since we use the real number and not the assembly/imprint number
         result.systemID = 1010;
+        // begin CRN
+        std::cout << "Det: " << result.detectorNumber << " Cry: " << result.crystalNumber << std::endl;
+        // end CRN
         return result;
     }
 
@@ -1065,6 +1068,9 @@ DetectorProperties DetectorConstruction::ParseVolumeName(G4String volumeName) {
         temp_stream>>result.detectorNumber;
         // converting this number to a "true" detector number isn't necessary anymore since we use the real number and not the assembly/imprint number
         result.systemID = 1020;
+        // begin CRN
+        std::cout << "Det: " << result.detectorNumber << " Cry: " << result.crystalNumber << std::endl;
+        // end CRN
         return result;
     }
 
@@ -1075,6 +1081,9 @@ DetectorProperties DetectorConstruction::ParseVolumeName(G4String volumeName) {
         temp_stream>>result.detectorNumber;
         // converting this number to a "true" detector number isn't necessary anymore since we use the real number and not the assembly/imprint number
         result.systemID = 1030;
+        // begin CRN
+        std::cout << "Det: " << result.detectorNumber << " ID: " << result.crystalNumber << std::endl;
+        // end CRN
         return result;
     }
 
@@ -1085,8 +1094,25 @@ DetectorProperties DetectorConstruction::ParseVolumeName(G4String volumeName) {
         temp_stream>>result.detectorNumber;
         // converting this number to a "true" detector number isn't necessary anymore since we use the real number and not the assembly/imprint number
         result.systemID = 1040;
+        // begin CRN
+        std::cout << "Det: " << result.detectorNumber << " ID: " << result.crystalNumber << std::endl;
+        // end CRN
         return result;
     }
+
+    if(volumeName.find("backQuarterSuppressor") != G4String::npos) {
+        std::string temp_string = volumeName.substr(volumeName.find("backQuarterSuppressor")+21);
+        std::replace(temp_string.begin(), temp_string.end(), '_', ' ');
+        std::istringstream temp_stream(temp_string);
+        temp_stream>>result.detectorNumber;
+        // converting this number to a "true" detector number isn't necessary anymore since we use the real number and not the assembly/imprint number
+        result.systemID = 1050;
+        // begin CRN
+        std::cout << "Det: " << result.detectorNumber << " ID: " << result.crystalNumber << std::endl;
+        // end CRN
+        return result;
+    }
+
 
     // for ancillary BGOs the detector number is the (ceiling of the) imprint number divided by 3
     // and the crystal number is the imprint number minus 3 times the detector number minus one
@@ -1254,4 +1280,3 @@ DetectorProperties DetectorConstruction::ParseVolumeName(G4String volumeName) {
 
     return result;
 }
-


### PR DESCRIPTION
I changed the naming convention of the BGO's to include detector number. Previously they were named based on an iterator so placing non-sequential detectors (e.g. 1, 3, 11, anad 14) caused a discrepancy in BGO compared to the clovers; now they follow the same method as the clovers.