### PR TITLE
Add C++11 flag to fix compile issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@
 cmake_minimum_required(VERSION 2.6 FATAL_ERROR)
 project(Griffinv10)
 
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 #----------------------------------------------------------------------------
 # Find Geant4 package, activating all available UI and Vis drivers by default
 # You can set WITH_GEANT4_UIVIS to OFF via the command line or ccmake/cmake-gui
@@ -23,7 +25,7 @@ include(${Geant4_USE_FILE})
 #----------------------------------------------------------------------------
 # Locate sources and headers for this project
 #
-include_directories(${PROJECT_SOURCE_DIR}/include 
+include_directories(${PROJECT_SOURCE_DIR}/include
                     ${Geant4_INCLUDE_DIR})
 file(GLOB sources ${PROJECT_SOURCE_DIR}/src/*.cc)
 file(GLOB headers ${PROJECT_SOURCE_DIR}/include/*.hh)
@@ -31,7 +33,7 @@ file(GLOB headers ${PROJECT_SOURCE_DIR}/include/*.hh)
 #----------------------------------------------------------------------------
 # Get examples sources from common and shared
 #
-#list(APPEND sources 
+#list(APPEND sources
 #  ${PROJECT_SOURCE_DIR}/../shared/src/ActionInitialization.cc
 #  ${PROJECT_SOURCE_DIR}/../shared/src/DetectorConstruction.cc
 #  ${PROJECT_SOURCE_DIR}/../shared/src/DetectorMessenger.cc
@@ -47,10 +49,10 @@ file(GLOB headers ${PROJECT_SOURCE_DIR}/include/*.hh)
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/../../common/analysis/cmake ${CMAKE_MODULE_PATH})
 find_package(HBOOK QUIET)
 if(NOT HBOOK_FOUND)
-  message(STATUS "G4 Examples: HBOOK package not found. --> g4tools/hbook analysis disabled")  
+  message(STATUS "G4 Examples: HBOOK package not found. --> g4tools/hbook analysis disabled")
 else()
-  message(STATUS "G4 Examples: HBOOK package found. --> g4tools/hbook analysis enabled")  
-  add_definitions(-DG4_USE_HBOOK)  
+  message(STATUS "G4 Examples: HBOOK package found. --> g4tools/hbook analysis enabled")
+  add_definitions(-DG4_USE_HBOOK)
 endif()
 
 #----------------------------------------------------------------------------
@@ -78,8 +80,8 @@ if (HBOOK_FOUND)
        OUTPUT  ${PROJECT_BINARY_DIR}/setntuc.o
        COMMAND gfortran
        ARGS  -c ${Geant4_INCLUDE_DIR}/tools/hbook/setntuc.f )
-  set(TOOLS_FORTRAN_OBJECTS close.o setpawc.o setntuc.o)       
-endif()       
+  set(TOOLS_FORTRAN_OBJECTS close.o setpawc.o setntuc.o)
+endif()
 
 #----------------------------------------------------------------------------
 # Add the executable, and link it to the Geant4 libraries
@@ -108,4 +110,3 @@ endforeach()
 # Install the executable to 'bin' directory under CMAKE_INSTALL_PREFIX
 #
 install(TARGETS Griffinv10 DESTINATION bin)
-


### PR DESCRIPTION
There was an issue when compiling the simulation on TRIUMF computers where cmake did not set the compiler flag to c++11 and therefore the simulation did not compile properly. 

This same issue is present on the geant4.10.04 branch. 